### PR TITLE
Fix for finder being shutdown before initialization when switching projects

### DIFF
--- a/src/widgets/finder.jai
+++ b/src/widgets/finder.jai
@@ -13,7 +13,7 @@ init_finder :: () {
 }
 
 deinit_finder :: () {
-    shutdown(*thread_group);
+    if finder.initted shutdown(*thread_group);
     finder.initted = false;
 }
 


### PR DESCRIPTION
This is the PR for issue #17 