### PR TITLE
open_file_in_explorer command

### DIFF
--- a/default.focus-config
+++ b/default.focus-config
@@ -141,6 +141,7 @@ Enter                       open_entry_in_place
 Ctrl-Enter                  open_entry_on_the_side
 Ctrl-1                      open_entry_on_the_left
 Ctrl-2                      open_entry_on_the_right
+Shift-Enter                 open_entry_in_explorer
 
 Tab                         open_directory
 

--- a/default_macos.focus-config
+++ b/default_macos.focus-config
@@ -140,6 +140,7 @@ Enter                       open_entry_in_place
 Cmd-Enter                   open_entry_on_the_side
 Cmd-1                       open_entry_on_the_left
 Cmd-2                       open_entry_on_the_right
+Shift-Enter                 open_entry_in_explorer
 
 Tab                         open_directory
 
@@ -155,7 +156,7 @@ Cmd-Enter                   open_entry_on_the_side
 Cmd-1                       open_entry_on_the_left
 Cmd-2                       open_entry_on_the_right
 
-Shift-Enter                 move_up  # an Cmdernative way to move
+Shift-Enter                 move_up  # an alternative way to move
 
 
 [common]

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -1280,7 +1280,23 @@ draw_open_file_dialog :: () {
             if ui.hot_last_frame == input_id && mouse_pointer_is_within(dir_rect) {
                 color = Colors.LIST_CURSOR;
                 set_pointer_image(.PRESSABLE);
-                if mouse.left.just_pressed { open_file_dialog_truncate_path_chunks(it_index); redraw_requested = true; }
+                if mouse.left.just_pressed {
+                    if shift_pressed() {
+                        // Shift + Click = Open dir in explorer
+                        
+                        path_chunks_trimmed := array_view(path_chunks, 1, it_index);
+                        dir_path: string = ---;
+                        if path_chunks_trimmed.count == 0 dir_path = root_dir;
+                        else dir_path = tprint("%/%", root_dir, join(..path_chunks_trimmed, separator = "/"));
+                        
+                        print("Opening %\n", dir_path);
+                        platform_open_in_explorer(dir_path);
+                    } else {
+                        // Regular Click = Trim chunks past this dir
+                        open_file_dialog_truncate_path_chunks(it_index);
+                        redraw_requested = true;
+                    }
+                }
             }
             draw_rounded_rect(dir_rect, color);
             Simp.draw_prepared_text(font_ui, xx (dir_rect.x + padding + half_padding), xx text_y, Colors.UI_DEFAULT);

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -1283,13 +1283,10 @@ draw_open_file_dialog :: () {
                 if mouse.left.just_pressed {
                     if shift_pressed() {
                         // Shift + Click = Open dir in explorer
-                        
                         path_chunks_trimmed := array_view(path_chunks, 1, it_index);
                         dir_path: string = ---;
                         if path_chunks_trimmed.count == 0 dir_path = root_dir;
                         else dir_path = tprint("%/%", root_dir, join(..path_chunks_trimmed, separator = "/"));
-                        
-                        print("Opening %\n", dir_path);
                         platform_open_in_explorer(dir_path);
                     } else {
                         // Regular Click = Trim chunks past this dir

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -1373,11 +1373,17 @@ draw_open_file_dialog :: () {
                 if mouse_pointer_is_within(entry_rect) && is_hovering_over(ui_id) {
                     if mouse.left.just_pressed then entries.selected_by_mouse = entry_index;
                     if entries.selected_by_mouse == -1 then draw_rect(entry_rect, Colors.LIST_CURSOR_LITE);
-                    placement := ifx ctrl_or_cmd_pressed() then Editor_Placement.on_the_side else .in_place;
                     if entries.selected_by_mouse == entry_index && mouse.left.just_released {
-                        open_file_dialog_open_entry(entry_index, placement);
-                        redraw_requested = true;
-                        break;  // don't finish drawing entries because the entries will likely change
+                        if shift_pressed() {
+                            // Shift + Click = open entry in explorer
+                            open_file_dialog_open_entry_in_explorer(entry_index);
+                        } else {
+                            // Regular click = open entry in editor
+                            placement := ifx ctrl_or_cmd_pressed() then Editor_Placement.on_the_side else .in_place;
+                            open_file_dialog_open_entry(entry_index, placement);
+                            redraw_requested = true;
+                            break;  // don't finish drawing entries because the entries will likely change
+                        }
                     }
                 }
                 if entries.selected_by_mouse == entry_index then draw_rect(entry_rect, Colors.LIST_CURSOR);

--- a/src/keymap.jai
+++ b/src/keymap.jai
@@ -335,6 +335,7 @@ ACTIONS_OPEN_FILE_DIALOG :: #run arrays_concat(ACTIONS_COMMON, string.[
     "open_entry_on_the_side",
     "open_entry_on_the_left",
     "open_entry_on_the_right",
+    "open_entry_in_explorer",
     "open_directory",
     "pop_directory",
 ]);
@@ -345,6 +346,7 @@ ACTIONS_SEARCH_DIALOG :: #run arrays_concat(ACTIONS_COMMON, string.[
     "open_entry_on_the_side",
     "open_entry_on_the_left",
     "open_entry_on_the_right",
+    "open_entry_in_explorer",
 ]);
 
 // Used for testing strings in parser

--- a/src/keymap.jai
+++ b/src/keymap.jai
@@ -346,7 +346,6 @@ ACTIONS_SEARCH_DIALOG :: #run arrays_concat(ACTIONS_COMMON, string.[
     "open_entry_on_the_side",
     "open_entry_on_the_left",
     "open_entry_on_the_right",
-    "open_entry_in_explorer",
 ]);
 
 // Used for testing strings in parser

