### PR TITLE
Font handling tweaks for Windows

### DIFF
--- a/FOCUS-CHANGELOG.txt
+++ b/FOCUS-CHANGELOG.txt
@@ -35,6 +35,7 @@
 + Workspace dir names with a dot will now be displayed correctly
 + Workspace dirs with similar names should now be disambiguated
 + Fixed editor commands executed using the command popup
++ Windows/Linux: you can now specify the name of any TrueType/OpenType font face that you have installed on the system and the editor will try to automatically find the correct font file for it (for example, if you have `font: courier new` in your config on a Windows system, the editor will automatically load `C:\Windows\Fonts\cour.ttf`). On Linux we use `libfontconfig` to match font face names to font files that are installed in the system. Please note that this auto-detection logic is just an addition to the existing behavior of the `font` config option (meaning that you can still specify paths to specific font files just as before). MacOS implementation will come in a future release.
 
 
 # RELEASES ==================================================================

--- a/src/platform/windows.jai
+++ b/src/platform/windows.jai
@@ -229,7 +229,6 @@ REFRESH_TIMER_ID :: 0;
 user32   :: #system_library "user32";
 kernel32 :: #system_library "kernel32";
 shell32  :: #system_library "shell32";
-gdi      :: #system_library "gdi32";
 ole32    :: #system_library "ole32";
 
 KF_FLAG_CREATE :: 0x00008000;                                       // https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/ne-shlobj_core-known_folder_flag
@@ -243,59 +242,6 @@ GetLogicalDriveStringsW :: (nBufferLength: DWORD, lpBuffer: *u16) -> DWORD #fore
 ShellExecuteW :: (hwnd: HWND, lpOperation: *u16, lpFile: *u16, lpParameters: *u16, lpDirectory: *u16, nShowCmd: int) -> s32 #foreign shell32;
 SHGetKnownFolderPath :: (nFolder: REFGUID, dwFlags: DWORD, hToken: HANDLE, pszPath: **u16) -> HRESULT #foreign shell32; 
 CoTaskMemFree :: (pv: *void) #foreign ole32;
-
-LOGFONTA:: struct {
-    lfHeight: s32;
-    lfWidth: s32;
-    lfEscapement: s32;
-    lfOrientation: s32;
-    lfWeight: s32;
-    lfItalic: u8;
-    lfUnderline: u8;
-    lfStrikeOut: u8;
-    lfCharSet: u8;
-    lfOutPrecision: u8;
-    lfClipPrecision: u8;
-    lfQuality: u8;
-    lfPitchAndFamily: u8;
-    lfFaceName: [32]u8;
-}
-
-ENUMLOGFONTEXA :: struct {
-    elfLogFont: LOGFONTA;
-    elfFullName: [64]u8;
-    elfStyle: [64]u8;
-    elfScript: [64]u8;
-}
-    
-TEXTMETRICA:: struct {
-    tmHeight: s32;
-    tmAscent: s32;
-    tmDescent: s32;
-    tmInternalLeading: s32;
-    tmExternalLeading: s32;
-    tmAveCharWidth: s32;
-    tmMaxCharWidth: s32;
-    tmWeight: s32;
-    tmOverhang: s32;
-    tmDigitizedAspectX: s32;
-    tmDigitizedAspectY: s32;
-    tmFirstChar: u8;
-    tmLastChar: u8;
-    tmDefaultChar: u8;
-    tmBreakChar: u8;
-    tmItalic: u8;
-    tmUnderlined: u8;
-    tmStruckOut: u8;
-    tmPitchAndFamily: u8;
-    tmCharSet: u8;
-}
-
-DEFAULT_CHARSET :: 1;
-FIXED_PITCH :: 1;
-
-FONTENUMPROCA :: #type (elfe: *ENUMLOGFONTEXA, me: *TEXTMETRICA, FontType: DWORD, lParam: LPARAM) -> s32 #c_call;
-EnumFontFamiliesExA :: (hdc: HDC, lf: *LOGFONTA, proc: FONTENUMPROCA, lParam: LPARAM, dwFlags: DWORD) -> s32 #foreign gdi;
 
 #import "Windows";
 #import "Windows_Registry";

