### PR TITLE
Add support for platform-specific "fuzzy" font search

### DIFF
--- a/src/config.jai
+++ b/src/config.jai
@@ -117,6 +117,11 @@ find_font_by_name :: (name: string) -> path: string, error_msg: string /* temp *
         array_add(*tried_paths, font_path);
     }
 
+    if ! #compile_time {
+        found, path := platform_find_font_by_name(name);
+        if found then return path, "";
+    }
+
     error_msg := tprint("Couldn't find font '%'.\n\nTried the following locations:\n - %\n\nPlease note that you can specify a full path to the desired font file.", name, join(..tried_paths, "\n - ", allocator = temp));
     return "", error_msg;
 }

--- a/src/platform/linux.jai
+++ b/src/platform/linux.jai
@@ -110,6 +110,11 @@ platform_get_save_file_name :: (name := "") -> string, bool {
     // return name;
 }
 
+platform_find_font_by_name :: (name: string, allocator := temp) -> bool, string {
+    found, path := LD.find_font(name, allocator);
+    return found, path;
+}
+
 platform_get_fonts_dir :: () -> string {
     return "/usr/share/fonts";
 }

--- a/src/platform/macos.jai
+++ b/src/platform/macos.jai
@@ -27,14 +27,14 @@ platform_config_dir :: inline () -> string {
 
 platform_get_centered_window_dimensions :: (open_on_biggest: bool) -> s32, s32, s32, s32 {
     // On macOS, we ignore open_on_biggest for now.
-    
+
     screen_size := NSScreen.frame(NSScreen.mainScreen()).size;
-    
+
     w := cast(s32) (screen_size.width  / 1.5);
     h := cast(s32) (screen_size.height / 1.5);
     x := cast(s32) (screen_size.width  / 2 - w / 2);
     y := cast(s32) (screen_size.height / 2 - h / 2);
-    
+
     return x, y, w, h;
 }
 
@@ -78,6 +78,10 @@ platform_enumerate_logical_drives :: inline () -> [] string {
 
 platform_get_save_file_name :: inline (name := "") -> string, bool {
     return "", false;
+}
+
+platform_find_font_by_name :: (name: string, allocator := temp) -> bool, string {
+    return false, "";
 }
 
 platform_get_fonts_dir :: inline () -> string {

--- a/src/platform/windows.jai
+++ b/src/platform/windows.jai
@@ -139,6 +139,10 @@ platform_get_save_file_name :: (name := "") -> string /* temp */, success: bool 
     return "", false;
 }
 
+platform_find_font_by_name :: (name: string, allocator := temp) -> bool, string {
+    return false, "";
+}
+
 platform_get_fonts_dir :: () -> string {
     return "C:/Windows/Fonts";
 }


### PR DESCRIPTION
This PR modifies `find_font_by_name()` to call a platform-specific hook when the regular font search algorithm is unable to find the user-requested font. The hook is intended to perform "fuzzy" matching on the font name specified by the user in the config file and return the path of a matching font file (if any). This should allow the user to specify the name of any font installed in the system without needing to know the exact path to the font file.

The only platform to currently implement the hook is Linux - the editor will attempt to load `libfontconfig` and use it to match the user-supplied name to a font file. This does not introduce a new dependency as the library is loaded dynamically at runtime and used only if loading is successful.