### PR TITLE
Added scroll_to_cursor_line_offset setting

### DIFF
--- a/default.focus-config
+++ b/default.focus-config
@@ -53,6 +53,7 @@ tab_size:                               4
 line_height_scale_percent:              120
 max_editor_width:                       -1
 editor_history_size:                    128
+scroll_to_cursor_line_offset            1
 
 
 [[keymap]]

--- a/default_macos.focus-config
+++ b/default_macos.focus-config
@@ -93,8 +93,8 @@ Cmd-[                       unindent
 
 Cmd-S                       save
 
-Alt-Minus                   move_to_previous_editor_history
-Alt-Plus                    move_to_next_editor_history
+Cmd-Alt-Minus               move_to_previous_editor_history
+Cmd-Alt-Plus                move_to_next_editor_history
 
 Cmd-/                       toggle_comment
 Cmd-L                       select_line

--- a/default_macos.focus-config
+++ b/default_macos.focus-config
@@ -53,6 +53,7 @@ tab_size:                               4
 line_height_scale_percent:              120
 max_editor_width:                       -1
 editor_history_size:                    128
+scroll_to_cursor_line_offset            1
 
 
 [[keymap]]
@@ -92,8 +93,8 @@ Cmd-[                       unindent
 
 Cmd-S                       save
 
-Cmd-Alt-Minus               move_to_previous_editor_history
-Cmd-Alt-Plus                move_to_next_editor_history
+Alt-Minus                   move_to_previous_editor_history
+Alt-Plus                    move_to_next_editor_history
 
 Cmd-/                       toggle_comment
 Cmd-L                       select_line

--- a/src/config.jai
+++ b/src/config.jai
@@ -314,6 +314,7 @@ Settings :: struct {
     max_editor_width                    := -1;
     can_cancel_go_to_line               := true;
     editor_history_size                 := 128;
+    scroll_to_cursor_line_offset        := 1;
 
     // TODO
     // convert_tabs_to_spaces_on_load:     false
@@ -472,6 +473,7 @@ SETTINGS :: Setting.[
     .{ "line_height_scale_percent",           .integer },
     .{ "max_editor_width",                    .integer },
     .{ "editor_history_size",                 .integer },
+    .{ "scroll_to_cursor_line_offset",        .integer },
 ];
 
 DEFAULT_CONFIG_FILE_DATA  :: #run read_entire_file(DEFAULT_CONFIG_NAME);

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -493,7 +493,7 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
             if left_target < 0 then left_target = 0;
             if left_target != scroll_x.target then start_animation(*viewport.scroll_x, viewport.left, left_target);
 
-            cursor_pos_from_top := cursor_coords[main_cursor].pos.line * line_height;
+            cursor_pos_from_top := (cursor_coords[main_cursor].pos.line + config.settings.scroll_to_cursor_line_offset) * line_height;
             top_target := cast(s32)(cursor_pos_from_top - rect.h / 2);
             if top_target < 0 then top_target = 0;
             if top_target != scroll_y.target then start_animation(*viewport.scroll_y, viewport.top, top_target);


### PR DESCRIPTION
Adds a line offset when centering view on cursor.  Default value is 1, which compensates for the slight too-low bias of the centering math caused by status bar existence.