--- a/src/platform/windows.jai
+++ b/src/platform/windows.jai
@@ -140,6 +140,42 @@ platform_get_save_file_name :: (name := "") -> string /* temp */, success: bool 
 }
 
 platform_find_font_by_name :: (name: string, allocator := temp) -> bool, string {
+    // We would like to use `EnumFontFamiliesExA()` so we can filter out fonts that are
+    // not monospace. However it only enumerates fonts that have been loaded in GDI via
+    // `AddFontResourceEx()` which doesn't include fonts installed in the user specific
+    // location (`%LocalAppData\Microsoft\Windows\Fonts`) by default.
+    //
+    // Instead of spamming `AddFontResourceEx()` calls we just take file names straight
+    // from he registry.
+
+    hkeys  : []HKEY   = .[HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE];
+    styles : []string = .[" Regular", ""];
+    types  : []string = .[" (TrueType)", ""];
+    key    : string   = "Software\\Microsoft\\Windows NT\\CurrentVersion\\Fonts\0";  // Needs '\0' at the end so we can pass it to RegGetValueA()
+    for hkey : hkeys {
+        for style : styles {
+            for type : types {
+                buff: [1024]u8;
+                size: DWORD = buff.count - 1;
+                
+                value := sprint("%1%2%3\0", name, style, type);  // Needs '\0' at the end so we can pass it to RegGetValueA()
+                defer free(value);
+                
+                ret := RegGetValueA(hkey, key.data, value.data, RRF_RT_REG_SZ, null, buff.data, *size);
+                if ret != 0 continue;
+                
+                path := to_string(buff.data, size);
+                if !is_absolute_path(path) {
+                    sb: String_Builder;
+                    init_string_builder(*sb);
+                    print_to_builder(*sb, "%/%", platform_get_fonts_dir(), path);
+                    return true, builder_to_string(*sb, allocator);
+                }
+                return true, copy_string(path, allocator);
+            }
+        }
+    }
+
     return false, "";
 }
 
@@ -212,4 +248,58 @@ ShellExecuteW :: (hwnd: HWND, lpOperation: *u16, lpFile: *u16, lpParameters: *u1
 SHGetKnownFolderPath :: (nFolder: REFGUID, dwFlags: DWORD, hToken: HANDLE, pszPath: **u16) -> HRESULT #foreign shell32; 
 CoTaskMemFree :: (pv: *void) #foreign ole32;
 
+LOGFONTA:: struct {
+    lfHeight: s32;
+    lfWidth: s32;
+    lfEscapement: s32;
+    lfOrientation: s32;
+    lfWeight: s32;
+    lfItalic: u8;
+    lfUnderline: u8;
+    lfStrikeOut: u8;
+    lfCharSet: u8;
+    lfOutPrecision: u8;
+    lfClipPrecision: u8;
+    lfQuality: u8;
+    lfPitchAndFamily: u8;
+    lfFaceName: [32]u8;
+}
+
+ENUMLOGFONTEXA :: struct {
+    elfLogFont: LOGFONTA;
+    elfFullName: [64]u8;
+    elfStyle: [64]u8;
+    elfScript: [64]u8;
+}
+    
+TEXTMETRICA:: struct {
+    tmHeight: s32;
+    tmAscent: s32;
+    tmDescent: s32;
+    tmInternalLeading: s32;
+    tmExternalLeading: s32;
+    tmAveCharWidth: s32;
+    tmMaxCharWidth: s32;
+    tmWeight: s32;
+    tmOverhang: s32;
+    tmDigitizedAspectX: s32;
+    tmDigitizedAspectY: s32;
+    tmFirstChar: u8;
+    tmLastChar: u8;
+    tmDefaultChar: u8;
+    tmBreakChar: u8;
+    tmItalic: u8;
+    tmUnderlined: u8;
+    tmStruckOut: u8;
+    tmPitchAndFamily: u8;
+    tmCharSet: u8;
+}
+
+DEFAULT_CHARSET :: 1;
+FIXED_PITCH :: 1;
+
+FONTENUMPROCA :: #type (elfe: *ENUMLOGFONTEXA, me: *TEXTMETRICA, FontType: DWORD, lParam: LPARAM) -> s32 #c_call;
+EnumFontFamiliesExA :: (hdc: HDC, lf: *LOGFONTA, proc: FONTENUMPROCA, lParam: LPARAM, dwFlags: DWORD) -> s32 #foreign gdi;
+
 #import "Windows";
+#import "Windows_Registry";

--- a/src/platform/windows.jai
+++ b/src/platform/windows.jai
@@ -166,10 +166,8 @@ platform_find_font_by_name :: (name: string, allocator := temp) -> bool, string 
                 
                 path := to_string(buff.data, size);
                 if !is_absolute_path(path) {
-                    sb: String_Builder;
-                    init_string_builder(*sb);
-                    print_to_builder(*sb, "%/%", platform_get_fonts_dir(), path);
-                    return true, builder_to_string(*sb, allocator);
+                    full_path := tprint("%/%", platform_get_fonts_dir(), path);
+                    return true, copy_string(full_path, allocator);
                 }
                 return true, copy_string(path, allocator);
             }
