### PR TITLE
Keybindings with multiple key combos

### DIFF
--- a/modules/Input/macos.jai
+++ b/modules/Input/macos.jai
@@ -9,112 +9,116 @@ window_minimized := false; // @@ Hack.
 osx_externally_generated_events: [..] Event;
 
 set_custom_cursor_handling :: (is_custom: bool) {
-     // @Incomplete: Implement this.
-     // Use this if you are doing immediate-mode API stuff that sets cursors and want to prevent cursors from flickering. Windows is annoying to interface with.
+    // @Incomplete: Implement this.
+    // Use this if you are doing immediate-mode API stuff that sets cursors and want to prevent cursors from flickering. Windows is annoying to interface with.
 }
 
 #scope_file
 
-OSX_VK_ESCAPE     :: 53;
-OSX_VK_F1         :: 122;
-OSX_VK_F2         :: 120;
-OSX_VK_F3         :: 99;
-OSX_VK_F4         :: 118;
-OSX_VK_F5         :: 96;
-OSX_VK_F6         :: 97;
-OSX_VK_F7         :: 98;
-OSX_VK_F8         :: 100;
-OSX_VK_F9         :: 101;
-OSX_VK_F10        :: 109;
-OSX_VK_F11        :: 103;
-OSX_VK_F12        :: 111;
-OSX_VK_F13        :: 105;
-OSX_VK_F14        :: 107;
-OSX_VK_F15        :: 113;
-OSX_VK_BACK_TICK  :: 50;
-OSX_VK_1          :: 18;
-OSX_VK_2          :: 19;
-OSX_VK_3          :: 20;
-OSX_VK_4          :: 21;
-OSX_VK_5          :: 23;
-OSX_VK_6          :: 22;
-OSX_VK_7          :: 26;
-OSX_VK_8          :: 28;
-OSX_VK_9          :: 25;
-OSX_VK_0          :: 29;
-OSX_VK_DASH       :: 27;
-OSX_VK_EQUAL      :: 24;
-OSX_VK_BACKSPACE  :: 51;
-OSX_VK_TAB        :: 48;
-OSX_VK_Q          :: 12;
-OSX_VK_W          :: 13;
-OSX_VK_E          :: 14;
-OSX_VK_R          :: 15;
-OSX_VK_T          :: 17;
-OSX_VK_Y          :: 16;
-OSX_VK_U          :: 32;
-OSX_VK_I          :: 34;
-OSX_VK_O          :: 31;
-OSX_VK_P          :: 35;
-OSX_VK_LBRACKET   :: 33;
-OSX_VK_RBRACKET   :: 30;
-OSX_VK_BACKSLASH  :: 42;
-OSX_VK_CAPS_LOCK  :: 57;
-OSX_VK_A          :: 0;
-OSX_VK_S          :: 1;
-OSX_VK_D          :: 2;
-OSX_VK_F          :: 3;
-OSX_VK_G          :: 5;
-OSX_VK_H          :: 4;
-OSX_VK_J          :: 38;
-OSX_VK_K          :: 40;
-OSX_VK_L          :: 37;
-OSX_VK_COLON      :: 41;
-OSX_VK_QUOTE      :: 39;
-OSX_VK_RETURN     :: 36;
-OSX_VK_SHIFT      :: 56;
-OSX_VK_Z          :: 6;
-OSX_VK_X          :: 7;
-OSX_VK_C          :: 8;
-OSX_VK_V          :: 9;
-OSX_VK_B          :: 11;
-OSX_VK_N          :: 45;
-OSX_VK_M          :: 46;
-OSX_VK_COMMA      :: 43;
-OSX_VK_PERIOD     :: 47;
-OSX_VK_FWD_SLASH  :: 44;
-OSX_VK_CONTROL    :: 59;
-OSX_VK_OPTION     :: 58;
-OSX_VK_COMMAND    :: 55;
-OSX_VK_SPACEBAR   :: 49;
-OSX_VK_INSERT     :: 114;
-OSX_VK_HOME       :: 115;
-OSX_VK_PAGE_UP    :: 116;
-OSX_VK_DELETE     :: 117;
-OSX_VK_END        :: 119;
-OSX_VK_PAGE_DOWN  :: 121;
-OSX_VK_UP         :: 126;
-OSX_VK_DOWN       :: 125;
-OSX_VK_RIGHT      :: 124;
-OSX_VK_LEFT       :: 123;
-OSX_VK_NUMLOCK        :: 71;
-OSX_VK_NUMPAD_EQUALS  :: 81;
-OSX_VK_NUMPAD_DIVIDE  :: 75;
-OSX_VK_NUMPAD_MULT    :: 67;
-OSX_VK_NUMPAD_7       :: 89;
-OSX_VK_NUMPAD_8       :: 91;
-OSX_VK_NUMPAD_9       :: 92;
-OSX_VK_NUMPAD_MINUS   :: 78;
-OSX_VK_NUMPAD_4       :: 86;
-OSX_VK_NUMPAD_5       :: 87;
-OSX_VK_NUMPAD_6       :: 88;
-OSX_VK_NUMPAD_PLUS    :: 69;
-OSX_VK_NUMPAD_1       :: 83;
-OSX_VK_NUMPAD_2       :: 84;
-OSX_VK_NUMPAD_3       :: 85;
-OSX_VK_NUMPAD_ENTER   :: 76;
-OSX_VK_NUMPAD_0       :: 82;
-OSX_VK_NUMPAD_PERIOD  :: 65;
+OSX_VK_ESCAPE        :: 53;
+OSX_VK_F1            :: 122;
+OSX_VK_F2            :: 120;
+OSX_VK_F3            :: 99;
+OSX_VK_F4            :: 118;
+OSX_VK_F5            :: 96;
+OSX_VK_F6            :: 97;
+OSX_VK_F7            :: 98;
+OSX_VK_F8            :: 100;
+OSX_VK_F9            :: 101;
+OSX_VK_F10           :: 109;
+OSX_VK_F11           :: 103;
+OSX_VK_F12           :: 111;
+OSX_VK_F13           :: 105;
+OSX_VK_F14           :: 107;
+OSX_VK_F15           :: 113;
+OSX_VK_BACK_TICK     :: 50;
+OSX_VK_1             :: 18;
+OSX_VK_2             :: 19;
+OSX_VK_3             :: 20;
+OSX_VK_4             :: 21;
+OSX_VK_5             :: 23;
+OSX_VK_6             :: 22;
+OSX_VK_7             :: 26;
+OSX_VK_8             :: 28;
+OSX_VK_9             :: 25;
+OSX_VK_0             :: 29;
+OSX_VK_DASH          :: 27;
+OSX_VK_EQUAL         :: 24;
+OSX_VK_BACKSPACE     :: 51;
+OSX_VK_TAB           :: 48;
+OSX_VK_Q             :: 12;
+OSX_VK_W             :: 13;
+OSX_VK_E             :: 14;
+OSX_VK_R             :: 15;
+OSX_VK_T             :: 17;
+OSX_VK_Y             :: 16;
+OSX_VK_U             :: 32;
+OSX_VK_I             :: 34;
+OSX_VK_O             :: 31;
+OSX_VK_P             :: 35;
+OSX_VK_LBRACKET      :: 33;
+OSX_VK_RBRACKET      :: 30;
+OSX_VK_BACKSLASH     :: 42;
+OSX_VK_CAPS_LOCK     :: 57;
+OSX_VK_A             :: 0;
+OSX_VK_S             :: 1;
+OSX_VK_D             :: 2;
+OSX_VK_F             :: 3;
+OSX_VK_G             :: 5;
+OSX_VK_H             :: 4;
+OSX_VK_J             :: 38;
+OSX_VK_K             :: 40;
+OSX_VK_L             :: 37;
+OSX_VK_COLON         :: 41;
+OSX_VK_QUOTE         :: 39;
+OSX_VK_RETURN        :: 36;
+OSX_VK_SHIFT         :: 56;
+OSX_VK_Z             :: 6;
+OSX_VK_X             :: 7;
+OSX_VK_C             :: 8;
+OSX_VK_V             :: 9;
+OSX_VK_B             :: 11;
+OSX_VK_N             :: 45;
+OSX_VK_M             :: 46;
+OSX_VK_COMMA         :: 43;
+OSX_VK_PERIOD        :: 47;
+OSX_VK_FWD_SLASH     :: 44;
+OSX_VK_CONTROL       :: 59;
+OSX_VK_OPTION        :: 58;
+OSX_VK_COMMAND       :: 55;
+OSX_VK_SPACEBAR      :: 49;
+OSX_VK_INSERT        :: 114;
+OSX_VK_HOME          :: 115;
+OSX_VK_PAGE_UP       :: 116;
+OSX_VK_DELETE        :: 117;
+OSX_VK_END           :: 119;
+OSX_VK_PAGE_DOWN     :: 121;
+OSX_VK_UP            :: 126;
+OSX_VK_DOWN          :: 125;
+OSX_VK_RIGHT         :: 124;
+OSX_VK_LEFT          :: 123;
+OSX_VK_NUMLOCK       :: 71;
+OSX_VK_NUMPAD_EQUALS :: 81;
+OSX_VK_NUMPAD_DIVIDE :: 75;
+OSX_VK_NUMPAD_MULT   :: 67;
+OSX_VK_NUMPAD_7      :: 89;
+OSX_VK_NUMPAD_8      :: 91;
+OSX_VK_NUMPAD_9      :: 92;
+OSX_VK_NUMPAD_MINUS  :: 78;
+OSX_VK_NUMPAD_4      :: 86;
+OSX_VK_NUMPAD_5      :: 87;
+OSX_VK_NUMPAD_6      :: 88;
+OSX_VK_NUMPAD_PLUS   :: 69;
+OSX_VK_NUMPAD_1      :: 83;
+OSX_VK_NUMPAD_2      :: 84;
+OSX_VK_NUMPAD_3      :: 85;
+OSX_VK_NUMPAD_ENTER  :: 76;
+OSX_VK_NUMPAD_0      :: 82;
+OSX_VK_NUMPAD_PERIOD :: 65;
+OSX_VK_RIGHT_COMMAND :: 54;
+OSX_VK_RIGHT_SHIFT   :: 60;
+OSX_VK_RIGHT_OPTION  :: 61;
+OSX_VK_RIGHT_CONTROL :: 62;
 
 input_vk_table_initialized := false;
 input_vk_translation_table: [128] Key_Code; // translates OSX system's virtual keys to jai's Input module's virtual keys
@@ -126,89 +130,93 @@ init_input_system :: () {
         <<it = UNKNOWN;
     }
 
