### PR TITLE
partial fix for large text pasted from other windows on Linux

### DIFF
--- a/modules/Linux_Display/ldx_input.jai
+++ b/modules/Linux_Display/ldx_input.jai
@@ -362,13 +362,18 @@ x11_clipboard_get_text :: (win: Window) -> string {  // Allocated via alloc; sho
         format: s32;
         data: *u8;
         type: Atom;
-        if XGetWindowProperty(display, win, property, 0, 32, True, AnyPropertyType, *type, *format, *nitems, *rem, *data) == 0 {
-            temp: string;
-            temp.data = data;
-            temp.count = xx nitems;
-            text = copy_string(temp);
-            XFree(data);
-            return text;
+        if XGetWindowProperty(display, win, property, 0, ~0, True, AnyPropertyType, *type, *format, *nitems, *rem, *data) == 0 {
+            assert(rem == 0); // to be sure we get all the bytes and there are no remaining bytes
+            if (type == x_global_xa_utf8 && format == 8) {
+                temp: string;
+                temp.data = data;
+                temp.count = xx nitems;
+                text = copy_string(temp);
+                XFree(data);
+                return text;
+            } else {
+                // @Incomplete: megabytes of text are sent in a different format which is not supported yet
+            }
         }
     }
 


### PR DESCRIPTION
Problem:
Current version has a limit of 128 bytes for texts pasted from other windows on Linux.

Reason:
in modules/Linux_Display/ldx_input.jai line 365
there is length 32 in the arguments AND later remainder bytes (*rem) return value is ignored

Partial fix:
Send ~0 instead of 32 to remove the upper limit on the length of one chunk. So, all bytes are sent in one huge chunk.
However, it does not handle really huge texts yet.
Also added assert(rem == 0) and check for return data type and format.

P.S. thanks for the cool editor! Really enjoying it so far