### PR TITLE
Support for per-platform config + custom scaling factor setting on Linux

### DIFF
--- a/src/config.jai
+++ b/src/config.jai
@@ -75,6 +75,9 @@ maybe_refresh_config :: (path: string) {
             should_reload_workspace = false;
         }
     }
+
+    dont_ignore_next_window_resize = true;
+    platform_apply_config(*config.platform);
 }
 
 is_our_config_file :: (path: string) -> bool {
@@ -229,6 +232,9 @@ merge_configs :: (dst: *Config, src: Config) {
         }
     }
     CODE_COLOR_MAP = refresh_code_color_map();
+
+    // Platform config
+    dst.platform = src.platform;
 }
 
 load_font_by_name :: (name: string) -> font_data: string, success: bool {
@@ -258,6 +264,7 @@ Config :: struct {
     keymap: Keymap;
     settings: Settings;
     style: Style;
+    platform: platform_config;
 }
 
 Workspace :: struct {

--- a/src/config_parser.jai
+++ b/src/config_parser.jai
@@ -40,6 +40,9 @@ parse_config :: (name: string, filename: string, file_data: string) -> Config, s
                 success, error_msg := parse_style_line(*parser, line);
                 if !success return result, false, error_msg;
 
+            case .platform;
+                success, error_msg := platform_parse_config_line(*parser, line);
+                if !success return result, false, error_msg;
         }
     }
 
@@ -70,6 +73,8 @@ parse_config :: (name: string, filename: string, file_data: string) -> Config, s
     result.style.font           = parser.data.font;
     result.style.font_size      = parser.data.font_size;
     result.style.parsed_colors  = parser.data.parsed_colors;  // @leak
+
+    result.platform = parser.parsed.platform;
 
     return result, true, "";
 }
@@ -172,6 +177,11 @@ log_parser_error :: (handler: Text_File_Handler, format: string, args: .. Any, f
     return message;
 } @PrintLike
 
+log_parser_error :: (full_path: string, line_number: int, message: string, flags := Log_Flags.NONE, loc := #caller_location) {
+    new_message := tprint("Line % of '%': %", line_number, full_path, message);
+    log(new_message, flags=Log_Flags.ERROR|flags, loc=loc);
+}
+
 Str_Code :: struct { str: string; code: Input.Key_Code; }
 using Input.Key_Code;
 STRING_TO_CODE_MAP :: Str_Code.[
@@ -257,6 +267,14 @@ switch_top_section :: (using parser: *Config_Parser, line: string) -> error: boo
                 return true, error_msg;
             }
             seen_top_sections |= .style;
+
+        case PLATFORM_CONFIG_SECTION;
+            top_section = .platform;
+            if seen_top_sections & .platform {
+                error_msg := log_parser_error(handler, "The section '%' is defined twice. This is an error.", PLATFORM_CONFIG_SECTION);
+                return true, error_msg;
+            }
+            seen_top_sections |= .platform;
 
         case;
             error_msg := log_parser_error(handler, "Expected one of the following top-level sections: [[workspace]], [[settings]], [[keymap]], [[style]], but found '%'", line);
@@ -565,6 +583,19 @@ parse_key_combo :: (using parser: *Config_Parser, key_name: string) -> Key_Combo
     return result, true, "";
 }
 