-    input_vk_translation_table[OSX_VK_ESCAPE] = ESCAPE;
-    input_vk_translation_table[OSX_VK_F1]     = F1;
-    input_vk_translation_table[OSX_VK_F2]     = F2;
-    input_vk_translation_table[OSX_VK_F3]     = F3;
-    input_vk_translation_table[OSX_VK_F4]     = F4;
-    input_vk_translation_table[OSX_VK_F5]     = F5;
-    input_vk_translation_table[OSX_VK_F6]     = F6;
-    input_vk_translation_table[OSX_VK_F7]     = F7;
-    input_vk_translation_table[OSX_VK_F8]     = F8;
-    input_vk_translation_table[OSX_VK_F9]     = F9;
-    input_vk_translation_table[OSX_VK_F10]    = F10;
-    input_vk_translation_table[OSX_VK_F11]    = F11;
-    input_vk_translation_table[OSX_VK_F12]    = F12;
-    input_vk_translation_table[OSX_VK_F13]    = PRINT_SCREEN; // sigh, the print screen key is reported by the system as F13
-    input_vk_translation_table[OSX_VK_F14]    = F14;
-    input_vk_translation_table[OSX_VK_F15]    = F15;
-    input_vk_translation_table[OSX_VK_BACK_TICK] = xx #char "`";
-    input_vk_translation_table[OSX_VK_1]      = xx #char "1";
-    input_vk_translation_table[OSX_VK_2]      = xx #char "2";
-    input_vk_translation_table[OSX_VK_3]      = xx #char "3";
-    input_vk_translation_table[OSX_VK_4]      = xx #char "4";
-    input_vk_translation_table[OSX_VK_5]      = xx #char "5";
-    input_vk_translation_table[OSX_VK_6]      = xx #char "6";
-    input_vk_translation_table[OSX_VK_7]      = xx #char "7";
-    input_vk_translation_table[OSX_VK_8]      = xx #char "8";
-    input_vk_translation_table[OSX_VK_9]      = xx #char "9";
-    input_vk_translation_table[OSX_VK_0]      = xx #char "0";
-    input_vk_translation_table[OSX_VK_DASH]   = xx #char "-";
-    input_vk_translation_table[OSX_VK_EQUAL]  = xx #char "+";
-    input_vk_translation_table[OSX_VK_BACKSPACE] = BACKSPACE;
-    input_vk_translation_table[OSX_VK_TAB]    = TAB;
-    input_vk_translation_table[OSX_VK_Q]      = xx #char "Q";
-    input_vk_translation_table[OSX_VK_W]      = xx #char "W";
-    input_vk_translation_table[OSX_VK_E]      = xx #char "E";
-    input_vk_translation_table[OSX_VK_R]      = xx #char "R";
-    input_vk_translation_table[OSX_VK_T]      = xx #char "T";
-    input_vk_translation_table[OSX_VK_Y]      = xx #char "Y";
-    input_vk_translation_table[OSX_VK_U]      = xx #char "U";
-    input_vk_translation_table[OSX_VK_I]      = xx #char "I";
-    input_vk_translation_table[OSX_VK_O]      = xx #char "O";
-    input_vk_translation_table[OSX_VK_P]      = xx #char "P";
-    input_vk_translation_table[OSX_VK_LBRACKET]  = xx #char "[";
-    input_vk_translation_table[OSX_VK_RBRACKET]  = xx #char "]";
-    input_vk_translation_table[OSX_VK_BACKSLASH] = xx #char "\\";
-    // input_vk_translation_table[OSX_VK_CAPS_LOCK] = UNKNOWN;
-    input_vk_translation_table[OSX_VK_A]      = xx #char "A";
-    input_vk_translation_table[OSX_VK_S]      = xx #char "S";
-    input_vk_translation_table[OSX_VK_D]      = xx #char "D";
-    input_vk_translation_table[OSX_VK_F]      = xx #char "F";
-    input_vk_translation_table[OSX_VK_G]      = xx #char "G";
-    input_vk_translation_table[OSX_VK_H]      = xx #char "H";
-    input_vk_translation_table[OSX_VK_J]      = xx #char "J";
-    input_vk_translation_table[OSX_VK_K]      = xx #char "K";
-    input_vk_translation_table[OSX_VK_L]      = xx #char "L";
-    input_vk_translation_table[OSX_VK_COLON]  = xx #char ";";
-    input_vk_translation_table[OSX_VK_QUOTE]  = xx #char "'";
-    input_vk_translation_table[OSX_VK_RETURN] = ENTER;
-    input_vk_translation_table[OSX_VK_SHIFT]  = SHIFT;
-    input_vk_translation_table[OSX_VK_Z]      = xx #char "Z";
-    input_vk_translation_table[OSX_VK_X]      = xx #char "X";
-    input_vk_translation_table[OSX_VK_C]      = xx #char "C";
-    input_vk_translation_table[OSX_VK_V]      = xx #char "V";
-    input_vk_translation_table[OSX_VK_B]      = xx #char "B";
-    input_vk_translation_table[OSX_VK_N]      = xx #char "N";
-    input_vk_translation_table[OSX_VK_M]      = xx #char "M";
-    input_vk_translation_table[OSX_VK_COMMA]  = xx #char ",";
-    input_vk_translation_table[OSX_VK_PERIOD] = xx #char ".";
-    input_vk_translation_table[OSX_VK_FWD_SLASH] = xx #char "/";
-    input_vk_translation_table[OSX_VK_CONTROL]  = CTRL;
-    input_vk_translation_table[OSX_VK_OPTION]   = ALT;
-    input_vk_translation_table[OSX_VK_COMMAND]  = CMD;
-    input_vk_translation_table[OSX_VK_SPACEBAR]  = xx #char " ";
-    input_vk_translation_table[OSX_VK_INSERT]    = INSERT;
-    input_vk_translation_table[OSX_VK_HOME]      = HOME;
-    input_vk_translation_table[OSX_VK_PAGE_UP]   = PAGE_UP;
-    input_vk_translation_table[OSX_VK_DELETE]    = DELETE;
-    input_vk_translation_table[OSX_VK_END]       = END;
-    input_vk_translation_table[OSX_VK_PAGE_DOWN] = PAGE_DOWN;
-    input_vk_translation_table[OSX_VK_UP]        = ARROW_UP;
-    input_vk_translation_table[OSX_VK_DOWN]      = ARROW_DOWN;
-    input_vk_translation_table[OSX_VK_RIGHT]     = ARROW_RIGHT;
-    input_vk_translation_table[OSX_VK_LEFT]      = ARROW_LEFT;
-    // input_vk_translation_table[OSX_VK_NUMLOCK]   = UNKNOWN;
+    input_vk_translation_table[OSX_VK_ESCAPE]        = ESCAPE;
+    input_vk_translation_table[OSX_VK_F1]            = F1;
+    input_vk_translation_table[OSX_VK_F2]            = F2;
+    input_vk_translation_table[OSX_VK_F3]            = F3;
+    input_vk_translation_table[OSX_VK_F4]            = F4;
+    input_vk_translation_table[OSX_VK_F5]            = F5;
+    input_vk_translation_table[OSX_VK_F6]            = F6;
+    input_vk_translation_table[OSX_VK_F7]            = F7;
+    input_vk_translation_table[OSX_VK_F8]            = F8;
+    input_vk_translation_table[OSX_VK_F9]            = F9;
+    input_vk_translation_table[OSX_VK_F10]           = F10;
+    input_vk_translation_table[OSX_VK_F11]           = F11;
+    input_vk_translation_table[OSX_VK_F12]           = F12;
+    input_vk_translation_table[OSX_VK_F13]           = PRINT_SCREEN; // sigh, the print screen key is reported by the system as F13
+    input_vk_translation_table[OSX_VK_F14]           = F14;
+    input_vk_translation_table[OSX_VK_F15]           = F15;
+    input_vk_translation_table[OSX_VK_BACK_TICK]     = xx #char "`";
+    input_vk_translation_table[OSX_VK_1]             = xx #char "1";
+    input_vk_translation_table[OSX_VK_2]             = xx #char "2";
+    input_vk_translation_table[OSX_VK_3]             = xx #char "3";
+    input_vk_translation_table[OSX_VK_4]             = xx #char "4";
+    input_vk_translation_table[OSX_VK_5]             = xx #char "5";
+    input_vk_translation_table[OSX_VK_6]             = xx #char "6";
+    input_vk_translation_table[OSX_VK_7]             = xx #char "7";
+    input_vk_translation_table[OSX_VK_8]             = xx #char "8";
+    input_vk_translation_table[OSX_VK_9]             = xx #char "9";
+    input_vk_translation_table[OSX_VK_0]             = xx #char "0";
+    input_vk_translation_table[OSX_VK_DASH]          = xx #char "-";
+    input_vk_translation_table[OSX_VK_EQUAL]         = xx #char "+";
+    input_vk_translation_table[OSX_VK_BACKSPACE]     = BACKSPACE;
+    input_vk_translation_table[OSX_VK_TAB]           = TAB;
+    input_vk_translation_table[OSX_VK_Q]             = xx #char "Q";
+    input_vk_translation_table[OSX_VK_W]             = xx #char "W";
+    input_vk_translation_table[OSX_VK_E]             = xx #char "E";
+    input_vk_translation_table[OSX_VK_R]             = xx #char "R";
+    input_vk_translation_table[OSX_VK_T]             = xx #char "T";
+    input_vk_translation_table[OSX_VK_Y]             = xx #char "Y";
+    input_vk_translation_table[OSX_VK_U]             = xx #char "U";
+    input_vk_translation_table[OSX_VK_I]             = xx #char "I";
+    input_vk_translation_table[OSX_VK_O]             = xx #char "O";
+    input_vk_translation_table[OSX_VK_P]             = xx #char "P";
+    input_vk_translation_table[OSX_VK_LBRACKET]      = xx #char "[";
+    input_vk_translation_table[OSX_VK_RBRACKET]      = xx #char "]";
+    input_vk_translation_table[OSX_VK_BACKSLASH]     = xx #char "\\";
+    // input_vk_translation_table[OSX_VK_CAPS_LOCK]  = UNKNOWN;
+    input_vk_translation_table[OSX_VK_A]             = xx #char "A";
+    input_vk_translation_table[OSX_VK_S]             = xx #char "S";
+    input_vk_translation_table[OSX_VK_D]             = xx #char "D";
+    input_vk_translation_table[OSX_VK_F]             = xx #char "F";
+    input_vk_translation_table[OSX_VK_G]             = xx #char "G";
+    input_vk_translation_table[OSX_VK_H]             = xx #char "H";
+    input_vk_translation_table[OSX_VK_J]             = xx #char "J";
+    input_vk_translation_table[OSX_VK_K]             = xx #char "K";
+    input_vk_translation_table[OSX_VK_L]             = xx #char "L";
+    input_vk_translation_table[OSX_VK_COLON]         = xx #char ";";
+    input_vk_translation_table[OSX_VK_QUOTE]         = xx #char "'";
+    input_vk_translation_table[OSX_VK_RETURN]        = ENTER;
+    input_vk_translation_table[OSX_VK_SHIFT]         = SHIFT;
+    input_vk_translation_table[OSX_VK_Z]             = xx #char "Z";
+    input_vk_translation_table[OSX_VK_X]             = xx #char "X";
+    input_vk_translation_table[OSX_VK_C]             = xx #char "C";
+    input_vk_translation_table[OSX_VK_V]             = xx #char "V";
+    input_vk_translation_table[OSX_VK_B]             = xx #char "B";
+    input_vk_translation_table[OSX_VK_N]             = xx #char "N";
+    input_vk_translation_table[OSX_VK_M]             = xx #char "M";
+    input_vk_translation_table[OSX_VK_COMMA]         = xx #char ",";
+    input_vk_translation_table[OSX_VK_PERIOD]        = xx #char ".";
+    input_vk_translation_table[OSX_VK_FWD_SLASH]     = xx #char "/";
+    input_vk_translation_table[OSX_VK_CONTROL]       = CTRL;
+    input_vk_translation_table[OSX_VK_OPTION]        = ALT;
+    input_vk_translation_table[OSX_VK_COMMAND]       = CMD;
+    input_vk_translation_table[OSX_VK_SPACEBAR]      = xx #char " ";
+    input_vk_translation_table[OSX_VK_INSERT]        = INSERT;
+    input_vk_translation_table[OSX_VK_HOME]          = HOME;
+    input_vk_translation_table[OSX_VK_PAGE_UP]       = PAGE_UP;
+    input_vk_translation_table[OSX_VK_DELETE]        = DELETE;
+    input_vk_translation_table[OSX_VK_END]           = END;
+    input_vk_translation_table[OSX_VK_PAGE_DOWN]     = PAGE_DOWN;
+    input_vk_translation_table[OSX_VK_UP]            = ARROW_UP;
+    input_vk_translation_table[OSX_VK_DOWN]          = ARROW_DOWN;
+    input_vk_translation_table[OSX_VK_RIGHT]         = ARROW_RIGHT;
+    input_vk_translation_table[OSX_VK_LEFT]          = ARROW_LEFT;
+    input_vk_translation_table[OSX_VK_RIGHT_SHIFT]   = SHIFT;
+    input_vk_translation_table[OSX_VK_RIGHT_CONTROL] = CTRL;
+    input_vk_translation_table[OSX_VK_RIGHT_OPTION]  = ALT;
+    input_vk_translation_table[OSX_VK_RIGHT_COMMAND] = CMD;
+    // input_vk_translation_table[OSX_VK_NUMLOCK]       = UNKNOWN;
     // input_vk_translation_table[OSX_VK_NUMPAD_EQUALS] = UNKNOWN;
     // input_vk_translation_table[OSX_VK_NUMPAD_DIVIDE] = UNKNOWN;
     // input_vk_translation_table[OSX_VK_NUMPAD_MULT]   = UNKNOWN;
