### PR TITLE
Fix input in the search bar not working on Linux (and probably MacOS as well)

### DIFF
--- a/src/editors.jai
+++ b/src/editors.jai
@@ -70,44 +70,47 @@ active_editor_handle_event :: (event: Input.Event, action: Action_Editors) -> ha
         using editor.search_bar;
         old_search_str := copy_temporary_string(to_string(input.text));
         handled := text_input_handle_event(*input, event);
-        if handled && old_search_str != to_string(input.text) then search_and_update_results(editor, buffer, jump = true);
+        if handled {
+            if old_search_str != to_string(input.text) then search_and_update_results(editor, buffer, jump = true);
+            return true;
+        }
 
         action := map_event_to_action(event, Action_Search_Dialog);
 
         if action == {
-            case .toggle_expand;                    search_bar_toggle_expand(editor);
+            case .toggle_expand;                    search_bar_toggle_expand(editor);                                             return true;
 
-            case .search_in_buffer;                 open_search_bar(editor, buffer, remember_cursor_position = false);
-            case .search_in_buffer_dropdown_mode;   open_search_bar(editor, buffer, .dropdown, remember_cursor_position = false);
+            case .search_in_buffer;                 open_search_bar(editor, buffer, remember_cursor_position = false);            return true;
+            case .search_in_buffer_dropdown_mode;   open_search_bar(editor, buffer, .dropdown, remember_cursor_position = false); return true;
 
-            case .move_up;                          search_bar_move_cursor(editor, buffer, -1, wrap = true);
-            case .move_down;                        search_bar_move_cursor(editor, buffer,  1, wrap = true);
-            case .move_up_fast;                     search_bar_move_cursor(editor, buffer, -5);
-            case .move_down_fast;                   search_bar_move_cursor(editor, buffer,  5);
+            case .move_up;                          search_bar_move_cursor(editor, buffer, -1, wrap = true);                      return true;
+            case .move_down;                        search_bar_move_cursor(editor, buffer,  1, wrap = true);                      return true;
+            case .move_up_fast;                     search_bar_move_cursor(editor, buffer, -5);                                   return true;
+            case .move_down_fast;                   search_bar_move_cursor(editor, buffer,  5);                                   return true;
 
-            case .close_current_editor;             close_search_bar(editor); close_current_editor();
-            case .close_other_editor;               close_other_editor();
+            case .close_current_editor;             close_search_bar(editor); close_current_editor();                             return true;
+            case .close_other_editor;               close_other_editor();                                                         return true;
         }
 
         if mode == .classic {
             if action == {
-                case .close_dialog;                 close_search_bar(editor);
-                case .open_entry_in_place;          search_bar_move_cursor(editor, buffer,  1, wrap = true);
+                case .close_dialog;                 close_search_bar(editor);                                return true;
+                case .open_entry_in_place;          search_bar_move_cursor(editor, buffer,  1, wrap = true); return true;
             }
         } else {
             if action == {
-                case .close_dialog;                 close_search_bar(editor, jump_to_original_cursor = true);
+                case .close_dialog;                 close_search_bar(editor, jump_to_original_cursor = true);      return true;
 
-                case .move_up_one_page;             search_bar_move_cursor(editor, buffer, -per_page);
-                case .move_down_one_page;           search_bar_move_cursor(editor, buffer,  per_page);
+                case .move_up_one_page;             search_bar_move_cursor(editor, buffer, -per_page);             return true;
+                case .move_down_one_page;           search_bar_move_cursor(editor, buffer,  per_page);             return true;
 
-                case .open_entry_in_place;          close_search_bar(editor);
-                case .open_entry_on_the_side;       search_bar_open_selected_result(editor, buffer, .on_the_side);
-                case .open_entry_on_the_left;       search_bar_open_selected_result(editor, buffer, .left);
-                case .open_entry_on_the_right;      search_bar_open_selected_result(editor, buffer, .right);
+                case .open_entry_in_place;          close_search_bar(editor);                                      return true;
+                case .open_entry_on_the_side;       search_bar_open_selected_result(editor, buffer, .on_the_side); return true;
+                case .open_entry_on_the_left;       search_bar_open_selected_result(editor, buffer, .left);        return true;
+                case .open_entry_on_the_right;      search_bar_open_selected_result(editor, buffer, .right);       return true;
             }
         }
-        return true;
+        return false;
     }
 
     cursors := editor.cursors;


### PR DESCRIPTION
Make `active_editor_handle_event()` aware of the latest input event handling changes.
Untested on Windows.