### PR TITLE
Fixed select_word, Added center_viewport_on_cursor, Added editor history

### DIFF
--- a/compile.bat
+++ b/compile.bat
@@ -1,3 +1,3 @@
 @echo off
 
-jai -quiet first.jai
+jai first.jai

--- a/compile.bat
+++ b/compile.bat
@@ -1,3 +1,3 @@
 @echo off
 
-jai first.jai
+jai -quiet first.jai

--- a/default.focus-config
+++ b/default.focus-config
@@ -47,6 +47,7 @@ insert_spaces_when_pressing_tab:        true
 strip_trailing_whitespace_on_save:      false
 smooth_scrolling:                       true
 double_shift_to_search_in_workspace:    false
+can_cancel_go_to_line:                  true
 max_entries_in_open_file_dialog:        2000
 tab_size:                               4
 line_height_scale_percent:              120
@@ -285,4 +286,3 @@ code_value:                     D699B5FF
 code_highlight:                 D89B75FF
 code_error:                     FF0000FF
 code_keyword:                   E67D74FF
-

--- a/default.focus-config
+++ b/default.focus-config
@@ -52,6 +52,7 @@ max_entries_in_open_file_dialog:        2000
 tab_size:                               4
 line_height_scale_percent:              120
 max_editor_width:                       -1
+editor_history_size:                    128
 
 
 [[keymap]]

--- a/default_macos.focus-config
+++ b/default_macos.focus-config
@@ -51,6 +51,7 @@ can_cancel_go_to_line:                  true
 max_entries_in_open_file_dialog:        2000
 tab_size:                               4
 line_height_scale_percent:              120
+editor_history_size:                    128
 
 
 [[keymap]]

--- a/default_macos.focus-config
+++ b/default_macos.focus-config
@@ -47,6 +47,7 @@ insert_spaces_when_pressing_tab:        true
 strip_trailing_whitespace_on_save:      false
 smooth_scrolling:                       true
 double_shift_to_search_in_workspace:    false
+can_cancel_go_to_line:                  true
 max_entries_in_open_file_dialog:        2000
 tab_size:                               4
 line_height_scale_percent:              120

--- a/default_macos.focus-config
+++ b/default_macos.focus-config
@@ -51,6 +51,7 @@ can_cancel_go_to_line:                  true
 max_entries_in_open_file_dialog:        2000
 tab_size:                               4
 line_height_scale_percent:              120
+max_editor_width:                       -1
 editor_history_size:                    128
 
 