@@ -251,200 +259,200 @@ update_cocoa_window_events :: () {
         type := NSEvent.type(nsevent);
         if type == {
             case NSEventTypeFlagsChanged;
-                keycode := NSEvent.keyCode(nsevent);
-                modifiers := NSEvent.modifierFlags(nsevent);
+            keycode := NSEvent.keyCode(nsevent);
+            modifiers := NSEvent.modifierFlags(nsevent);
 
-                shift_state := (modifiers & NSEventModifierFlagShift) != 0;
-                ctrl_state  := (modifiers & NSEventModifierFlagControl) != 0;
-                alt_state   := (modifiers & NSEventModifierFlagOption) != 0;
-                cmd_state   := (modifiers & NSEventModifierFlagCommand) != 0;
+            shift_state := (modifiers & NSEventModifierFlagShift) != 0;
+            ctrl_state  := (modifiers & NSEventModifierFlagControl) != 0;
+            alt_state   := (modifiers & NSEventModifierFlagOption) != 0;
+            cmd_state   := (modifiers & NSEventModifierFlagCommand) != 0;
 
-                repeat := NO;
+            repeat := NO;
 
-                event: Event;
-                event.type = .KEYBOARD;
-                event.key_code = get_key_code(keycode);
+            event: Event;
+            event.type = .KEYBOARD;
+            event.key_code = get_key_code(keycode);
 
-                button_state_flags := (DOWN | START);
-                if event.key_code == {
-                    case Key_Code.SHIFT;  if !shift_state then button_state_flags = Key_Current_State.END;
-                    case Key_Code.ALT;    if !alt_state   then button_state_flags = Key_Current_State.END;
-                    case Key_Code.CTRL;   if !ctrl_state  then button_state_flags = Key_Current_State.END;
-                    case Key_Code.CMD;    if !cmd_state   then button_state_flags = Key_Current_State.END;
-                }
+            button_state_flags := (DOWN | START);
+            if event.key_code == {
+                case Key_Code.SHIFT;  if !shift_state then button_state_flags = Key_Current_State.END;
+                case Key_Code.ALT;    if !alt_state   then button_state_flags = Key_Current_State.END;
+                case Key_Code.CTRL;   if !ctrl_state  then button_state_flags = Key_Current_State.END;
+                case Key_Code.CMD;    if !cmd_state   then button_state_flags = Key_Current_State.END;
+            }
 
-                event.key_pressed = 0;
-                if button_state_flags & DOWN then event.key_pressed = 1;
+            event.key_pressed = 0;
+            if button_state_flags & DOWN then event.key_pressed = 1;
 
-                event.packed = 0;
-                event.shift_pressed    = shift_state;
-                event.ctrl_pressed     = ctrl_state;
-                event.alt_pressed      = alt_state;
-                event.cmd_meta_pressed = cmd_state;
-                event.repeat = (repeat != NO);
+            event.packed = 0;
+            event.shift_pressed    = shift_state;
+            event.ctrl_pressed     = ctrl_state;
+            event.alt_pressed      = alt_state;
+            event.cmd_meta_pressed = cmd_state;
+            event.repeat = (repeat != NO);
 
-                input_button_states[event.key_code] |= button_state_flags;
+            input_button_states[event.key_code] |= button_state_flags;
 
-                array_add(*events_this_frame, event);
+            array_add(*events_this_frame, event);
             case NSEventTypeKeyDown;
-                keycode := NSEvent.keyCode(nsevent);
-                characters := NSEvent.characters(nsevent);
-                modifiers := NSEvent.modifierFlags(nsevent);
+            keycode := NSEvent.keyCode(nsevent);
+            characters := NSEvent.characters(nsevent);
+            modifiers := NSEvent.modifierFlags(nsevent);
 
-                shift_state := (modifiers & NSEventModifierFlagShift) != 0;
-                ctrl_state  := (modifiers & NSEventModifierFlagControl) != 0;
-                alt_state   := (modifiers & NSEventModifierFlagOption) != 0;
-                cmd_state   := (modifiers & NSEventModifierFlagCommand) != 0;
+            shift_state := (modifiers & NSEventModifierFlagShift) != 0;
+            ctrl_state  := (modifiers & NSEventModifierFlagControl) != 0;
+            alt_state   := (modifiers & NSEventModifierFlagOption) != 0;
+            cmd_state   := (modifiers & NSEventModifierFlagCommand) != 0;
 
-                repeat := NSEvent.isARepeat(nsevent);
+            repeat := NSEvent.isARepeat(nsevent);
 
-                event: Event;
-                event.type = .KEYBOARD;
-                event.key_pressed = 1;
-                event.key_code = get_key_code(keycode);
-                event.packed = 0;
-                event.shift_pressed    = shift_state;
-                event.ctrl_pressed     = ctrl_state;
-                event.alt_pressed      = alt_state;
-                event.cmd_meta_pressed = cmd_state;
-                event.repeat = (repeat != NO);
+            event: Event;
+            event.type = .KEYBOARD;
+            event.key_pressed = 1;
+            event.key_code = get_key_code(keycode);
+            event.packed = 0;
+            event.shift_pressed    = shift_state;
+            event.ctrl_pressed     = ctrl_state;
+            event.alt_pressed      = alt_state;
+            event.cmd_meta_pressed = cmd_state;
+            event.repeat = (repeat != NO);
 
-                input_button_states[event.key_code] |= (DOWN | START);
+            input_button_states[event.key_code] |= (DOWN | START);
 
-                // Length will be 0 if this was a dead key.
-                // @Incomplete: How do we handle diacritics entered via dead keys?
-                // For example for "¨ + a => ä", if we ignore the dead key for ¨ here and then only handle the "a", people won’t be able to assemble the "ä".
-                if characters && NSString.length(characters) {
-                    utf32_data := NSString.dataUsingEncoding(characters, NSUTF32LittleEndianStringEncoding);
-                    // defer release(utf32_data);
-                    utf32 := cast(*u32) NSData.bytes(utf32_data);
-                    count := NSData.length(utf32_data) / size_of(u32);
+            // Length will be 0 if this was a dead key.
+            // @Incomplete: How do we handle diacritics entered via dead keys?
+            // For example for "¨ + a => ä", if we ignore the dead key for ¨ here and then only handle the "a", people won’t be able to assemble the "ä".
+            if characters && NSString.length(characters) {
+                utf32_data := NSString.dataUsingEncoding(characters, NSUTF32LittleEndianStringEncoding);
+                // defer release(utf32_data);
+                utf32 := cast(*u32) NSData.bytes(utf32_data);
+                count := NSData.length(utf32_data) / size_of(u32);
 
-                    event.text_input_count = xx count;
-                    array_add(*events_this_frame, event);
-
-                    for 0..count-1 {
-                        event: Event;
-                        event.type = .TEXT_INPUT;
-                        event.utf32 = utf32[it];
-
-                        // filter out control characters
-                        if event.utf32 <= 31   then continue;
-                        if event.utf32 == 0x7F then continue; // DEL
-
-                        // skip Private Use Area U+F700 (this contains values for NS function keys)
-                        if (event.utf32 & 0xFF00) == 0xF700 then continue;
-
-                        array_add(*events_this_frame, event);
-                    }
-                } else {
-                    array_add(*events_this_frame, event);
-                }
-
-                // continue;
-            case NSEventTypeKeyUp;
-                keycode := NSEvent.keyCode(nsevent);
-                characters := NSEvent.characters(nsevent);
-                modifiers := NSEvent.modifierFlags(nsevent);
-
-                shift_state := (modifiers & NSEventModifierFlagShift) != 0;
-                ctrl_state  := (modifiers & NSEventModifierFlagControl) != 0;
-                alt_state   := (modifiers & NSEventModifierFlagOption) != 0;
-                cmd_state   := (modifiers & NSEventModifierFlagCommand) != 0;
-
-                event: Event;
-                event.type = .KEYBOARD;
-                event.key_pressed = 0;
-                event.key_code = get_key_code(keycode);
-                event.packed = 0;  // @Temporary: Unions not currently initialized.
-                event.shift_pressed    = shift_state;
-                event.ctrl_pressed     = ctrl_state;
-                event.alt_pressed      = alt_state;
-                event.cmd_meta_pressed = cmd_state;
-
-                input_button_states[event.key_code] = Key_Current_State.END;  // Because we shadowed that by Key_Code.END.
-
+                event.text_input_count = xx count;
                 array_add(*events_this_frame, event);
 
-                // continue;
+                for 0..count-1 {
+                    event: Event;
+                    event.type = .TEXT_INPUT;
+                    event.utf32 = utf32[it];
+
+                    // filter out control characters
+                    if event.utf32 <= 31   then continue;
+                    if event.utf32 == 0x7F then continue; // DEL
+
+                    // skip Private Use Area U+F700 (this contains values for NS function keys)
+                    if (event.utf32 & 0xFF00) == 0xF700 then continue;
+
+                    array_add(*events_this_frame, event);
+                }
+            } else {
+                array_add(*events_this_frame, event);
+            }
+
+            // continue;
+            case NSEventTypeKeyUp;
+            keycode := NSEvent.keyCode(nsevent);
+            characters := NSEvent.characters(nsevent);
+            modifiers := NSEvent.modifierFlags(nsevent);
+
+            shift_state := (modifiers & NSEventModifierFlagShift) != 0;
+            ctrl_state  := (modifiers & NSEventModifierFlagControl) != 0;
+            alt_state   := (modifiers & NSEventModifierFlagOption) != 0;
+            cmd_state   := (modifiers & NSEventModifierFlagCommand) != 0;
+
+            event: Event;
+            event.type = .KEYBOARD;
+            event.key_pressed = 0;
+            event.key_code = get_key_code(keycode);
+            event.packed = 0;  // @Temporary: Unions not currently initialized.
+            event.shift_pressed    = shift_state;
+            event.ctrl_pressed     = ctrl_state;
+            event.alt_pressed      = alt_state;
+            event.cmd_meta_pressed = cmd_state;
+
+            input_button_states[event.key_code] = Key_Current_State.END;  // Because we shadowed that by Key_Code.END.
+
+            array_add(*events_this_frame, event);
+
+            // continue;
 
             // NOTE: no continues here because mouse events have to be sent to NSApp in order for the window's title-bar buttons to work (close, minimize, maximize)
             case NSEventTypeLeftMouseDown; #through;
             case NSEventTypeRightMouseDown; #through;
             case NSEventTypeOtherMouseDown;
-                event: Event;
-                event.type = .KEYBOARD;
-                num := NSEvent.buttonNumber(nsevent);
+            event: Event;
+            event.type = .KEYBOARD;
+            num := NSEvent.buttonNumber(nsevent);
 
-                // Apple doesnt seem to document what the values returned by buttonNumber
-                // other than a non-mouse event returns 0 (and yet a left click mouse event also returns 0)
-                MLEFT   :: 0;
-                MRIGHT  :: 1;
-                MMIDDLE :: 2;
+            // Apple doesnt seem to document what the values returned by buttonNumber
+            // other than a non-mouse event returns 0 (and yet a left click mouse event also returns 0)
+            MLEFT   :: 0;
+            MRIGHT  :: 1;
+            MMIDDLE :: 2;
 
-                if num > MMIDDLE {
-                    // we dont yet handle mouse buttons other than Left, Right, Middle
-                } else {
-                    if      num == MLEFT   then event.key_code = Key_Code.MOUSE_BUTTON_LEFT;
-                    else if num == MRIGHT  then event.key_code = Key_Code.MOUSE_BUTTON_RIGHT;
-                    else if num == MMIDDLE then event.key_code = Key_Code.MOUSE_BUTTON_MIDDLE;
+            if num > MMIDDLE {
+                // we dont yet handle mouse buttons other than Left, Right, Middle
+            } else {
+                if      num == MLEFT   then event.key_code = Key_Code.MOUSE_BUTTON_LEFT;
+                else if num == MRIGHT  then event.key_code = Key_Code.MOUSE_BUTTON_RIGHT;
+                else if num == MMIDDLE then event.key_code = Key_Code.MOUSE_BUTTON_MIDDLE;
 
-                    input_button_states[event.key_code] = (START | DOWN);
-                    event.key_pressed = 1;
+                input_button_states[event.key_code] = (START | DOWN);
+                event.key_pressed = 1;
 
-                    array_add(*events_this_frame, event);
-                }
+                array_add(*events_this_frame, event);
+            }
             case NSEventTypeLeftMouseUp; #through;
             case NSEventTypeRightMouseUp; #through;
             case NSEventTypeOtherMouseUp;
-                event: Event;
-                event.type = .KEYBOARD;
-                num := NSEvent.buttonNumber(nsevent);
+            event: Event;
+            event.type = .KEYBOARD;
+            num := NSEvent.buttonNumber(nsevent);
 
-                // Apple doesnt seem to document what the values returned by buttonNumber
-                // other than a non-mouse event returns 0 (and yet a left click mouse event also returns 0)
-                MLEFT   :: 0;
-                MRIGHT  :: 1;
-                MMIDDLE :: 2;
+            // Apple doesnt seem to document what the values returned by buttonNumber
+            // other than a non-mouse event returns 0 (and yet a left click mouse event also returns 0)
+            MLEFT   :: 0;
+            MRIGHT  :: 1;
+            MMIDDLE :: 2;
 
-                if num > MMIDDLE {
-                    // we dont yet handle mouse buttons other than Left, Right, Middle
-                } else {
-                    if      num == MLEFT   then event.key_code = Key_Code.MOUSE_BUTTON_LEFT;
-                    else if num == MRIGHT  then event.key_code = Key_Code.MOUSE_BUTTON_RIGHT;
-                    else if num == MMIDDLE then event.key_code = Key_Code.MOUSE_BUTTON_MIDDLE;
+            if num > MMIDDLE {
+                // we dont yet handle mouse buttons other than Left, Right, Middle
+            } else {
+                if      num == MLEFT   then event.key_code = Key_Code.MOUSE_BUTTON_LEFT;
+                else if num == MRIGHT  then event.key_code = Key_Code.MOUSE_BUTTON_RIGHT;
+                else if num == MMIDDLE then event.key_code = Key_Code.MOUSE_BUTTON_MIDDLE;
 
-                    input_button_states[event.key_code] = END;
-                    event.key_pressed = 0;
+                input_button_states[event.key_code] = END;
+                event.key_pressed = 0;
 
-                    array_add(*events_this_frame, event);
-                }
+                array_add(*events_this_frame, event);
+            }
 
             case NSEventTypeMouseMoved;
-                mouse_delta_x += cast(int) NSEvent.deltaX(nsevent);
-                mouse_delta_y += cast(int) NSEvent.deltaY(nsevent);
+            mouse_delta_x += cast(int) NSEvent.deltaX(nsevent);
+            mouse_delta_y += cast(int) NSEvent.deltaY(nsevent);
 
             case NSEventTypeScrollWheel;
-                // delx := NSEvent.deltaX(nsevent);
-                dely := NSEvent.deltaY(nsevent);
-                // delz := NSEvent.deltaZ(nsevent);
-                // print("del: %, %, %\n", delx, dely, delz);
+            // delx := NSEvent.deltaX(nsevent);
+            dely := NSEvent.deltaY(nsevent);
+            // delz := NSEvent.deltaZ(nsevent);
+            // print("del: %, %, %\n", delx, dely, delz);
 
-                // it seems that OSX does scroll wheel acceleration.
-                // the smallest step I'm seeing with a Razer mouse is 0.1 for 1 bump
-                // but just quickly going past about 3 bumps yeilds ~0.6. Spinning
-                // the wheel a bit more quickly starts hitting above 15.0, sigh.
-                // In any case for now we're just multiplying by 10 since we probably
-                // as least want to register a single scroll bump. We'll likely need to
-                // tune WHEEL_DELTA at some point. -josh 6 November 2018
+            // it seems that OSX does scroll wheel acceleration.
+            // the smallest step I'm seeing with a Razer mouse is 0.1 for 1 bump
+            // but just quickly going past about 3 bumps yeilds ~0.6. Spinning
+            // the wheel a bit more quickly starts hitting above 15.0, sigh.
+            // In any case for now we're just multiplying by 10 since we probably
+            // as least want to register a single scroll bump. We'll likely need to
+            // tune WHEEL_DELTA at some point. -josh 6 November 2018
 
-                event: Event;
-                event.type = .MOUSE_WHEEL;
-                event.typical_wheel_delta = WHEEL_DELTA;
-                event.wheel_delta = cast(s32) (dely * 10.0);
-                array_add(*events_this_frame, event);
+            event: Event;
+            event.type = .MOUSE_WHEEL;
+            event.typical_wheel_delta = WHEEL_DELTA;
+            event.wheel_delta = cast(s32) (dely * 10.0);
+            array_add(*events_this_frame, event);
 
-                mouse_delta_z += event.wheel_delta;
+            mouse_delta_z += event.wheel_delta;
         }
     }
 