--- a/src/platform/linux.jai
+++ b/src/platform/linux.jai
@@ -119,7 +119,7 @@ platform_get_fonts_dir :: () -> string {
     return "/usr/share/fonts";
 }
 
-platform_open_in_explorer :: (dir: string) {
+platform_open_in_explorer :: (path: string, reveal := false) {
 }
 
 #scope_file

--- a/src/platform/macos.jai
+++ b/src/platform/macos.jai
@@ -89,8 +89,9 @@ platform_get_fonts_dir :: inline () -> string {
     return "/Library/Fonts";
 }
 
-platform_open_in_explorer :: inline (dir: string) {
-    run_command("open", dir);
+platform_open_in_explorer :: (path: string, reveal := false) {
+    if reveal run_command("open", "-R", path);
+    else      run_command("open", path);
 }
 
 #scope_file

--- a/src/platform/windows.jai
+++ b/src/platform/windows.jai
@@ -193,8 +193,11 @@ platform_get_fonts_dir :: () -> string {
 }
 
 platform_open_in_explorer :: (path: string, reveal := false) {
-    // TODO: Support reveal for files? -Don Swet 22-May-2023
-    ShellExecuteW(window, utf8_to_wide("explore"), utf8_to_wide(path), xx 0, xx 0, SW_NORMAL);
+    path_backslashes := copy_string(path, allocator = temp);
+    path_overwrite_separators(path_backslashes, #char "\\");
+    
+    if reveal run_command("explorer", "/select,", path_backslashes);
+    else      run_command("explorer", path_backslashes);
 }
 
 #scope_file
@@ -246,3 +249,4 @@ CoTaskMemFree :: (pv: *void) #foreign ole32;
 
 #import "Windows";
 #import "Windows_Registry";
+#import "Process";

--- a/src/platform/windows.jai
+++ b/src/platform/windows.jai
@@ -192,8 +192,9 @@ platform_get_fonts_dir :: () -> string {
     return fonts_dir;
 }
 
-platform_open_in_explorer :: (dir: string) {
-    ShellExecuteW(window, utf8_to_wide("explore"), utf8_to_wide(dir), xx 0, xx 0, SW_NORMAL);
+platform_open_in_explorer :: (path: string, reveal := false) {
+    // TODO: Support reveal for files? -Don Swet 22-May-2023
+    ShellExecuteW(window, utf8_to_wide("explore"), utf8_to_wide(path), xx 0, xx 0, SW_NORMAL);
 }
 
 #scope_file

--- a/src/widgets/open_file_dialog.jai
+++ b/src/widgets/open_file_dialog.jai
@@ -137,7 +137,26 @@ open_file_dialog_open_entry_in_explorer :: (selected: s64) {
     using open_file_dialog;
     if selected >= entries.filtered.count return;
     entry := entries.filtered[selected];
-    platform_open_in_explorer(ifx entry.name == "/" then "/" else entry.full_path, reveal = entry.type == .file);
+    
+    path: string = ---;
+    #if OS == .WINDOWS {
+        if ends_with(entry.name, ":") {
+            // Drive letter. We need to add a slash.
+            b: String_Builder;
+            append(*b, entry.name);
+            append(*b, #char "/");
+            path = builder_to_string(*b, allocator = temp);
+        } else {
+            // Not a drive letter.
+            path = entry.full_path;
+        }
+    } else {
+        path = ifx entry.name == "/" then "/" else entry.full_path;
+    }
+    
+    print("Opening %\n", path);
+    
+    platform_open_in_explorer(path, reveal = entry.type == .file);
 }
 
 open_file_dialog_truncate_path_chunks :: (chunk_index: s64) {

--- a/src/widgets/open_file_dialog.jai
+++ b/src/widgets/open_file_dialog.jai
@@ -138,16 +138,8 @@ open_file_dialog_open_entry_in_explorer :: (selected: s64) {
     
     path: string = ---;
     #if OS == .WINDOWS {
-        if ends_with(entry.name, ":") {
-            // Drive letter. We need to add a slash.
-            b: String_Builder;
-            append(*b, entry.name);
-            append(*b, #char "/");
-            path = builder_to_string(*b, allocator = temp);
-        } else {
-            // Not a drive letter.
-            path = entry.full_path;
-        }
+        if ends_with(entry.name, ":") path = tprint("%/", entry.name); // Drive letter. We need to add a slash.
+        else                          path = entry.full_path;          // Not a drive letter.
     } else {
         path = ifx entry.name == "/" then "/" else entry.full_path;
     }

--- a/src/widgets/open_file_dialog.jai
+++ b/src/widgets/open_file_dialog.jai
@@ -97,8 +97,6 @@ open_file_dialog_open_entry :: (selected: s64, placement: Editor_Placement, fold
             }
         }
     }
-    
-                        if ctrl_or_cmd_pressed() print("cmd\n");
 
     if entry.type == {
         case .nothing;

--- a/src/widgets/open_file_dialog.jai
+++ b/src/widgets/open_file_dialog.jai
@@ -402,7 +402,28 @@ scan_current_folder :: () {
             if should_ignore_file(file.full_name) return;
         }
 
-        full_path := copy_string(file.full_name);  // one allocation in the pool, the rest are views into it
+        full_path: string = ---;   // one allocation in the pool, the rest are views into it
+        #if OS == .WINDOWS {
+            // Fix an extra slash in Windows (ugh)
+            b: String_Builder;
+            previous_char_was_slash := false;
+            for 0..file.full_name.count - 1 {
+                c := file.full_name.data[it];
+                if c == #char "/" {
+                    if previous_char_was_slash continue; // Ignore double slashes
+                    previous_char_was_slash = true;
+                } else {
+                    previous_char_was_slash = false;
+                }
+                
+                append(*b, c);
+            }
+            
+            full_path = builder_to_string(*b);
+        } else {
+            full_path = copy_string(file.full_name);
+        }
+        
         path, basename, extension, name := path_decomp(full_path);
 
         entry := array_add(*open_file_dialog.current_files);

--- a/src/widgets/open_file_dialog.jai
+++ b/src/widgets/open_file_dialog.jai
@@ -152,8 +152,6 @@ open_file_dialog_open_entry_in_explorer :: (selected: s64) {
         path = ifx entry.name == "/" then "/" else entry.full_path;
     }
     
-    print("Opening %\n", path);
-    
     platform_open_in_explorer(path, reveal = entry.type == .file);
 }
 

--- a/src/widgets/open_file_dialog.jai
+++ b/src/widgets/open_file_dialog.jai
@@ -9,6 +9,7 @@ open_file_dialog_handle_event :: (event: Input.Event) -> handled: bool {
             case .open_entry_on_the_side;   open_file_dialog_open_entry(entries.selected, .on_the_side);                                                                         return true;
             case .open_entry_on_the_left;   open_file_dialog_open_entry(entries.selected, .left);                                                                                return true;
             case .open_entry_on_the_right;  open_file_dialog_open_entry(entries.selected, .right);                                                                               return true;
+            case .open_entry_in_explorer;   open_file_dialog_open_entry_in_explorer(entries.selected);                                                                           return true;
             case .open_directory;           open_file_dialog_open_entry(entries.selected, .in_place, folder_only = true, maybe_open_root_dir = event.key_code == #char "/");     return true;
             case .pop_directory;            if pop_directory() return true;
 
@@ -96,6 +97,8 @@ open_file_dialog_open_entry :: (selected: s64, placement: Editor_Placement, fold
             }
         }
     }
+    
+                        if ctrl_or_cmd_pressed() print("cmd\n");
 
     if entry.type == {
         case .nothing;
@@ -128,6 +131,13 @@ open_file_dialog_open_entry :: (selected: s64, placement: Editor_Placement, fold
             array_add(*path_chunks, copy_string(entry.name));
             refresh_entries();
     }
+}
+
+open_file_dialog_open_entry_in_explorer :: (selected: s64) {
+    using open_file_dialog;
+    if selected >= entries.filtered.count return;
+    entry := entries.filtered[selected];
+    platform_open_in_explorer(ifx entry.name == "/" then "/" else entry.full_path, reveal = entry.type == .file);
 }
 
 open_file_dialog_truncate_path_chunks :: (chunk_index: s64) {


### PR DESCRIPTION
- Added the command to keymap.jai and open_file_dialog_handle_event
- Added it to editors section of default configs as Shift-Enter
- Modified platform_open_in_explorer to accept an argument on whether to reveal a file/path or open it (open = the default)
- Modified draw.jai to support Shift+Click both on path chunks and entries in the navigate dialog
- Added a few special-cases to trim (or add) trailing slashes in order to make this work ("C://thing" -> "C:/thing" & "C:" -> "C:/" on Windows, "//" -> "/" on Mac/Linux)

Extensively tested. Everything I tried worked on both Windows and macOS, including files/directories with spaces in their paths. Seems to be solid. Even fixed a few bugs that I discovered. (These bugs did not seem to cause problems elsewhere in the program. Oh well. They are now fixed.)