@@ -186,9 +184,7 @@ platform_get_fonts_dir :: () -> string {
         defer CoTaskMemFree(path_utf16);
         if SUCCEEDED(ret) {
             fonts_dir = copy_string(wide_to_utf8(path_utf16));
-            for 0..fonts_dir.count - 1 {
-                if fonts_dir[it] == #char "\\" then fonts_dir[it] = #char "/";
-            }
+            path_overwrite_separators(fonts_dir, #char "/");
         } else {
             fonts_dir = "C:/Windows/Fonts";
         }

--- a/src/platform/windows.jai
+++ b/src/platform/windows.jai
@@ -144,7 +144,20 @@ platform_find_font_by_name :: (name: string, allocator := temp) -> bool, string 
 }
 
 platform_get_fonts_dir :: () -> string {
-    return "C:/Windows/Fonts";
+    if !fonts_dir {
+        path_utf16: *u16;
+        ret := SHGetKnownFolderPath(*FOLDERID_Fonts, KF_FLAG_CREATE, null, *path_utf16);
+        defer CoTaskMemFree(path_utf16);
+        if SUCCEEDED(ret) {
+            fonts_dir = copy_string(wide_to_utf8(path_utf16));
+            for 0..fonts_dir.count - 1 {
+                if fonts_dir[it] == #char "\\" then fonts_dir[it] = #char "/";
+            }
+        } else {
+            fonts_dir = "C:/Windows/Fonts";
+        }
+    }
+    return fonts_dir;
 }
 
 platform_open_in_explorer :: (dir: string) {
@@ -152,6 +165,8 @@ platform_open_in_explorer :: (dir: string) {
 }
 
 #scope_file
+
+fonts_dir: string;
 
 monitor_enum_proc :: (hMonitor: HMONITOR, hdc: HDC, rect: *RECT, data: LPARAM) -> BOOL #c_call {
     monitor : Monitor = ---;
@@ -182,6 +197,11 @@ REFRESH_TIMER_ID :: 0;
 user32   :: #system_library "user32";
 kernel32 :: #system_library "kernel32";
 shell32  :: #system_library "shell32";
+gdi      :: #system_library "gdi32";
+ole32    :: #system_library "ole32";
+
+KF_FLAG_CREATE :: 0x00008000;                                       // https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/ne-shlobj_core-known_folder_flag
+FOLDERID_Fonts :: #run uid("FD228CB7-AE11-4AE3-864C-16F3910AB8FE"); // https://learn.microsoft.com/en-us/windows/win32/shell/knownfolderid
 
 WaitMessage :: () -> s32 #foreign user32;
 SetTimer  :: (hWnd: HWND, nIDEvent: u64, uElapse: u32, lpTimerFunc: *void) -> s32 #foreign user32;
@@ -189,5 +209,7 @@ KillTimer :: (hWnd: HWND, nIDEvent: u64) -> bool #foreign user32;
 GetDpiForWindow :: (hWnd: HWND) -> u32 #foreign user32;
 GetLogicalDriveStringsW :: (nBufferLength: DWORD, lpBuffer: *u16) -> DWORD #foreign kernel32;
 ShellExecuteW :: (hwnd: HWND, lpOperation: *u16, lpFile: *u16, lpParameters: *u16, lpDirectory: *u16, nShowCmd: int) -> s32 #foreign shell32;
+SHGetKnownFolderPath :: (nFolder: REFGUID, dwFlags: DWORD, hToken: HANDLE, pszPath: **u16) -> HRESULT #foreign shell32; 
+CoTaskMemFree :: (pv: *void) #foreign ole32;
 
 #import "Windows";


### PR DESCRIPTION
* `platform_get_fonts_dir()` actually attempts to get the fonts directory from the OS instead of simply returning a hard-coded value
* implemented `platform_find_font_by_name()`