+platform_parse_config_line :: (using parser: *Config_Parser, line: string) -> success: bool, error_msg: string {
+    if begins_with(line, "[") {
+        for PLATFORM_SUBSECTION_NAMES {
+            if line == it { platform_subsection = xx it_index; return true, ""; }
+        }
+        error_msg := log_parser_error(handler, "Unknown platform subsection '%'.\nAvailable options are: %.", line, join(..PLATFORM_SUBSECTION_NAMES, ", ", allocator = temp));
+        return false, error_msg;
+    }
+    success, error_msg := platform_parse_config_line(*parsed.platform, platform_subsection, line);
+    if !success log_parser_error(handler.full_path, handler.line_number, error_msg);
+    return success, error_msg;
+}
+
 #scope_file
 
 Config_Parser :: struct {
@@ -578,6 +609,7 @@ Config_Parser :: struct {
         keymap;
         settings;
         style;
+        platform;
     } = .none;
 
     seen_top_sections: enum_flags {
@@ -585,6 +617,7 @@ Config_Parser :: struct {
         keymap;
         settings;
         style;
+        platform;
     };
 
     workspace_subsection: enum {
@@ -624,6 +657,8 @@ Config_Parser :: struct {
         "[open file dialog]",
         "[search dialog]",
     ];
+
+    platform_subsection: PLATFORM_SUBSECTION_ENUM;
 
     // Will be filled during parsing
     data: struct {

--- a/src/main.jai
+++ b/src/main.jai
@@ -61,6 +61,11 @@ main :: () {
     CODE_COLOR_MAP = refresh_code_color_map();
 
 
+    // This may generate window resize events if DPI/scaling settings need to be
+    // applied, so make sure to only call it after the window is created.
+    platform_apply_config(*config.platform);
+
+    if config.settings.maximize_on_start then platform_maximize_window(window);
 
     platform_enable_drag_and_drop(window);
 
@@ -104,13 +109,14 @@ main :: () {
         for Input.get_window_resizes() {
             Simp.update_window(it.window);
             if (it.window == window) {
-                should_reinit := (it.width != window_width) || (it.height != window_height);
+                should_reinit := dont_ignore_next_window_resize || ((it.width != window_width) || (it.height != window_height));
                 window_width = it.width;
                 window_height = it.height;
                 if should_reinit {
                     screen    = make_rect(0, 0, window_width, window_height);
                     dpi_scale = platform_get_dpi_scale(window);
                     init_fonts_and_dependent_things();
+                    dont_ignore_next_window_resize = false;
                 }
                 window_resized = true;
             }
@@ -234,6 +240,7 @@ main :: () {
             hard_reload_workspace();
             should_reload_workspace = false;
             redraw_requested = true;
+            platform_apply_config(*config.platform);
         }
 
         reset_temporary_storage();
@@ -576,6 +583,12 @@ Project_Dir :: struct {
 just_dropped_file := "";
 
 cpu_info: Cpu_X86;
+
+// This will be set to `true` in `maybe_refresh_config()` to signal that the
+// next window resize event should be handled even if the window doesn't actually
+// change size. This is needed when changing DPI/scaling options which require
+// a full repaint.
+dont_ignore_next_window_resize := false;
 
 
 #load "layout.jai";

--- a/src/platform/linux.jai
+++ b/src/platform/linux.jai
@@ -1,5 +1,49 @@
-platform_setup :: () {
+PLATFORM_CONFIG_SECTION :: "[[linux]]";
+PLATFORM_SUBSECTION_ENUM :: enum {}
+PLATFORM_SUBSECTION_NAMES :: string.[];
 
+platform_config :: struct {
+    scaling_factor: float = 0.0;
+}
+
+platform_parse_config_line :: (config: *platform_config, section: PLATFORM_SUBSECTION_ENUM, line: string) -> success: bool, error_msg: string {
+    if trim(line) == "" return true, "";  // ???
+
+    setting, value := break_by_spaces(line);
+    setting = trim_right(setting, ":");
+
+    config.scaling_factor = 0.0;
+
+    if setting == {
+        case "scaling_factor"; {
+            f_val, success := parse_float(*value);
+            if !success {
+                error_msg := tprint("Couldn't parse '%' - expected a valid float, got '%'", setting, value);
+                return false, error_msg;
+            }
+            // @TODO: scaling factors under 1.0 break the editor widget on Wayland,
+            //        investigate why this happens
+            lower_limit := ifx DEBUG then 0.5 else 1.0;
+            if (f_val != 0.0) && (f_val < lower_limit || f_val > 5.0) {
+                error_msg := tprint("Couldn't parse '%' - value out of the expected range ([% ... 5.0])", lower_limit, setting);
+                return false, error_msg;
+            }
+            config.scaling_factor = f_val;
+        }
+        case; {
+            error_msg := tprint("Unknown setting '%' in section '%'", setting, PLATFORM_CONFIG_SECTION);
+            return false, error_msg;
+        }
+    }
+
+    return true, "";
+}
+
+platform_apply_config :: (config: *platform_config) {
+    LD.set_fixed_scaling(config.scaling_factor);
+}
+
+platform_setup :: () {
 }
 
 platform_get_centered_window_dimensions :: (open_on_biggest: bool) -> s32, s32, s32, s32 {
@@ -65,3 +109,4 @@ Monitor :: struct {
 monitors : [..] Monitor;
 
 LD :: #import "Linux_Display";
+#import "Math";

--- a/src/platform/macos.jai
+++ b/src/platform/macos.jai
@@ -1,5 +1,16 @@
-platform_setup :: inline () {
+PLATFORM_CONFIG_SECTION :: "[[macos]]";
+PLATFORM_SUBSECTION_ENUM :: enum {}
+PLATFORM_SUBSECTION_NAMES :: string.[];
+platform_config :: struct {}
 
+platform_parse_config_line :: (config: *platform_config, section: PLATFORM_SUBSECTION_ENUM, line: string) -> success: bool, error_msg: string {
+    return true, "";
+}
+
+platform_apply_config :: (config: *platform_config) {
+}
+
+platform_setup :: inline () {
 }
 
 platform_get_centered_window_dimensions :: (open_on_biggest: bool) -> s32, s32, s32, s32 {

--- a/src/platform/windows.jai
+++ b/src/platform/windows.jai
@@ -1,3 +1,15 @@
+PLATFORM_CONFIG_SECTION :: "[[windows]]";
+PLATFORM_SUBSECTION_ENUM :: enum {}
+PLATFORM_SUBSECTION_NAMES :: string.[];
+platform_config :: struct {}
+
+platform_parse_config_line :: (config: *platform_config, section: PLATFORM_SUBSECTION_ENUM, line: string) -> success: bool, error_msg: string {
+    return true, "";
+}
+
+platform_apply_config :: (config: *platform_config) {
+}
+
 platform_setup :: () {
     if timeBeginPeriod(1) != TIMERR_NOERROR then log_error("Couldn't set minimum timer resolution");
 }


### PR DESCRIPTION
This PR adds the following changes:
1. each platform backend now defines a top-level section for platform-specific options, a platform-specific structure to hold the options it cares about and a custom option parsing function that gets invoked from the main config parsing logic.
2. a new config file option on Linux to allow users to override the content scaling factor