--- a/src/config_parser.jai
+++ b/src/config_parser.jai
@@ -480,18 +480,37 @@ parse_keymap_line :: (using parser: *Config_Parser, line: string) -> success: bo
         return false, error_msg;
     }
 
-    key_name, action_name := break_by_spaces(line);
-    if !action_name {
-        error_msg := log_parser_error(handler, "Expected a space after the key combo, found '%'", key_name);
+    // Parse key combo parts and action
+    key_combo_parts: [..] Key_Combo_Part;
+    key_combo_error_msg: string;
+    action_name: string;
+    item: string;
+    rest_of_line := line;
+
+    while true {
+        // The last item we encounter will be interpreted as the action name, all parts before it will be parsed as key combinations.
+        item, rest_of_line = break_by_spaces(rest_of_line);
+        if !rest_of_line {
+            action_name = item;
+            break;
+        }
+
+        key_combo_part, key_ok, msg := parse_key_combo_part(parser, item);
+        if !key_ok {
+            key_combo_error_msg = msg;
+            break;
+        }
+
+        array_add(*key_combo_parts, key_combo_part);
+    }
+
+    if key_combo_parts.count == 0 || !action_name {
+        error_msg := tprint("Invalid key combo: '%'.\n%", line, key_combo_error_msg);
         return false, error_msg;
     }
 
-    // Parse key combo
-    key_combo, key_ok, msg := parse_key_combo(parser, key_name);
-    if !key_ok {
-        error_msg := tprint("Invalid key combo: '%'.\n%\nNote that spaces aren't allowed in key combos.", line, msg);
-        return false, error_msg;
-    }
+    key_combo: Key_Combo;
+    key_combo.parts = key_combo_parts;
 
     // Parse actions
     map_action :: (name: string, combo: Key_Combo, available_actions: [] string, target_keymap: *[..] Key_Mapping, subsection: string) #expand {
@@ -519,8 +538,8 @@ parse_keymap_line :: (using parser: *Config_Parser, line: string) -> success: bo
     return true, "";
 }
 
-parse_key_combo :: (using parser: *Config_Parser, key_name: string) -> Key_Combo, success: bool, error_msg: string /* temp */ {
-    result: Key_Combo;
+parse_key_combo_part :: (using parser: *Config_Parser, key_name: string) -> Key_Combo_Part, success: bool, error_msg: string /* temp */ {
+    result: Key_Combo_Part;
 
     // Parse modifier flags
     modifier_string := key_name;

--- a/src/config_parser.jai
+++ b/src/config_parser.jai
@@ -480,9 +480,9 @@ parse_keymap_line :: (using parser: *Config_Parser, line: string) -> success: bo
         return false, error_msg;
     }
 
-    // Parse key combo parts and action
-    key_combo_parts: [..] Key_Combo_Part;
-    key_combo_error_msg: string;
+    // Parse key sequence and action
+    key_sequence: [..] Key_Combo;
+    key_sequence_error_message: string;
     action_name: string;
     item: string;
     rest_of_line := line;
@@ -495,29 +495,26 @@ parse_keymap_line :: (using parser: *Config_Parser, line: string) -> success: bo
             break;
         }
 
