### PR TITLE
Implement horizontal scrolling

### DIFF
--- a/src/draw.jai
+++ b/src/draw.jai
@@ -280,6 +280,11 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
 
     editor_is_active := editor_id == editors.active && Input.input_application_has_focus;
 
+    if editor.viewport.rect != rect {
+        editor.viewport.rect = rect;
+        editor.viewport.max_line_pixel_width = 0;
+    }
+
     // Calculate text origin in screen coordinates
     text_offset := make_vector2(char_x_advance, -char_x_advance);
     text_origin := top_left(rect) + text_offset - make_vector2(xx viewport.left, line_height - viewport.top);
@@ -416,6 +421,8 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
 
     // Draw editor
     {
+        min_visible_chars :: 5;
+
         push_scissor(rect);
         defer pop_scissor();
 
@@ -435,8 +442,8 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
             }
         } else if cursor_moved {
             // Detect if cursor is off screen and start scrolling to it
-            bounds := shrink_x(rect, text_offset.x + char_x_advance * 5);
-            bounds  = shrink_y(bounds, -text_offset.y + line_height * 5);
+            bounds := shrink_x(rect, text_offset.x + char_x_advance * min_visible_chars);
+            bounds  = shrink_y(bounds, -text_offset.y + line_height * min_visible_chars);
             bounds.h += 2;
             bounds.y -= line_height + 2;
             if bounds.w < 0 || bounds.h < 0 then bounds = rect;  // fall back
@@ -517,13 +524,17 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
             redraw_requested = true;
         }
 