--- a/src/config.jai
+++ b/src/config.jai
@@ -305,6 +305,7 @@ Settings :: struct {
     smooth_scrolling                    := true;
     line_height_scale_percent           := 120;
     max_editor_width                    := -1;
+    can_cancel_go_to_line               := true;
 
     // TODO
     // convert_tabs_to_spaces_on_load:     false
@@ -456,6 +457,7 @@ SETTINGS :: Setting.[
     .{ "insert_spaces_when_pressing_tab",     .boolean },
     .{ "strip_trailing_whitespace_on_save",   .boolean },
     .{ "smooth_scrolling",                    .boolean },
+    .{ "can_cancel_go_to_line",               .boolean },
 
     .{ "max_entries_in_open_file_dialog",     .integer },
     .{ "tab_size",                            .integer },

--- a/src/config.jai
+++ b/src/config.jai
@@ -306,6 +306,7 @@ Settings :: struct {
     line_height_scale_percent           := 120;
     max_editor_width                    := -1;
     can_cancel_go_to_line               := true;
+    editor_history_size                 := 128;
 
     // TODO
     // convert_tabs_to_spaces_on_load:     false
@@ -463,6 +464,7 @@ SETTINGS :: Setting.[
     .{ "tab_size",                            .integer },
     .{ "line_height_scale_percent",           .integer },
     .{ "max_editor_width",                    .integer },
+    .{ "editor_history_size",                 .integer },
 ];
 
 DEFAULT_CONFIG_FILE_DATA  :: #run read_entire_file(DEFAULT_CONFIG_NAME);

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -85,10 +85,10 @@ active_editor_handle_event :: (event: Input.Event, action: Action_Editors) -> ha
             case .toggle_expand;                    search_bar_toggle_expand(editor);                                             return true;
             case .toggle_case_sensitive;            search_bar_toggle_case_sensitive(editor, buffer);                             return true;
             case .toggle_whole_word;                search_bar_toggle_whole_word(editor, buffer);                                 return true;
-            
+
             case .search_in_buffer;                 open_search_bar(editor, buffer, remember_cursor_position = false);            return true;
             case .search_in_buffer_dropdown_mode;   open_search_bar(editor, buffer, .dropdown, remember_cursor_position = false); return true;
-            
+
             case .move_up;                          search_bar_move_cursor(editor, buffer, -1, wrap = true);                      return true;
             case .move_down;                        search_bar_move_cursor(editor, buffer,  1, wrap = true);                      return true;
             case .move_up_fast;                     search_bar_move_cursor(editor, buffer, -5);                                   return true;
@@ -164,6 +164,7 @@ active_editor_handle_event :: (event: Input.Event, action: Action_Editors) -> ha
         case .create_cursor_above;              create_cursor                       (editor, buffer, .above); keep_selection = true;
         case .create_cursor_below;              create_cursor                       (editor, buffer, .below); keep_selection = true;
 
+        case .select_word;                      select_word(editor, buffer); keep_selection = true;
         case .select_word_or_create_another_cursor; enabled_whole_words = select_word_or_create_another_cursor(editor, buffer); keep_selection = true;
 
         // Actions that do something per cursor
@@ -1068,6 +1069,17 @@ create_cursor :: (using editor: *Editor, buffer: Buffer, where: enum { above; be
 
     cursor_moved = true;
 }
+
+
+select_word :: (using editor: *Editor, buffer: Buffer) {
+    editor.cursor_moved = true;
+    for * editor.cursors {
+        if has_selection(it) continue;
+        select_word(buffer, it);
+        editor.search_whole_words = true;
+    }
+}
+
 
 select_word_or_create_another_cursor :: (using editor: *Editor, buffer: Buffer) -> whole_words: bool {
     editor.cursor_moved = true;

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -150,6 +150,7 @@ active_editor_handle_event :: (event: Input.Event, action: Action_Editors) -> ha
         case .duplicate_editor;                 switch_to_editor(.other, duplicate_current = true);
         case .move_editor_to_the_left;          if editors.active == editors.right then swap_panes();
         case .move_editor_to_the_right;         if editors.active == editors.left  then swap_panes();
+        case .center_viewport_on_cursor;        center_viewport_on_cursor           (editor, buffer);
         case .move_cursor_to_viewport_center;   move_cursor_to_viewport_center      (editor, buffer);
         case .remove_additional_cursors;        remove_additional_cursors           (editor);
         case .scroll_viewport_up;               smooth_scroll(editor, direction = .up);                 activate_hold_action(action, event);
@@ -458,6 +459,19 @@ move_viewport :: (editor: *Editor, dir: enum { left; up; right; down; }) {
     }
 }
 
+
+center_viewport_on_cursor :: (using editor: *Editor, buffer: Buffer) {
+    //line_num = clamp(line_num - 1, 0, buffer.line_starts.count - 2);
+    //line_start := get_line_start_offset(buffer, cast(s32)line_num);
+    //line_end   := get_line_end_offset  (buffer, cast(s32)line_num);
+    //cursor := cursors[main_cursor];
+    //cursor.pos = line_start + count_whitespace(buffer.bytes, line_start, line_end);
+    //cursor.sel = line_end;  // to make the line visible
+    //add_paste_animation(editor, get_selection(cursor));
+    editor.scroll_to_cursor = .yes;
+}
+
+
 move_cursor_to_viewport_center :: (editor: *Editor, buffer: Buffer) {
     cursor := leave_only_original_cursor(editor);
     // We assume that editors always take up most of the screen vertically.
@@ -468,6 +482,8 @@ move_cursor_to_viewport_center :: (editor: *Editor, buffer: Buffer) {
     cursor.sel = cursor.pos;
     editor.cursor_moved = true;
 }
+
+
 
 leave_only_original_cursor :: (using editor: *Editor) -> *Cursor {
     // Remove all cursors except the original one

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -39,6 +39,8 @@ editors_handle_event :: (event: Input.Event) -> handled: bool {
     return false;
 }
 
+
+
 activate_editors :: () {
     active_global_widget = .editors;
     cursors_start_blinking();
@@ -164,6 +166,8 @@ active_editor_handle_event :: (event: Input.Event, action: Action_Editors) -> ha
         case .select_all;                       select_all                          (editor, buffer); keep_selection = true;
         case .create_cursor_above;              create_cursor                       (editor, buffer, .above); keep_selection = true;
         case .create_cursor_below;              create_cursor                       (editor, buffer, .below); keep_selection = true;
+        case .move_to_previous_editor_history;  move_to_previous_editor_history     ();
+        case .move_to_next_editor_history;      move_to_next_editor_history         ();
 
         case .select_word;                      select_word(editor, buffer); keep_selection = true;
         case .select_word_or_create_another_cursor; enabled_whole_words = select_word_or_create_another_cursor(editor, buffer); keep_selection = true;
@@ -1215,6 +1219,25 @@ switch_to_editor :: (side: enum { left; right; other; }, duplicate_current := fa
     cursors_start_blinking();
 }
 
+set_editor_panes :: (left_editor_id: s64, right_editor_id: s64, active_editor_id: s64 = -1) {
+    if left_editor_id < 0  return;
+
+    if right_editor_id >= 0 {
+        editors.left   = left_editor_id;
+        editors.right  = right_editor_id;
+
+        if editors.layout != .Double {
+            editors_start_moving_splitter(0.5, start = 1.0);
+            editors.layout = .Double;
+        }
+    }
+    else {
+        editors.layout = .Single;
+    }
+
+    make_editor_active(ifx active_editor_id > -1 else left_editor_id);
+}
+
 swap_panes :: () {
     if editors.layout != .Double return;
     tmp := editors.left;
@@ -1246,11 +1269,12 @@ smooth_scroll :: (editor: Editor, direction: Smooth_Scroll_Direction, fast := fa
     }
 }
 
-find_or_create_editor :: (buffer_id: s64, existing_editor: s64 = -1) -> editor_id: s64, created: bool {
+find_or_create_editor :: (buffer_id: s64, unwanted_existing_editor: s64 = -1) -> editor_id: s64, created: bool {
     assert(buffer_id >= 0 && buffer_id < open_buffers.count, "Attempt to create editor for nonexistent buffer");
-    for open_editors {
-        if it.buffer_id == buffer_id && it_index != existing_editor return it_index, false;
-    }
+    for open_editors
+        if it.buffer_id == buffer_id && it_index != unwanted_existing_editor
+            return it_index, false;
+
     editor_id := open_editors.count;
     editor := array_add(*open_editors);
     editor.buffer_id = buffer_id;
@@ -2327,6 +2351,7 @@ Editor :: struct {
     last_cursor_created_using_mouse_at: Time;
 
     scroll_to_cursor: enum u8 { no; yes; yes_new_editor; }  // trigger a scroll so that the cursor is in the center vertically
+    pane_location: enum u8 { single; left; right; }
 
     highlights: [..] Text_Highlight;
     refresh_highlights: bool;
@@ -2433,6 +2458,7 @@ buffers_table: Table(string, s64);  // a map from full buffer path to buffer id 
 open_buffers_lock: Mutex;  // must hold while adding a new buffer
 
 editors: Editor_State;
+editor_history: Editor_History;
 
 // Keyboard smooth scrolling
 Smooth_Scroll_Direction :: enum {
@@ -2452,6 +2478,109 @@ editor_smooth_scroll: struct {
 
 splitter_pos:  float = 0.5;  // 0.5 means it's in the middle
 splitter_anim: Tween_Animation(float);
+
+
+Editor_History :: struct {
+    frames : [..] Editor_History_Frame;
+    head : int;
+    tail : int;
+    current : int;
+}
+
+Editor_History_Frame :: struct {
+    active_editor_id: s64;
+    left_editor_id: s64;
+    right_editor_id: s64;
+    pos: s32;
+}
+
+operator== :: (a: Editor_History_Frame, b: Editor_History_Frame) -> bool {
+    return a.active_editor_id == b.active_editor_id
+        && a.left_editor_id   == b.left_editor_id
+        && a.right_editor_id  == b.right_editor_id
+        && a.pos == b.pos;
+}
+
+maybe_save_editor_history :: () -> saved: bool {
+    if editors.layout == .None  return false;
+
+    editor := *open_editors[editors.active];
+    frame := Editor_History_Frame.{
+        active_editor_id = editors.active,
+        left_editor_id = ifx editors.layout == .None then -1
+                         else ifx editors.layout == .Single then editors.active
+                         else editors.left,
+        right_editor_id = ifx editors.layout == .Double then editors.right else -1,
+        pos = editor.cursors[editor.main_cursor].pos,
+    };
+
+    return maybe_add_to_editor_history(*editor_history, frame);
+}
+
+maybe_add_to_editor_history :: (using history: *Editor_History, frame: Editor_History_Frame) -> added: bool {
+    if frames.count == 0 {
+        array_add(*frames, frame);
+        head, tail, current = 0;
+        return true;
+    }
+
+    if frames[current] == frame  return false;
+
+    previous_frame := frames[current];
+    current = (current + 1) % config.settings.editor_history_size;
+    if current == tail
+        tail = (tail + 1) % config.settings.editor_history_size;
+
+    // When a pane closes it may result in two updates: the cursor moving over to the
+    // other pane and then the pane being closed.  In these cases we should overwrite the
+    // former with the latter so it is stored as a single step.
+    if frame.right_editor_id == -1 && previous_frame.right_editor_id != -1
+    && frame.active_editor_id == previous_frame.active_editor_id
+    && frame.pos == previous_frame.pos
+    && (frame.left_editor_id == previous_frame.left_editor_id || frame.left_editor_id == previous_frame.right_editor_id) {
+        frames[head] = frame;
+        current = head;
+    }
+    else {
+        if current < frames.count
+            frames[current] = frame;
+        else
+            array_add(*frames, frame);
+        head = current;
+    }
+
+    return true;
+}
+
+move_to_previous_editor_history :: () {
+    using editor_history;
+    if frames.count == 0 || current == tail
+        return;
+
+    current -= 1;
+    if current < 0
+        current = config.settings.editor_history_size - 1;
+    move_to_editor_history_frame(frames[current]);
+}
+
+move_to_next_editor_history :: () {
+    using editor_history;
+    if frames.count == 0 || current == head
+        return;
+
+    current = (current + 1) % config.settings.editor_history_size;
+    move_to_editor_history_frame(frames[current]);
+}
+
+move_to_editor_history_frame :: (frame: Editor_History_Frame) {
+    set_editor_panes(frame.left_editor_id, frame.right_editor_id, frame.active_editor_id);
+    editor := *open_editors[editors.active];
+    cursor := leave_only_original_cursor(editor);
+    cursor.pos = frame.pos;
+    cursor.sel = cursor.pos;
+    add_paste_animation(editor, get_selection(cursor));
+    editor.scroll_to_cursor = .yes;
+}
 
 
 #scope_file

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -461,13 +461,6 @@ move_viewport :: (editor: *Editor, dir: enum { left; up; right; down; }) {
 
 
 center_viewport_on_cursor :: (using editor: *Editor, buffer: Buffer) {
-    //line_num = clamp(line_num - 1, 0, buffer.line_starts.count - 2);
-    //line_start := get_line_start_offset(buffer, cast(s32)line_num);
-    //line_end   := get_line_end_offset  (buffer, cast(s32)line_num);
-    //cursor := cursors[main_cursor];
-    //cursor.pos = line_start + count_whitespace(buffer.bytes, line_start, line_end);
-    //cursor.sel = line_end;  // to make the line visible
-    //add_paste_animation(editor, get_selection(cursor));
     editor.scroll_to_cursor = .yes;
 }
 

--- a/src/keymap.jai
+++ b/src/keymap.jai
@@ -346,6 +346,8 @@ ACTIONS_EDITORS :: #run arrays_concat(ACTIONS_COMMON, string.[
     "move_editor_to_the_right",
     "create_new_file",
     "create_new_file_on_the_side",
+    "move_to_previous_editor_history",
+    "move_to_next_editor_history",
 ]);
 
 ACTIONS_OPEN_FILE_DIALOG :: #run arrays_concat(ACTIONS_COMMON, string.[

--- a/src/keymap.jai
+++ b/src/keymap.jai
@@ -45,6 +45,22 @@ map_event_to_action :: (event: Input.Event, $Action: Type) -> Action, Key_Mappin
     return invalid_action, invalid_mapping;
 }
 
+
+dump_key_mappings :: () {
+    dump_keys :: (title: string, key_mapping: []Key_Mapping, action_type: Type) #expand {
+        print("\n%\n", title);
+        for keymap: key_mapping {
+            for key_combo: keymap.key_sequence
+                print("% %\n", key_combo_strings(key_combo), cast(action_type)keymap.action);
+        }
+    }
+    dump_keys("File", config.keymap.open_file_dialog, Action_Open_File_Dialog);
+    dump_keys("Search", config.keymap.search_dialog, Action_Search_Dialog);
+    dump_keys("Editor", config.keymap.editors, Action_Editors);
+    dump_keys("Common", config.keymap.common, Action_Common);
+}
+
+
 activate_hold_action :: (action: $Action_Type, event: Input.Event) {
     _, matched_mapping := map_event_to_action(event, Action_Type);  // we map it here again to avoid passing it in through multiple functions
 
@@ -284,6 +300,8 @@ ACTIONS_COMMON :: string.[
     "reset_font_size_to_default",
     "close_current_editor",
     "close_other_editor",
+
+    "dump_key_mappings",
 ];
 
 ACTIONS_EDITORS :: #run arrays_concat(ACTIONS_COMMON, string.[
@@ -314,6 +332,7 @@ ACTIONS_EDITORS :: #run arrays_concat(ACTIONS_COMMON, string.[
     "scroll_viewport_right",
     "move_up_to_empty_line",
     "move_down_to_empty_line",
+    "center_viewport_on_cursor",
     "move_cursor_to_viewport_center",
     "remove_additional_cursors",
     "break_line",

--- a/src/main.jai
+++ b/src/main.jai
@@ -253,6 +253,7 @@ main :: () {
 
         // TODO:
         // maybe_save_editor_state_into_session();
+        maybe_save_editor_history();
 
         if should_reload_workspace {
             hard_reload_workspace();

--- a/src/main.jai
+++ b/src/main.jai
@@ -300,6 +300,8 @@ handle_common_editor_action :: (action: Action_Editors, placement: Editor_Placem
 
         case .show_commands;                                    show_commands_dialog();                             return true;
 
+        case .dump_key_mappings;                                dump_key_mappings ();                               return true;
+
         // TODO: search_in_buffer
         case .search_in_project;
             if active_global_widget == .editors then finder_open_from_editor(); else finder_open();

--- a/src/widgets/commands.jai
+++ b/src/widgets/commands.jai
@@ -172,6 +172,7 @@ commands := #run Command.[
     .{ .move_up_to_empty_line,                              "Move Up To Empty Line",              0, .Single },
     .{ .move_down_to_empty_line,                            "Move Down To Empty Line",            0, .Single },
 
+    .{ .center_viewport_on_cursor,                          "Center View On Cursor",              0, .Single },
     .{ .move_cursor_to_viewport_center,                     "Move Cursor To Screen Center",       0, .Single },
     .{ .remove_additional_cursors,                          "Remove Additional Cursors",          0, .Single },
 
@@ -186,6 +187,8 @@ commands := #run Command.[
 
     .{ .move_editor_to_the_left,                            "Move Pane To The Left",              0, .Double },
     .{ .move_editor_to_the_right,                           "Move Pane To The Right",             0, .Double },
+
+    .{ .dump_key_mappings,                                  "Dump Key Mappings",                  0, .None },
 ];
 
 Command :: struct {

--- a/src/widgets/commands.jai
+++ b/src/widgets/commands.jai
@@ -175,6 +175,8 @@ commands := #run Command.[
     .{ .center_viewport_on_cursor,                          "Center View On Cursor",              0, .Single },
     .{ .move_cursor_to_viewport_center,                     "Move Cursor To Screen Center",       0, .Single },
     .{ .remove_additional_cursors,                          "Remove Additional Cursors",          0, .Single },
+    .{ .move_to_previous_editor_history,                    "Move To Previous Cursor Position",   0, .Single },
+    .{ .move_to_next_editor_history,                        "Move To Next Cursor Position",       0, .Single },
 
     .{ .new_line_below_without_breaking,                    "New Line Below Without Breaking",    0, .Single },
     .{ .new_line_above_without_breaking,                    "New Line Above Without Breaking",    0, .Single },

--- a/src/widgets/go_to_line_dialog.jai
+++ b/src/widgets/go_to_line_dialog.jai
@@ -4,9 +4,10 @@ go_to_line_dialog_handle_event :: (event: Input.Event) -> handled: bool {
     if event.type == .KEYBOARD && event.key_pressed {
         action, mapping := map_event_to_action(event, Action_Search_Dialog);
         if action == {
-            case .close_dialog;             close_go_to_line_dialog(jump_to_original_cursor = true);    return true;
-            case .open_entry_in_place;      close_go_to_line_dialog();                                  return true;
-            case .open_entry_on_the_side;   close_go_to_line_dialog();                                  return true;
+            case .close_dialog;             close_go_to_line_dialog(jump_to_original_cursor = config.settings.can_cancel_go_to_line);
+                                            return true;
+            case .open_entry_in_place;      close_go_to_line_dialog(); return true;
+            case .open_entry_on_the_side;   close_go_to_line_dialog(); return true;
         }
 
         old_text := copy_temporary_string(to_string(input.text));


### PR DESCRIPTION
* Fixed `select_word` editor binding not working.
* Added `center_viewport_on_cursor` command.
* Added `dump_key_mappings` command (dumps all key mapping to console for debugging).
* Added rudimentary editor history feature, let's you move back and forth through your recent edit locations.