-        key_combo_part, key_ok, msg := parse_key_combo_part(parser, item);
+        key_combo, key_ok, msg := parse_key_combo(parser, item);
         if !key_ok {
-            key_combo_error_msg = msg;
+            key_sequence_error_message = msg;
             break;
         }
 
-        array_add(*key_combo_parts, key_combo_part);
+        array_add(*key_sequence, key_combo);
     }
 
-    if key_combo_parts.count == 0 || !action_name {
-        error_msg := tprint("Invalid key combo: '%'.\n%", line, key_combo_error_msg);
+    if key_sequence.count == 0 || !action_name {
+        error_msg := tprint("Invalid key sequence: '%'.\n%", line, key_sequence_error_message);
         return false, error_msg;
     }
 
-    key_combo: Key_Combo;
-    key_combo.parts = key_combo_parts;
-
     // Parse actions
-    map_action :: (name: string, combo: Key_Combo, available_actions: [] string, target_keymap: *[..] Key_Mapping, subsection: string) #expand {
+    map_action :: (name: string, key_sequence: [] Key_Combo, available_actions: [] string, target_keymap: *[..] Key_Mapping, subsection: string) #expand {
         found := false;
         for available_actions {
             if name == it {
-                array_add(target_keymap, Key_Mapping.{ combo = combo, action = cast(u32) it_index });
+                array_add(target_keymap, Key_Mapping.{ key_sequence = key_sequence, action = cast(u32) it_index });
                 found = true;
                 break;
             }
@@ -529,17 +526,17 @@ parse_keymap_line :: (using parser: *Config_Parser, line: string) -> success: bo
     }
 
     if #complete keymap_subsection == {
-        case .common;           map_action(action_name, key_combo, ACTIONS_COMMON,           *data.keymap_common,           "[common]");
-        case .editors;          map_action(action_name, key_combo, ACTIONS_EDITORS,          *data.keymap_editors,          "[editors]");
-        case .open_file_dialog; map_action(action_name, key_combo, ACTIONS_OPEN_FILE_DIALOG, *data.keymap_open_file_dialog, "[open file dialog]");
-        case .search_dialog;    map_action(action_name, key_combo, ACTIONS_SEARCH_DIALOG,    *data.keymap_search_dialog,    "[search dialog]");
+        case .common;           map_action(action_name, key_sequence, ACTIONS_COMMON,           *data.keymap_common,           "[common]");
+        case .editors;          map_action(action_name, key_sequence, ACTIONS_EDITORS,          *data.keymap_editors,          "[editors]");
+        case .open_file_dialog; map_action(action_name, key_sequence, ACTIONS_OPEN_FILE_DIALOG, *data.keymap_open_file_dialog, "[open file dialog]");
+        case .search_dialog;    map_action(action_name, key_sequence, ACTIONS_SEARCH_DIALOG,    *data.keymap_search_dialog,    "[search dialog]");
     }
 
     return true, "";
 }
 