-        // Smooth keyboard scrolling
-        if editor_smooth_scroll.active && editor_id == editors.active {
+        // Smooth scrolling - vertical
+        if editor_smooth_scroll.direction != .NONE && editor_id == editors.active {
             speed := 60 * line_height;  // pixels per second
             if editor_smooth_scroll.fast then speed *= 2;
             time_elapsed := cast(float) (frame_time - editor_smooth_scroll.started_at);
-            new_scroll_pos := editor_smooth_scroll.start_y + time_elapsed * speed * (ifx editor_smooth_scroll.up then -1 else 1);
-            viewport.top = clamp(cast(s32) new_scroll_pos, 0, max_y_scroll);
+            new_scroll_y := cast(float) editor_smooth_scroll.start_y;
+            if editor_smooth_scroll.direction == {
+                case .UP;    new_scroll_y -= time_elapsed * speed;
+                case .DOWN;  new_scroll_y += time_elapsed * speed;
+            }
+            viewport.top = clamp(cast(s32) new_scroll_y, 0, max_y_scroll);
             viewport.scroll_y.target = viewport.top;
             viewport_remember_glue_point(*viewport, buffer);
             redraw_requested = true;
@@ -554,6 +565,44 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
             start = get_line_start_offset(buffer, visible_lines_start),
             end   = get_line_start_offset(buffer, visible_lines_end + 1),
         };
+        for line_num : visible_lines_start .. visible_lines_end {
+            line_start := get_line_start_offset(buffer, line_num);
+            length := get_line_start_offset(buffer, line_num+1) - line_start;
+            line := array_view(buffer.bytes, line_start, length);
+            line_pixel_width := cast(s32) ((get_num_chars(line) + min_visible_chars) * char_x_advance);
+            viewport.max_line_pixel_width = max(viewport.max_line_pixel_width, line_pixel_width);
+        }
+        viewport_width := cast(s32) rect.w;
+        max_x_scroll := cast(s32) 0;
+        if viewport.max_line_pixel_width > viewport_width
+            max_x_scroll = viewport.max_line_pixel_width - viewport_width;
+
+        if (ui.hot_last_frame == ui_id || ui.hot_last_frame == scrollbar_id) && mouse_pointer_is_within(rect) && mouse.scroll_x_delta != 0 && !dont_scroll_this_frame {
+            using editor.viewport;
+            new_target := clamp(scroll_x.target - mouse.scroll_x_delta, 0, max_x_scroll);
+            if mouse.smooth_scroll {
+                start_animation(*scroll_x, left, new_target);
+            } else {
+                scroll_x.target = new_target;
+                left = new_target;
+                viewport_remember_glue_point(*viewport, buffer);
+            }
+        }
+        // Smooth scrolling - horizontal
+        if editor_smooth_scroll.direction != .NONE && editor_id == editors.active {
+            speed := 60 * char_x_advance;
+            if editor_smooth_scroll.fast then speed *= 2;
+            time_elapsed := cast(float) (frame_time - editor_smooth_scroll.started_at);
+            new_scroll_x := cast(float) editor_smooth_scroll.start_x;
+            if editor_smooth_scroll.direction == {
+                case .LEFT;  new_scroll_x -= time_elapsed * speed;
+                case .RIGHT; new_scroll_x += time_elapsed * speed;
+            }
+            viewport.left = clamp(cast(s32) new_scroll_x, 0, max_x_scroll);
+            viewport.scroll_x.target = viewport.left;
+            viewport_remember_glue_point(*viewport, buffer);
+            redraw_requested = true;
+        }
 
         // Draw scrollbar marks
         {

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -280,11 +280,6 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
 
     editor_is_active := editor_id == editors.active && Input.input_application_has_focus;
 
-    if editor.viewport.rect != rect {
-        editor.viewport.rect = rect;
-        editor.viewport.max_line_pixel_width = 0;
-    }
-
     // Calculate text origin in screen coordinates
     text_offset := make_vector2(char_x_advance, -char_x_advance);
     text_origin := top_left(rect) + text_offset - make_vector2(xx viewport.left, line_height - viewport.top);
@@ -431,6 +426,11 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
         max_y_scroll := max(cast(s32)((buffer.line_starts.count - 2) * line_height), 0);
 
         if (ui.hot_last_frame == ui_id || ui.hot_last_frame == scrollbar_id) && mouse_pointer_is_within(rect) && mouse.scroll_y_delta != 0 && !dont_scroll_this_frame {
+            // Mousewheel scrolling - vertical
+            // We only handle vertical scrolling here because horizontal scrolling depends on the
+            // length of the longest visible line, which we can only determine once we determine
+            // the first visible line. Thus we need to "resolve" vertical scrolling before we can
+            // properly handle horizontal scrolling.
             using editor.viewport;
             new_target := clamp(scroll_y.target - mouse.scroll_y_delta, 0, max_y_scroll);
             if mouse.smooth_scroll {
@@ -524,15 +524,17 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
             redraw_requested = true;
         }
 
-        // Smooth scrolling - vertical
-        if editor_smooth_scroll.direction != .NONE && editor_id == editors.active {
+        // Keyboard smooth scrolling - vertical
+        // As mentioned above, we can properly peform horizontal scrolling only once vertical
+        // scrolling is done, allowing us to determine the longest visible line.
+        if editor_smooth_scroll.direction != .none && editor_id == editors.active {
             speed := 60 * line_height;  // pixels per second
             if editor_smooth_scroll.fast then speed *= 2;
             time_elapsed := cast(float) (frame_time - editor_smooth_scroll.started_at);
             new_scroll_y := cast(float) editor_smooth_scroll.start_y;
             if editor_smooth_scroll.direction == {
-                case .UP;    new_scroll_y -= time_elapsed * speed;
-                case .DOWN;  new_scroll_y += time_elapsed * speed;
+                case .up;    new_scroll_y -= time_elapsed * speed;
+                case .down;  new_scroll_y += time_elapsed * speed;
             }
             viewport.top = clamp(cast(s32) new_scroll_y, 0, max_y_scroll);
             viewport.scroll_y.target = viewport.top;
@@ -574,9 +576,11 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
         }
         viewport_width := cast(s32) rect.w;
         max_x_scroll := cast(s32) 0;
-        if viewport.max_line_pixel_width > viewport_width
-            max_x_scroll = viewport.max_line_pixel_width - viewport_width;
+        if viewport.max_line_pixel_width > viewport_width then max_x_scroll = viewport.max_line_pixel_width - viewport_width;
 
+        // Now that we can compute max_x_scroll we can handle horizontal scrolling.
+        // We handle both scrollwheel and keyboard smooth scrolling below.
+        // Mousewheel scrolling - vertical
         if (ui.hot_last_frame == ui_id || ui.hot_last_frame == scrollbar_id) && mouse_pointer_is_within(rect) && mouse.scroll_x_delta != 0 && !dont_scroll_this_frame {
             using editor.viewport;
             new_target := clamp(scroll_x.target - mouse.scroll_x_delta, 0, max_x_scroll);
@@ -588,15 +592,15 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
                 viewport_remember_glue_point(*viewport, buffer);
             }
         }
-        // Smooth scrolling - horizontal
-        if editor_smooth_scroll.direction != .NONE && editor_id == editors.active {
+        // Keyboard smooth scrolling - horizontal
+        if editor_smooth_scroll.direction != .none && editor_id == editors.active {
             speed := 60 * char_x_advance;
             if editor_smooth_scroll.fast then speed *= 2;
             time_elapsed := cast(float) (frame_time - editor_smooth_scroll.started_at);
             new_scroll_x := cast(float) editor_smooth_scroll.start_x;
             if editor_smooth_scroll.direction == {
-                case .LEFT;  new_scroll_x -= time_elapsed * speed;
-                case .RIGHT; new_scroll_x += time_elapsed * speed;
+                case .left;  new_scroll_x -= time_elapsed * speed;
+                case .right; new_scroll_x += time_elapsed * speed;
             }
             viewport.left = clamp(cast(s32) new_scroll_x, 0, max_x_scroll);
             viewport.scroll_x.target = viewport.left;

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -16,13 +16,13 @@ editors_handle_event :: (event: Input.Event) -> handled: bool {
                 for hold_actions_to_be_stopped {
                     if it == {
                         case .scroll_viewport_up;           #through;
-                        case .scroll_viewport_up_fast;      if editor_smooth_scroll.direction == .UP then editor_smooth_scroll.direction = .NONE;
+                        case .scroll_viewport_up_fast;      if editor_smooth_scroll.direction == .up then editor_smooth_scroll.direction = .none;
 
                         case .scroll_viewport_down;         #through;
-                        case .scroll_viewport_down_fast;    if editor_smooth_scroll.direction == .DOWN then editor_smooth_scroll.direction = .NONE;
+                        case .scroll_viewport_down_fast;    if editor_smooth_scroll.direction == .down then editor_smooth_scroll.direction = .none;
 
-                        case .scroll_viewport_left;         if editor_smooth_scroll.direction == .LEFT then editor_smooth_scroll.direction = .NONE;
-                        case .scroll_viewport_right;        if editor_smooth_scroll.direction == .RIGHT then editor_smooth_scroll.direction = .NONE;
+                        case .scroll_viewport_left;         if editor_smooth_scroll.direction == .left then editor_smooth_scroll.direction = .none;
+                        case .scroll_viewport_right;        if editor_smooth_scroll.direction == .right then editor_smooth_scroll.direction = .none;
                     }
                 }
                 // @Incomplete: Does stopping hold actions actually count as handling an event in the sense that it should suppress other event handlers?
@@ -148,12 +148,12 @@ active_editor_handle_event :: (event: Input.Event, action: Action_Editors) -> ha
         case .move_editor_to_the_right;         if editors.active == editors.left  then swap_panes();
         case .move_cursor_to_viewport_center;   move_cursor_to_viewport_center      (editor, buffer);
         case .remove_additional_cursors;        remove_additional_cursors           (editor);
-        case .scroll_viewport_up;               smooth_scroll(editor, direction = .UP);                activate_hold_action(action, event);
-        case .scroll_viewport_up_fast;          smooth_scroll(editor, direction = .UP, fast = true);   activate_hold_action(action, event);
-        case .scroll_viewport_down;             smooth_scroll(editor, direction = .DOWN);              activate_hold_action(action, event);
-        case .scroll_viewport_down_fast;        smooth_scroll(editor, direction = .DOWN, fast = true); activate_hold_action(action, event);
-        case .scroll_viewport_left;             smooth_scroll(editor, direction = .LEFT);              activate_hold_action(action, event);
-        case .scroll_viewport_right;            smooth_scroll(editor, direction = .RIGHT);             activate_hold_action(action, event);
+        case .scroll_viewport_up;               smooth_scroll(editor, direction = .up);                 activate_hold_action(action, event);
+        case .scroll_viewport_up_fast;          smooth_scroll(editor, direction = .up, fast = true);    activate_hold_action(action, event);
+        case .scroll_viewport_down;             smooth_scroll(editor, direction = .down);               activate_hold_action(action, event);
+        case .scroll_viewport_down_fast;        smooth_scroll(editor, direction = .down, fast = true);  activate_hold_action(action, event);
+        case .scroll_viewport_left;             smooth_scroll(editor, direction = .left, fast = true);  activate_hold_action(action, event);
+        case .scroll_viewport_right;            smooth_scroll(editor, direction = .right, fast = true); activate_hold_action(action, event);
         case .undo;                             undo                                (editor, buffer); keep_selection = true;
         case .redo;                             redo                                (editor, buffer); keep_selection = true;
         case .select_all;                       select_all                          (editor, buffer); keep_selection = true;
@@ -1181,7 +1181,7 @@ toggle_expand :: () {
 
 smooth_scroll :: (editor: Editor, direction: Smooth_Scroll_Direction, fast := false) {
     editor_smooth_scroll.direction = direction;
-    if editor_smooth_scroll.direction != .NONE {
+    if editor_smooth_scroll.direction != .none {
         editor_smooth_scroll.started_at = frame_time;
         editor_smooth_scroll.start_x    = editor.viewport.left;
         editor_smooth_scroll.start_y    = editor.viewport.top;
@@ -2302,7 +2302,6 @@ Viewport :: struct {
     scroll_y := #run Tween_Animation(s32).{ speed = xx 0.1, func = .lerp };
     scroll_x := #run Tween_Animation(s32).{ speed = xx 0.1, func = .lerp };
 
-    rect: Rect;
     max_line_pixel_width: s32;
 
     Glue_Point :: struct { buffer_pos: s32; offset_within_line: s32; }
@@ -2391,14 +2390,14 @@ editors: Editor_State;
 
 // Keyboard smooth scrolling
 Smooth_Scroll_Direction :: enum {
-    NONE;
-    UP;
-    DOWN;
-    LEFT;
-    RIGHT;
+    none;
+    up;
+    down;
+    left;
+    right;
 }
 editor_smooth_scroll: struct {
-    direction: Smooth_Scroll_Direction;  // if not up, then down
+    direction: Smooth_Scroll_Direction;
     fast: bool;
     started_at: Time;
     start_x: s32;

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -15,12 +15,14 @@ editors_handle_event :: (event: Input.Event) -> handled: bool {
                 hold_actions_to_be_stopped := map_key_release_to_hold_actions(event, Action_Editors);
                 for hold_actions_to_be_stopped {
                     if it == {
-                        case .scroll_viewport_up;           if  editor_smooth_scroll.up then editor_smooth_scroll.active = false;
-                        case .scroll_viewport_up_fast;      if  editor_smooth_scroll.up then editor_smooth_scroll.active = false;
-                        case .scroll_viewport_down;         if !editor_smooth_scroll.up then editor_smooth_scroll.active = false;
-                        case .scroll_viewport_down_fast;    if !editor_smooth_scroll.up then editor_smooth_scroll.active = false;
-                        // case .scroll_viewport_left;
-                        // case .scroll_viewport_right;
+                        case .scroll_viewport_up;           #through;
+                        case .scroll_viewport_up_fast;      if editor_smooth_scroll.direction == .UP then editor_smooth_scroll.direction = .NONE;
+
+                        case .scroll_viewport_down;         #through;
+                        case .scroll_viewport_down_fast;    if editor_smooth_scroll.direction == .DOWN then editor_smooth_scroll.direction = .NONE;
+
+                        case .scroll_viewport_left;         if editor_smooth_scroll.direction == .LEFT then editor_smooth_scroll.direction = .NONE;
+                        case .scroll_viewport_right;        if editor_smooth_scroll.direction == .RIGHT then editor_smooth_scroll.direction = .NONE;
                     }
                 }
                 // @Incomplete: Does stopping hold actions actually count as handling an event in the sense that it should suppress other event handlers?
@@ -146,12 +148,12 @@ active_editor_handle_event :: (event: Input.Event, action: Action_Editors) -> ha
         case .move_editor_to_the_right;         if editors.active == editors.left  then swap_panes();
         case .move_cursor_to_viewport_center;   move_cursor_to_viewport_center      (editor, buffer);
         case .remove_additional_cursors;        remove_additional_cursors           (editor);
-        case .scroll_viewport_up;               vertical_smooth_scroll              (editor, up = true);               activate_hold_action(action, event);
-        case .scroll_viewport_up_fast;          vertical_smooth_scroll              (editor, up = true, fast = true);  activate_hold_action(action, event);
-        case .scroll_viewport_down;             vertical_smooth_scroll              (editor, up = false);              activate_hold_action(action, event);
-        case .scroll_viewport_down_fast;        vertical_smooth_scroll              (editor, up = false, fast = true); activate_hold_action(action, event);
-        case .scroll_viewport_left;             // print("scroll_viewport_left - not implemented\n");
-        case .scroll_viewport_right;            // print("scroll_viewport_right - not implemented\n");
+        case .scroll_viewport_up;               smooth_scroll(editor, direction = .UP);                activate_hold_action(action, event);
+        case .scroll_viewport_up_fast;          smooth_scroll(editor, direction = .UP, fast = true);   activate_hold_action(action, event);
+        case .scroll_viewport_down;             smooth_scroll(editor, direction = .DOWN);              activate_hold_action(action, event);
+        case .scroll_viewport_down_fast;        smooth_scroll(editor, direction = .DOWN, fast = true); activate_hold_action(action, event);
+        case .scroll_viewport_left;             smooth_scroll(editor, direction = .LEFT);              activate_hold_action(action, event);
+        case .scroll_viewport_right;            smooth_scroll(editor, direction = .RIGHT);             activate_hold_action(action, event);
         case .undo;                             undo                                (editor, buffer); keep_selection = true;
         case .redo;                             redo                                (editor, buffer); keep_selection = true;
         case .select_all;                       select_all                          (editor, buffer); keep_selection = true;
@@ -1177,13 +1179,12 @@ toggle_expand :: () {
     }
 }
 
-vertical_smooth_scroll :: (editor: Editor, up: bool, fast := false) {
-    if !editor_smooth_scroll.active {
-        // Start smooth scrolling
-        editor_smooth_scroll.active     = true;
+smooth_scroll :: (editor: Editor, direction: Smooth_Scroll_Direction, fast := false) {
+    editor_smooth_scroll.direction = direction;
+    if editor_smooth_scroll.direction != .NONE {
         editor_smooth_scroll.started_at = frame_time;
+        editor_smooth_scroll.start_x    = editor.viewport.left;
         editor_smooth_scroll.start_y    = editor.viewport.top;
-        editor_smooth_scroll.up         = up;
         editor_smooth_scroll.fast       = fast;
     }
 }
@@ -2301,6 +2302,9 @@ Viewport :: struct {
     scroll_y := #run Tween_Animation(s32).{ speed = xx 0.1, func = .lerp };
     scroll_x := #run Tween_Animation(s32).{ speed = xx 0.1, func = .lerp };
 
+    rect: Rect;
+    max_line_pixel_width: s32;
+
     Glue_Point :: struct { buffer_pos: s32; offset_within_line: s32; }
 }
 
@@ -2386,11 +2390,18 @@ open_buffers_lock: Mutex;  // must hold while adding a new buffer
 editors: Editor_State;
 
 // Keyboard smooth scrolling
+Smooth_Scroll_Direction :: enum {
+    NONE;
+    UP;
+    DOWN;
+    LEFT;
+    RIGHT;
+}
 editor_smooth_scroll: struct {
-    active: bool;
-    up:     bool;  // if not up, then down
-    fast:   bool;
+    direction: Smooth_Scroll_Direction;  // if not up, then down
+    fast: bool;
     started_at: Time;
+    start_x: s32;
     start_y: s32;
 };
 

--- a/src/layout.jai
+++ b/src/layout.jai
@@ -67,7 +67,7 @@ shrink_y :: (rect: Rect, amount: float) -> Rect {
 
 cut_left :: (rect: Rect, amount: float, $margin := 0) -> (left: Rect,  remainder: Rect) {
     amount = floor(amount);
-    
+
     remainder := rect;
 
     remainder.w -= amount;
@@ -89,7 +89,7 @@ cut_left :: (rect: Rect, amount: float, $margin := 0) -> (left: Rect,  remainder
 
 cut_right :: (rect: Rect, amount: float) -> (right: Rect, remainder: Rect) {
     amount = floor(amount);
-    
+
     remainder := rect;
 
     remainder.w -= amount;
@@ -103,7 +103,7 @@ cut_right :: (rect: Rect, amount: float) -> (right: Rect, remainder: Rect) {
 
 cut_bottom :: (rect: Rect, amount: float) -> (bottom: Rect, remainder: Rect) {
     amount = floor(amount);
-    
+
     remainder := rect;
 
     remainder.h -= amount;
@@ -117,7 +117,7 @@ cut_bottom :: (rect: Rect, amount: float) -> (bottom: Rect, remainder: Rect) {
 
 cut_top :: (rect: Rect, amount: float) -> (top: Rect, remainder: Rect) {
     amount = floor(amount);
-    
+
     remainder := rect;
 
     remainder.h -= amount;
@@ -196,4 +196,8 @@ align_to_grid :: (rect: Rect) -> Rect {
 Rect :: struct {
     x, y : float;
     w, h : float;
+}
+
+operator == :: (r1: Rect, r2: Rect) -> bool {
+    return r1.x == r2.x && r1.y == r2.y && r1.w == r2.w && r1.h == r2.h;
 }

--- a/src/main.jai
+++ b/src/main.jai
@@ -380,7 +380,11 @@ update_mouse_state :: () {
     mouse.pointer.x = xx x;
     mouse.pointer.y = xx (window_height - y);
 
-    mouse.scroll_y_delta = cast(s32) (cast(float) Input.mouse_delta_z * WHEEL_SENSITIVITY);
+    if shift_pressed() {
+        mouse.scroll_x_delta = cast(s32) (cast(float) Input.mouse_delta_z * WHEEL_SENSITIVITY);
+    } else {
+        mouse.scroll_y_delta = cast(s32) (cast(float) Input.mouse_delta_z * WHEEL_SENSITIVITY);
+    }
     mouse.smooth_scroll = (mouse.scroll_y_delta % 120) == 0;  // @Robustness: hard-coded typical delta, but it really should be ok for now
     if !config.settings.smooth_scrolling then mouse.smooth_scroll = false;
 
@@ -506,6 +510,7 @@ mouse: Mouse_State;
 
 Mouse_State :: struct {
     pointer: Vector2;
+    scroll_x_delta: s32;
     scroll_y_delta: s32;
     smooth_scroll: bool;
 


### PR DESCRIPTION
Supports both keyboard and mousewheel based scrolling (only `shift+vertical-scroll-wheel` for now, will implement actual horizontal scroll wheel support in a future PR).