-parse_key_combo_part :: (using parser: *Config_Parser, key_name: string) -> Key_Combo_Part, success: bool, error_msg: string /* temp */ {
-    result: Key_Combo_Part;
+parse_key_combo :: (using parser: *Config_Parser, key_name: string) -> Key_Combo, success: bool, error_msg: string /* temp */ {
+    result: Key_Combo;
 
     // Parse modifier flags
     modifier_string := key_name;

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -168,32 +168,45 @@ draw_welcome_screen :: (main_area: Rect) {
             // Figure out combo width for aligning right
             combo_width := 0.0;
             plus_width  := cast(float) Simp.get_text_width(font_ui, "+");
-            for combo {
-                combo_width += xx Simp.get_text_width(font_ui, it) + 2 * padding_h;
+            padding_between_parts := plus_width + 2 * padding_h;
+
+            for combo_part: combo {
+                for combo_part {
+                    combo_width += xx Simp.get_text_width(font_ui, it) + 2 * padding_h;
+                    if it_index < combo_part.count - 1 {
+                        combo_width += plus_width + 2 * padding_h;
+                    }
+                }
+
                 if it_index < combo.count - 1 {
-                    combo_width += plus_width + 2 * padding_h;
+                    combo_width += padding_between_parts;
                 }
             }
 
             x = right_area.x + align_x - combo_width;
             text_y := y + padding_v * 1.5;
 
-            key_rect := Rect.{ x = x, y = y, w = 0, h = key_height };
-            for combo {
-                key_rect.x = x;
-                key_rect.w = xx Simp.prepare_text(font_ui, it) + 2 * padding_h;
-                key_rect = align_to_grid(key_rect);
-                shadow_rect := expand(key_rect, 1);
-                shadow_rect.y -= 2;
-                draw_rounded_rect(shadow_rect, Colors.BACKGROUND_DARK);
-                draw_rounded_rect(key_rect, Colors.SELECTION_ACTIVE);
-                Simp.draw_prepared_text(font_ui, xx (x + padding_h), xx text_y, Colors.UI_DEFAULT);
-                x += key_rect.w;
-                if it_index < combo.count - 1 {
-                    Simp.draw_text(font_ui, xx (x + padding_h), xx text_y, "+", Colors.UI_DEFAULT);
-                    x += plus_width + 2 * padding_h;
+            for combo_part: combo {
+                key_rect := Rect.{ x = x, y = y, w = 0, h = key_height };
+                for combo_part {
+                    key_rect.x = x;
+                    key_rect.w = xx Simp.prepare_text(font_ui, it) + 2 * padding_h;
+                    key_rect = align_to_grid(key_rect);
+                    shadow_rect := expand(key_rect, 1);
+                    shadow_rect.y -= 2;
+                    draw_rounded_rect(shadow_rect, Colors.BACKGROUND_DARK);
+                    draw_rounded_rect(key_rect, Colors.SELECTION_ACTIVE);
+                    Simp.draw_prepared_text(font_ui, xx (x + padding_h), xx text_y, Colors.UI_DEFAULT);
+                    x += key_rect.w;
+                    if it_index < combo_part.count - 1 {
+                        Simp.draw_text(font_ui, xx (x + padding_h), xx text_y, "+", Colors.UI_DEFAULT);
+                        x += plus_width + 2 * padding_h;
+                    }
                 }
+
+                x += padding_between_parts;
             }
+
             Simp.draw_text(font_ui, xx (x + padding_h * 10), xx text_y, shortcut.description, Colors.UI_DEFAULT);
 
             y -= line_height;
@@ -1132,7 +1145,33 @@ draw_file_info :: (buffer: Buffer, width: float, padding: float, _pen: Vector2, 
         pen.x += width + padding;
         width = xx Simp.prepare_text(font_ui_small, buffer.file.path);
         Simp.draw_prepared_text(font_ui_small, xx pen.x, xx pen.y, color = Colors.UI_DIM);
+    }
 
+    if key_combo_input_state.key_combo_in_progress {
+        // Draw separator
+        pen.x += width + padding;
+        width = xx Simp.prepare_text(font_ui_small, BULLET_CHAR);
+        Simp.draw_prepared_text(font_ui_small, xx pen.x, xx pen.y, color = Colors.UI_DIM);
+
+        // Draw key combo
+        builder: String_Builder;
+        builder.allocator = temp;
+
+        for part_index: 0..key_combo_input_state.current_key_combo_length - 1 {
+            combo_part := key_combo_part_strings(key_combo_input_state.key_combo_candidates[0].combo.parts[part_index]);
+            for combo_part {
+                print_to_builder(*builder, "%", it);
+                if it_index < combo_part.count - 1  print_to_builder(*builder, "+");
+            }
+
+            print_to_builder(*builder, " ");
+        }
+
+        print_to_builder(*builder, "...");
+
+        pen.x += width + padding;
+        width = xx Simp.prepare_text(font_ui_small, builder_to_string(*builder));
+        Simp.draw_prepared_text(font_ui_small, xx pen.x, xx pen.y, color = Colors.UI_DIM);
     }
 
     pen.x += width;
@@ -1548,8 +1587,19 @@ draw_commands_dialog :: () {
                 combo_rect.x += width;
                 combo_rect.w -= width + padding;
 
-                combo_str := join(..combo, " + ", allocator = temp);
-                combo_width := cast(float) Simp.prepare_text(font_ui_small, combo_str);
+                builder: String_Builder;
+                builder.allocator = temp;
+
+                for combo_part: combo {
+                    for combo_part {
+                        print_to_builder(*builder, "%", it);
+                        if it_index < combo_part.count - 1  print_to_builder(*builder, " + ");
+                    }
+
+                    if it_index < combo.count - 1  print_to_builder(*builder, "  ");
+                }
+
+                combo_width := cast(float) Simp.prepare_text(font_ui_small, builder_to_string(*builder));
 
                 if is_valid(combo_rect) && combo_width < combo_rect.w {
                     pen.x = combo_rect.x + combo_rect.w - combo_width;

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -163,32 +163,32 @@ draw_welcome_screen :: (main_area: Rect) {
         y := logo_rect.y + logo_rect.h - key_height - (logo_rect.h - total_height) / 2;
 
         for shortcut : SHORTCUTS_TO_DISPLAY {
-            combo := get_first_matching_key_combo_from_action(shortcut.action);
+            key_sequence_strings := get_first_matching_key_sequence_from_action(shortcut.action);
 
-            // Figure out combo width for aligning right
-            combo_width := 0.0;
+            // Figure out key sequence width for aligning right
+            key_sequence_width := 0.0;
             plus_width  := cast(float) Simp.get_text_width(font_ui, "+");
             padding_between_parts := plus_width + 2 * padding_h;
 
-            for combo_part: combo {
-                for combo_part {
-                    combo_width += xx Simp.get_text_width(font_ui, it) + 2 * padding_h;
-                    if it_index < combo_part.count - 1 {
-                        combo_width += plus_width + 2 * padding_h;
+            for combo_strings: key_sequence_strings {
+                for combo_strings {
+                    key_sequence_width += xx Simp.get_text_width(font_ui, it) + 2 * padding_h;
+                    if it_index < combo_strings.count - 1 {
+                        key_sequence_width += plus_width + 2 * padding_h;
                     }
                 }
 
-                if it_index < combo.count - 1 {
-                    combo_width += padding_between_parts;
+                if it_index < key_sequence_strings.count - 1 {
+                    key_sequence_width += padding_between_parts;
                 }
             }
 
-            x = right_area.x + align_x - combo_width;
+            x = right_area.x + align_x - key_sequence_width;
             text_y := y + padding_v * 1.5;
 
-            for combo_part: combo {
+            for combo_strings: key_sequence_strings {
                 key_rect := Rect.{ x = x, y = y, w = 0, h = key_height };
-                for combo_part {
+                for combo_strings {
                     key_rect.x = x;
                     key_rect.w = xx Simp.prepare_text(font_ui, it) + 2 * padding_h;
                     key_rect = align_to_grid(key_rect);
@@ -198,7 +198,7 @@ draw_welcome_screen :: (main_area: Rect) {
                     draw_rounded_rect(key_rect, Colors.SELECTION_ACTIVE);
                     Simp.draw_prepared_text(font_ui, xx (x + padding_h), xx text_y, Colors.UI_DEFAULT);
                     x += key_rect.w;
-                    if it_index < combo_part.count - 1 {
+                    if it_index < combo_strings.count - 1 {
                         Simp.draw_text(font_ui, xx (x + padding_h), xx text_y, "+", Colors.UI_DEFAULT);
                         x += plus_width + 2 * padding_h;
                     }
@@ -1147,21 +1147,23 @@ draw_file_info :: (buffer: Buffer, width: float, padding: float, _pen: Vector2, 
         Simp.draw_prepared_text(font_ui_small, xx pen.x, xx pen.y, color = Colors.UI_DIM);
     }
 
-    if key_combo_input_state.key_combo_in_progress {
+    if key_sequence_input_state.key_sequence_in_progress {
+        using key_sequence_input_state;
+
         // Draw separator
         pen.x += width + padding;
         width = xx Simp.prepare_text(font_ui_small, BULLET_CHAR);
         Simp.draw_prepared_text(font_ui_small, xx pen.x, xx pen.y, color = Colors.UI_DIM);
 
-        // Draw key combo
+        // Draw key sequence
         builder: String_Builder;
         builder.allocator = temp;
 
-        for part_index: 0..key_combo_input_state.current_key_combo_length - 1 {
-            combo_part := key_combo_part_strings(key_combo_input_state.key_combo_candidates[0].combo.parts[part_index]);
-            for combo_part {
+        for combo_index: 0..current_key_sequence_length - 1 {
+            combo_strings := key_combo_strings(matches_for_current_key_sequence[0].key_sequence[combo_index]);
+            for combo_strings {
                 print_to_builder(*builder, "%", it);
-                if it_index < combo_part.count - 1  print_to_builder(*builder, "+");
+                if it_index < combo_strings.count - 1  print_to_builder(*builder, "+");
             }
 
             print_to_builder(*builder, " ");
@@ -1581,28 +1583,28 @@ draw_commands_dialog :: () {
             // width = xx Simp.prepare_text(font_ui_small, tprint("%", formatInt(entry.sort_key, base=16)));
             // Simp.draw_prepared_text(font_ui_small, xx pen.x, xx pen.y, color = Colors.UI_DIM);
 
-            combo := get_first_matching_key_combo_from_action(entry.action);
-            if combo {
-                combo_rect := shrink_x(entry_rect, margin);
-                combo_rect.x += width;
-                combo_rect.w -= width + padding;
+            key_sequence := get_first_matching_key_sequence_from_action(entry.action);
+            if key_sequence {
+                key_sequence_rect := shrink_x(entry_rect, margin);
+                key_sequence_rect.x += width;
+                key_sequence_rect.w -= width + padding;
 
                 builder: String_Builder;
                 builder.allocator = temp;
 
-                for combo_part: combo {
-                    for combo_part {
+                for combo: key_sequence {
+                    for combo {
                         print_to_builder(*builder, "%", it);
-                        if it_index < combo_part.count - 1  print_to_builder(*builder, " + ");
+                        if it_index < combo.count - 1  print_to_builder(*builder, " + ");
                     }
 
-                    if it_index < combo.count - 1  print_to_builder(*builder, "  ");
+                    if it_index < key_sequence.count - 1  print_to_builder(*builder, "  ");
                 }
 
-                combo_width := cast(float) Simp.prepare_text(font_ui_small, builder_to_string(*builder));
+                key_sequence_width := cast(float) Simp.prepare_text(font_ui_small, builder_to_string(*builder));
 
-                if is_valid(combo_rect) && combo_width < combo_rect.w {
-                    pen.x = combo_rect.x + combo_rect.w - combo_width;
+                if is_valid(key_sequence_rect) && key_sequence_width < key_sequence_rect.w {
+                    pen.x = key_sequence_rect.x + key_sequence_rect.w - key_sequence_width;
                     Simp.draw_prepared_text(font_ui_small, xx pen.x, xx pen.y, Colors.UI_DIM);
                 }
             }

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -30,7 +30,7 @@ editors_handle_event :: (event: Input.Event) -> handled: bool {
             }
 
         case .TEXT_INPUT;
-            if !key_combo_input_state.key_combo_in_progress {
+            if !key_sequence_input_state.key_sequence_in_progress {
                 active_editor_type_char(event.utf32);
                 return true;
             }

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -30,8 +30,10 @@ editors_handle_event :: (event: Input.Event) -> handled: bool {
             }
 
         case .TEXT_INPUT;
-            active_editor_type_char(event.utf32);
-            return true;
+            if !key_combo_input_state.key_combo_in_progress {
+                active_editor_type_char(event.utf32);
+                return true;
+            }
     }
 
     return false;

--- a/src/keymap.jai
+++ b/src/keymap.jai
@@ -1,5 +1,5 @@
 map_event_to_action :: (event: Input.Event, $Action: Type) -> Action, Key_Mapping {
-    using key_combo_input_state;
+    using key_sequence_input_state;
 
     invalid_action := cast(Action) 0xFFFF;
     invalid_mapping := Key_Mapping.{};
@@ -7,29 +7,29 @@ map_event_to_action :: (event: Input.Event, $Action: Type) -> Action, Key_Mappin
     if event.type != .KEYBOARD return invalid_action, invalid_mapping;
     if !event.key_pressed      return invalid_action, invalid_mapping;
 
-    // Check for modifier keys being pressed by themselves; this shouldn't reset an active combo.
+    // Check for modifier keys being pressed by themselves; this shouldn't reset a key sequence that's in progress.
     key_combo_input_this_frame = event.key_code != .ALT && event.key_code != .CTRL && event.key_code != .SHIFT && event.key_code != .CMD && event.key_code != .META;
 
     keys_to_search := get_keymap_for_action_type(Action);
-    if key_combo_candidates.count > 0  keys_to_search = key_combo_candidates;
+    if matches_for_current_key_sequence.count > 0  keys_to_search = matches_for_current_key_sequence;
 
     event_key_code := cast(u32) event.key_code;
 
     for key_mapping: keys_to_search {
-        if current_key_combo_length >= key_mapping.combo.parts.count  continue;
-        if minimum_key_combo_length > 0 && key_mapping.combo.parts.count < minimum_key_combo_length  continue;
+        if current_key_sequence_length >= key_mapping.key_sequence.count  continue;
+        if minimum_key_sequence_length > 0 && key_mapping.key_sequence.count < minimum_key_sequence_length  continue;
 
-        combo := key_mapping.combo;
-        part := key_mapping.combo.parts[current_key_combo_length];
+        key_sequence := key_mapping.key_sequence;
+        combo := key_sequence[current_key_sequence_length];
 
-        if part.key_code == event_key_code && part.mods.packed == (event.modifier_flags.packed | part.ignore.packed) {
-            if combo.parts.count == current_key_combo_length + 1 {
+        if combo.key_code == event_key_code && combo.mods.packed == (event.modifier_flags.packed | combo.ignore.packed) {
+            if key_sequence.count == current_key_sequence_length + 1 {
                 found_match = true;
                 return cast(Action) key_mapping.action, key_mapping;
             } else {
-                array_add(*new_key_combo_candidates, key_mapping);
-                minimum_key_combo_length = key_mapping.combo.parts.count;
-                key_combo_in_progress = true;
+                array_add(*new_matches_for_current_key_sequence, key_mapping);
+                minimum_key_sequence_length = key_sequence.count;
+                key_sequence_in_progress = true;
             }
         }
     }
@@ -48,7 +48,7 @@ map_event_to_action :: (event: Input.Event, $Action: Type) -> Action, Key_Mappin
 activate_hold_action :: (action: $Action_Type, event: Input.Event) {
     _, matched_mapping := map_event_to_action(event, Action_Type);  // we map it here again to avoid passing it in through multiple functions
 
-    if matched_mapping.combo.parts.count != 1  return; // Don't support hold actions for multipart key combos.
+    if matched_mapping.key_sequence.count != 1  return; // Don't support hold actions for multipart key sequences.
 
     hold_action := Hold_Action.{ action_type = Action_Type, matched_mapping = matched_mapping };
 
@@ -70,7 +70,7 @@ map_key_release_to_hold_actions :: (event: Input.Event, $Action: Type) -> [] Act
 
     for active_hold_actions {
         if it.action_type != Action continue;
-        combo := it.matched_mapping.combo.parts[0];
+        combo := it.matched_mapping.key_sequence[0];
 
         if combo.key_code == cast(u32) event.key_code ||
           (event.key_code == .SHIFT && combo.mods.shift_pressed    && !combo.ignore.shift_pressed)    ||
@@ -86,43 +86,43 @@ map_key_release_to_hold_actions :: (event: Input.Event, $Action: Type) -> [] Act
     return actions;
 }
 
-get_first_matching_key_combo_from_action :: (action: $T) -> [][] string /* temp */ {
+get_first_matching_key_sequence_from_action :: (action: $T) -> [][] string /* temp */ {
     keymap := get_keymap_for_action_type(type_of(action));
-    combo: Key_Combo = ---;
+    key_sequence: [] Key_Combo = ---;
     found := false;
     action_code := cast(u32) action;
 
-    for mapping : keymap {
+    for mapping: keymap {
         if action_code == mapping.action {
-            combo = mapping.combo;
+            key_sequence = mapping.key_sequence;
             found = true;
             break;
         }
     }
     if !found return .[];
 
-    key_parts: [..][] string;
-    key_parts.allocator = temp;
-    for combo.parts  array_add(*key_parts, key_combo_part_strings(it));
-    return key_parts;
+    key_sequence_parts: [..][] string;
+    key_sequence_parts.allocator = temp;
+    for key_sequence  array_add(*key_sequence_parts, key_combo_strings(it));
+    return key_sequence_parts;
 }
 
-key_combo_part_strings :: (combo_part: Key_Combo_Part) -> [] string {
+key_combo_strings :: (combo: Key_Combo) -> [] string /* temp */ {
     keys: [..] string;
     keys.allocator = temp;
     array_reserve(*keys, 5);  // modifiers + key
 
     #if OS == .LINUX {
-        if combo_part.mods.cmd_meta_pressed then array_add(*keys, "Meta");
+        if combo.mods.cmd_meta_pressed then array_add(*keys, "Meta");
     }
-    if combo_part.mods.ctrl_pressed  then array_add(*keys, "Ctrl");
-    if combo_part.mods.alt_pressed   then array_add(*keys, "Alt");
-    if combo_part.mods.shift_pressed then array_add(*keys, "Shift");
+    if combo.mods.ctrl_pressed  then array_add(*keys, "Ctrl");
+    if combo.mods.alt_pressed   then array_add(*keys, "Alt");
+    if combo.mods.shift_pressed then array_add(*keys, "Shift");
     #if OS == .MACOS {
-        if combo_part.mods.cmd_meta_pressed then array_add(*keys, "Cmd");
+        if combo.mods.cmd_meta_pressed then array_add(*keys, "Cmd");
     }
 
-    key_name := keymap_map_key_code_to_string(combo_part.key_code);
+    key_name := keymap_map_key_code_to_string(combo.key_code);
     array_add(*keys, key_name);
     return keys;
 }
@@ -157,58 +157,54 @@ operator == :: (a: Hold_Action, b: Hold_Action) -> bool {
     return memcmp(*a, *b, size_of(Hold_Action)) == 0;
 }
 
-reset_key_combo :: () {
-    using key_combo_input_state;
-    array_reset_keeping_memory(*key_combo_candidates);
-    minimum_key_combo_length = 0;
-    current_key_combo_length = 0;
-    key_combo_in_progress = false;
+reset_key_sequence :: () {
+    using key_sequence_input_state;
+    array_reset_keeping_memory(*matches_for_current_key_sequence);
+    minimum_key_sequence_length = 0;
+    current_key_sequence_length = 0;
+    key_sequence_in_progress = false;
 }
 
 #scope_export
 
-start_key_combo_handling :: () {
-    using key_combo_input_state;
+start_key_sequence_handling :: () {
+    using key_sequence_input_state;
     key_combo_input_this_frame = false;
     found_match = false;
-    array_reset_keeping_memory(*new_key_combo_candidates);
+    array_reset_keeping_memory(*new_matches_for_current_key_sequence);
 }
 
-end_key_combo_handling :: () {
-    using key_combo_input_state;
-    if new_key_combo_candidates.count > 0 { // Input occurred this frame, and we have a new list of key combo candidates.
-        current_key_combo_length += 1;
-        array_reset_keeping_memory(*key_combo_candidates);
-        array_add(*key_combo_candidates, ..new_key_combo_candidates);
+end_key_sequence_handling :: () {
+    using key_sequence_input_state;
+    if new_matches_for_current_key_sequence.count > 0 { // Input occurred this frame, and we have a new list of key combo candidates.
+        current_key_sequence_length += 1;
+        array_reset_keeping_memory(*matches_for_current_key_sequence);
+        array_add(*matches_for_current_key_sequence, ..new_matches_for_current_key_sequence);
     } else if key_combo_input_this_frame { // Input occurred this frame, but no candidates are left; reset the active key combo.
-        reset_key_combo();
+        reset_key_sequence();
     }
 
-    if found_match  reset_key_combo();
+    if found_match  reset_key_sequence();
 }
 
-key_combo_input_state: Key_Combo_Input_State;
+key_sequence_input_state: Key_Sequence_Input_State;
 
-Key_Combo_Input_State :: struct {
-    key_combo_candidates: [..] Key_Mapping;
-    new_key_combo_candidates: [..] Key_Mapping;
-    current_key_combo_length: int;
-    minimum_key_combo_length: int;
+Key_Sequence_Input_State :: struct {
+    matches_for_current_key_sequence: [..] Key_Mapping;
+    new_matches_for_current_key_sequence: [..] Key_Mapping;
+    current_key_sequence_length: int;
+    minimum_key_sequence_length: int;
+    key_sequence_in_progress: bool;
     key_combo_input_this_frame: bool;
-    key_combo_in_progress: bool;
     found_match: bool;
 }
 
 Key_Mapping :: struct {
-    combo:  Key_Combo;
+    key_sequence: [] Key_Combo;
     action: u32;  // NOTE: tried to use a union with actual enums here, but the compiler crashes @compilerbug
 }
 
 Key_Combo :: struct {
-    parts: [] Key_Combo_Part;
-}
-
-Key_Combo_Part :: struct {
     key_code: u32;
     mods: Mods;
     ignore: Mods;

--- a/src/keymap.jai
+++ b/src/keymap.jai
@@ -1,20 +1,39 @@
 map_event_to_action :: (event: Input.Event, $Action: Type) -> Action, Key_Mapping {
-    invalid_action  := cast(Action) 0xFFFF;
+    using key_combo_input_state;
+
+    invalid_action := cast(Action) 0xFFFF;
     invalid_mapping := Key_Mapping.{};
 
     if event.type != .KEYBOARD return invalid_action, invalid_mapping;
-    if !event.key_pressed return invalid_action, invalid_mapping;
+    if !event.key_pressed      return invalid_action, invalid_mapping;
 
-    keymap := get_keymap_for_action_type(Action);
+    // Check for modifier keys being pressed by themselves; this shouldn't reset an active combo.
+    key_combo_input_this_frame = event.key_code != .ALT && event.key_code != .CTRL && event.key_code != .SHIFT && event.key_code != .CMD && event.key_code != .META;
+
+    keys_to_search := get_keymap_for_action_type(Action);
+    if key_combo_candidates.count > 0  keys_to_search = key_combo_candidates;
 
     event_key_code := cast(u32) event.key_code;
 
-    for keymap {
-        if it.combo.key_code == event_key_code && it.combo.mods.packed == (event.modifier_flags.packed | it.combo.ignore.packed) {
-            return cast(Action) it.action, it;
+    for key_mapping: keys_to_search {
+        if current_key_combo_length >= key_mapping.combo.parts.count  continue;
+        if minimum_key_combo_length > 0 && key_mapping.combo.parts.count < minimum_key_combo_length  continue;
+
+        combo := key_mapping.combo;
+        part := key_mapping.combo.parts[current_key_combo_length];
+
+        if part.key_code == event_key_code && part.mods.packed == (event.modifier_flags.packed | part.ignore.packed) {
+            if combo.parts.count == current_key_combo_length + 1 {
+                found_match = true;
+                return cast(Action) key_mapping.action, key_mapping;
+            } else {
+                array_add(*new_key_combo_candidates, key_mapping);
+                minimum_key_combo_length = key_mapping.combo.parts.count;
+                key_combo_in_progress = true;
+            }
         }
     }
-    
+
     #if Action == Action_Open_File_Dialog {
         // Hard-coded case: When the Open File dialog is active, "/" or "\" opens a directory.
         if event.key_code == {
@@ -22,12 +41,15 @@ map_event_to_action :: (event: Input.Event, $Action: Type) -> Action, Key_Mappin
             case #char "\\"; return .open_directory, invalid_mapping;
         }
     }
-    
+
     return invalid_action, invalid_mapping;
 }
 
 activate_hold_action :: (action: $Action_Type, event: Input.Event) {
     _, matched_mapping := map_event_to_action(event, Action_Type);  // we map it here again to avoid passing it in through multiple functions
+
+    if matched_mapping.combo.parts.count != 1  return; // Don't support hold actions for multipart key combos.
+
     hold_action := Hold_Action.{ action_type = Action_Type, matched_mapping = matched_mapping };
 
     // NOTE: array_add_if_unique didn't work because it couldn't find the operator == for Hold_Actions.
@@ -48,7 +70,8 @@ map_key_release_to_hold_actions :: (event: Input.Event, $Action: Type) -> [] Act
 
     for active_hold_actions {
         if it.action_type != Action continue;
-        combo := it.matched_mapping.combo;
+        combo := it.matched_mapping.combo.parts[0];
+
         if combo.key_code == cast(u32) event.key_code ||
           (event.key_code == .SHIFT && combo.mods.shift_pressed    && !combo.ignore.shift_pressed)    ||
           (event.key_code == .CTRL  && combo.mods.ctrl_pressed     && !combo.ignore.ctrl_pressed)     ||
@@ -63,7 +86,7 @@ map_key_release_to_hold_actions :: (event: Input.Event, $Action: Type) -> [] Act
     return actions;
 }
 
-get_first_matching_key_combo_from_action :: (action: $T) -> [] string /* temp */ {
+get_first_matching_key_combo_from_action :: (action: $T) -> [][] string /* temp */ {
     keymap := get_keymap_for_action_type(type_of(action));
     combo: Key_Combo = ---;
     found := false;
@@ -78,24 +101,29 @@ get_first_matching_key_combo_from_action :: (action: $T) -> [] string /* temp */
     }
     if !found return .[];
 
+    key_parts: [..][] string;
+    key_parts.allocator = temp;
+    for combo.parts  array_add(*key_parts, key_combo_part_strings(it));
+    return key_parts;
+}
+
+key_combo_part_strings :: (combo_part: Key_Combo_Part) -> [] string {
     keys: [..] string;
     keys.allocator = temp;
     array_reserve(*keys, 5);  // modifiers + key
 
-
     #if OS == .LINUX {
-        if combo.mods.cmd_meta_pressed then array_add(*keys, "Meta");
+        if combo_part.mods.cmd_meta_pressed then array_add(*keys, "Meta");
     }
-    if combo.mods.ctrl_pressed  then array_add(*keys, "Ctrl");
-    if combo.mods.alt_pressed   then array_add(*keys, "Alt");
-    if combo.mods.shift_pressed then array_add(*keys, "Shift");
+    if combo_part.mods.ctrl_pressed  then array_add(*keys, "Ctrl");
+    if combo_part.mods.alt_pressed   then array_add(*keys, "Alt");
+    if combo_part.mods.shift_pressed then array_add(*keys, "Shift");
     #if OS == .MACOS {
-        if combo.mods.cmd_meta_pressed then array_add(*keys, "Cmd");
+        if combo_part.mods.cmd_meta_pressed then array_add(*keys, "Cmd");
     }
 
-    key_name := keymap_map_key_code_to_string(combo.key_code);
+    key_name := keymap_map_key_code_to_string(combo_part.key_code);
     array_add(*keys, key_name);
-
     return keys;
 }
 
@@ -129,7 +157,47 @@ operator == :: (a: Hold_Action, b: Hold_Action) -> bool {
     return memcmp(*a, *b, size_of(Hold_Action)) == 0;
 }
 
+reset_key_combo :: () {
+    using key_combo_input_state;
+    array_reset_keeping_memory(*key_combo_candidates);
+    minimum_key_combo_length = 0;
+    current_key_combo_length = 0;
+    key_combo_in_progress = false;
+}
+
 #scope_export
+
+start_key_combo_handling :: () {
+    using key_combo_input_state;
+    key_combo_input_this_frame = false;
+    found_match = false;
+    array_reset_keeping_memory(*new_key_combo_candidates);
+}
+
+end_key_combo_handling :: () {
+    using key_combo_input_state;
+    if new_key_combo_candidates.count > 0 { // Input occurred this frame, and we have a new list of key combo candidates.
+        current_key_combo_length += 1;
+        array_reset_keeping_memory(*key_combo_candidates);
+        array_add(*key_combo_candidates, ..new_key_combo_candidates);
+    } else if key_combo_input_this_frame { // Input occurred this frame, but no candidates are left; reset the active key combo.
+        reset_key_combo();
+    }
+
+    if found_match  reset_key_combo();
+}
+
+key_combo_input_state: Key_Combo_Input_State;
+
+Key_Combo_Input_State :: struct {
+    key_combo_candidates: [..] Key_Mapping;
+    new_key_combo_candidates: [..] Key_Mapping;
+    current_key_combo_length: int;
+    minimum_key_combo_length: int;
+    key_combo_input_this_frame: bool;
+    key_combo_in_progress: bool;
+    found_match: bool;
+}
 
 Key_Mapping :: struct {
     combo:  Key_Combo;
@@ -137,10 +205,14 @@ Key_Mapping :: struct {
 }
 
 Key_Combo :: struct {
+    parts: [] Key_Combo_Part;
+}
+
+Key_Combo_Part :: struct {
     key_code: u32;
     mods: Mods;
     ignore: Mods;
-} #no_padding;
+}
 
 // Generate action enums from the corresponding arrays below
 #insert -> string {

--- a/src/main.jai
+++ b/src/main.jai
@@ -163,7 +163,7 @@ main :: () {
         // If we handle it as a keyboard event we will need to ignore its text input duplicates
         num_text_input_events_to_ignore := 0;
 
-        start_key_combo_handling();
+        start_key_sequence_handling();
 
         for event : Input.events_this_frame {
             // General events
@@ -238,7 +238,7 @@ main :: () {
             if handled && event.type == .KEYBOARD then num_text_input_events_to_ignore = event.text_input_count;
         }
 
-        end_key_combo_handling();
+        end_key_sequence_handling();
 
         if should_quit && unsaved_buffers_exist() && !force_quit {
             show_unsaved_buffers_dialog();

--- a/src/main.jai
+++ b/src/main.jai
@@ -163,6 +163,8 @@ main :: () {
         // If we handle it as a keyboard event we will need to ignore its text input duplicates
         num_text_input_events_to_ignore := 0;
 
+        start_key_combo_handling();
+
         for event : Input.events_this_frame {
             // General events
             if event.type == {
@@ -235,6 +237,8 @@ main :: () {
 
             if handled && event.type == .KEYBOARD then num_text_input_events_to_ignore = event.text_input_count;
         }
+
+        end_key_combo_handling();
 
         if should_quit && unsaved_buffers_exist() && !force_quit {
             show_unsaved_buffers_dialog();

--- a/src/widgets/text_input.jai
+++ b/src/widgets/text_input.jai
@@ -41,7 +41,7 @@ text_input_handle_event :: (using input: *Text_Input, event: Input.Event) -> han
 }
 
 text_input_type_char :: (using input: *Text_Input, char: u32) {
-    if key_combo_input_state.key_combo_in_progress  return;
+    if key_sequence_input_state.key_sequence_in_progress  return;
 
     if edits.count == 0 {
         // Always remember cursor before any edits

--- a/src/widgets/text_input.jai
+++ b/src/widgets/text_input.jai
@@ -7,9 +7,9 @@ text_input_handle_event :: (using input: *Text_Input, event: Input.Event) -> han
     if frame_time - last_edit_time >= EDIT_GROUP_TIMEOUT then new_edit_group(input);
 
     action := map_event_to_action(event, Action_Common);
-    
+
     extend_selection := event.shift_pressed;
-    
+
     if action == {
         case .copy;                     copy(input);
         case .cut;                      cut(input);
@@ -34,13 +34,15 @@ text_input_handle_event :: (using input: *Text_Input, event: Input.Event) -> han
         case .delete_word_right;        delete_word_right(input);
         case;                           return false;
     }
-    
+
     if old_text != to_string(text) then last_edit_time = frame_time;
 
     return true;
 }
 
 text_input_type_char :: (using input: *Text_Input, char: u32) {
+    if key_combo_input_state.key_combo_in_progress  return;
+
     if edits.count == 0 {
         // Always remember cursor before any edits
         cursor_before_edits = cursor;
@@ -51,7 +53,7 @@ text_input_type_char :: (using input: *Text_Input, char: u32) {
 
     cursor.pos = clamp(cursor.pos, 0, xx text.count);  // make sure cursor is in the correct position
     cursor.sel = clamp(cursor.sel, 0, xx text.count);
-    
+
     utf8_char := convert_utf32_to_utf8(char);
     if !has_selection(cursor) {
         // No selection
@@ -65,7 +67,7 @@ text_input_type_char :: (using input: *Text_Input, char: u32) {
     }
     cursor.pos = min(cursor.pos, cursor.sel) + utf8_char.count;
     cursor.sel = cursor.pos;
-    
+
     last_edit_time = frame_time;
 }
 
@@ -159,7 +161,7 @@ paste :: (using input: *Text_Input) {
 
 undo :: (using input: *Text_Input) {
     new_edit_group(input);
-    
+
     if undos.count == 0 return;
     edit_group := pop(*undos);
     // Revert edits in the backwards order
@@ -283,12 +285,12 @@ delete_right_char :: inline (using input: *Text_Input) {
     delete_selection(input);
 }
 
-delete_word_left :: inline (using input: *Text_Input) {    
+delete_word_left :: inline (using input: *Text_Input) {
     if !has_selection(cursor) then cursor.pos = scan_through_similar_chars_on_the_left(input, cursor.pos);
     delete_left_char(input);
 }
 
-delete_word_right :: inline (using input: *Text_Input) {    
+delete_word_right :: inline (using input: *Text_Input) {
     if !has_selection(cursor) then cursor.pos = scan_through_similar_chars_on_the_right(input, cursor.pos);
     delete_right_char(input);
 }
@@ -307,7 +309,7 @@ new_edit_group :: (using input: *Text_Input) {
     new_group := array_add(*undos);
     new_group.edits = to_owned_array(*edits);
     new_group.cursor = cursor_before_edits;
-    
+
     cursor_before_edits = cursor;
 }
 
@@ -319,9 +321,9 @@ insert_string_at_offset :: (using input: *Text_Input, offset: s64, new_str: stri
 replace_range :: (using input: *Text_Input, start: s64, end: s64, new_str: string) {
     old_str := to_string(array_view(text, start, end - start));
     if new_str == old_str return;
-    
+
     new_replace_edit(input, xx start, xx end, old_str, new_str);
-    replace_range_raw(input, start, end, new_str); 
+    replace_range_raw(input, start, end, new_str);
 }
 
 delete_range :: (using input: *Text_Input, start: s64, end: s64) {
@@ -499,27 +501,27 @@ get_char_at_offset_as_string :: (using input: Text_Input, offset: s32) -> string
 Text_Input :: struct {
     text: [..] u8;
     cursor: Cursor;
-    
+
     undos: [..] Edit_Group;
     redos: [..] Edit_Group;
     edits: [..] Edit;
     cursor_before_edits: Cursor;
     last_edit_time: Time;
-    
+
     scroll_x: s32;
     scroll_anim: Tween_Animation(s32);
-    
+
     mouse_selection_mode: bool;  // to indicate the mouse is being dragged to select text
 
     Cursor :: struct {
         pos, sel: s32;  // cursor position (in chars, not bytes)
     }
-    
+
     Edit_Group :: struct {
         edits: [] Edit;
         cursor: Cursor;
     }
-    
+
     // Some copypasta from buffer, but it's ok
     Edit :: struct {
         type: enum { insert; insert_char; replace; delete; };
@@ -544,7 +546,7 @@ Text_Input :: struct {
             };
         }
     }
-    
+
     Offset_Range :: struct {
         start, end: s32;  // we won't open large files anyway
     }


### PR DESCRIPTION
This is an implementation for keybindings consisting of more than one key combo (e.g., binding `Ctrl-X Ctrl-S` to a specific command). I have resorted to the following nomenclature: a keybinding is defined by a *key sequence*, which consists of one or more *key combos*. Currently, all commands in Focus are called using key sequences consisting of just one key combo. Something like `Ctrl-X Ctrl-S` would be an example of a key sequence consisting of two key combos. This type of key sequence is very prevalent in Emacs, but also exists in editors like VS Code (I think they call it 'key chords' there).

I've tested the implementation on Windows and macOS.

## Summary of changes

#### `src/keymap.jai`, `src/main.jai`
These changes implement the actual key sequence handling. A global variable of type `Key_Sequence_Input_State` keeps track of whether a key sequence is in progress, and if so, which `Key_Mappings` are a match for the key sequence so far. Some state is recorded per frame to know if any relevant input occurred, if a complete match was found this frame, and what the new matches are. An initial key combo will be matched against the entire keymap; further combos will be matched only against the list of current matches. The key sequence ends when a complete match has been found, or when no matches remain.

---

#### `src/config_parser.jai`
The parser has been updated to support key sequences. The format of the config is the same as before, except that you can now have N key combos in front of an action rather than just one.

One subtlety that I ran into: since config files are merged (e.g., the global and the default configs), there is a risk that a config higher up in the hierarchy will define a keybinding that is the same as the prefix of a custom keybinding (e.g., we have a custom `Ctrl-X Ctrl-S` keybind, but the default config will define `Ctrl-X` for cut). I worked around this by saying that when (part of) a keybinding is matched, key sequences shorter than the one that was already matched will no longer be considered. In our example, when pressing `Ctrl-X`, our `Ctrl-X Ctrl-S` keybind will be encountered first; since it consists of 2 key combos, from that point onwards only key sequences with at least 2 key combos will be considered, so the `Ctrl-X` from the default config will be ignored. This seems like a decent way to deal with collisions between different configs. Perhaps a future improvement could be to warn users when there are keybindings that match the prefix of another keybinding, at least within a single config file.

---

#### `src/editors.jai`, `src/widgets/text_input.jai`
Added checks to prevent text input while a key sequence is in progress.

---

#### `src/draw.jai`
Edits to draw shortcut keys correctly in various places. I also added a bonus feature: while a key sequence is in progress, the key sequence so far will be displayed in the status bar (for key sequences that consist of one part, nothing will be displayed). It's just a suggestion though, maybe some will find it annoying.

---

#### `modules/Input/macos.jai`
Not totally necessary for this feature, but this change fixes an issue where the righthand side modifiers keys were not handled properly on macOS, causing key sequences not to always work with those keys. I sent in a bug report for this, so it will probably be fixed in one of the coming betas.

---

Some other points to consider:

- `parse_keymap_line` in `src/config_parser.jai` creates a resizable array to store each key sequence; those arrays use the default allocator right now (they ultimately end up in a `Key_Mapping` in a keymap). I don't think this is a big deal since parsing configs won't happen often in the general case, but perhaps the memory management could be cleaner. I considered a fixed size array on `Key_Mapping` and have key sequences have a max length (say 4 or 8), but that seems uglier.

- It is possible to use optional modifier syntax anywhere in a key sequence (e.g. `Ctrl-X {Ctrl}-S`); this seems to work as expected, but there may be some edge cases where it doesn't as I haven't tested it thoroughly.

- I decided that hold actions should not apply to key sequences with more than one key combo, since that doesn't seem to make that much sense.