### PR TITLE
Better clipboard handling

### DIFF
--- a/src/buffer.jai
+++ b/src/buffer.jai
@@ -908,13 +908,11 @@ Buffer :: struct {
 
 Cursor :: struct {
     using state: State;
-    clipboard: Clipboard;
 
-    State     :: struct { pos, sel: s32; col_wanted: s32 = -1; }
-    Clipboard :: struct { start: s32; count: s32; }
+    State :: struct { pos, sel: s32; col_wanted: s32 = -1; }
 }
 
-#assert size_of(Cursor) == (2 + 1 + 2) * size_of(s32);  // make sure no padding accidentally gets added
+#assert size_of(Cursor) == (2 + 1) * size_of(s32);  // make sure no padding accidentally gets added
 
 Cursor_Coords :: struct {
     pos, sel: Coords;

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -333,11 +333,9 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
 
             if !deleted_cursor {
                 // Create new cursor
-                same_clipboard, clipboard := cursors_have_the_same_clipboard(editor);
                 new_cursor := array_add(*cursors);
                 new_cursor.pos = click_offset;
                 new_cursor.sel = new_cursor.pos;
-                if same_clipboard then new_cursor.clipboard = clipboard;
 
                 main_cursor = cursors.count - 1;
                 new_cursor_just_created_using_mouse = true;

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -2217,7 +2217,7 @@ paste_from_clipboard :: (editor: *Editor, buffer: *Buffer) {
             clipboard_slice := clipboard.slices[it_index];
             selection       := get_selection(cursor);
             count           := clipboard_slice.count - 1; // Don't paste the last newline of the slice
-            if it_index == clipboard.slices.count - 1 && clipboard_slice.was_selected then clipboard_slice.count += 1; // If the last slice was selected, it didn't have newline
+            if it_index == clipboard.slices.count - 1 && clipboard_slice.was_selected then count += 1; // If the last slice was selected, it didn't have newline
             str             := slice(clipboard.text, clipboard_slice.start, count); 
 
             replace_range(buffer, selection, str);

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -2139,34 +2139,34 @@ delete_to_end_of_line :: (editor: *Editor, buffer: *Buffer) {
 }
 
 copy_selection_to_clipboard :: (editor: *Editor, buffer: *Buffer, cut := false) {
+    // Check if there's anything to copy else we exit early so we don't trash the clipboard
     any_selection := false;
-    for cursor : editor.cursors { if has_selection(cursor) { any_selection = true; break; } }
+    for editor.cursors { if has_selection(it) { any_selection = true; break; } }
+    if !any_selection && !cut && !config.settings.copy_whole_line_without_selection return;
 
-    if !any_selection && (cut || config.settings.copy_whole_line_without_selection) {
-        // If no cursors have a selection, then pressing cut will cut whole lines
-        // (or copy them if it's enabled in the config file)
-        for * cursor : editor.cursors {
-            // Select the whole line
-            line := offset_to_line(buffer, cursor.pos);
-            cursor.sel = get_line_start_offset(buffer, line);
-            cursor.pos = get_line_start_offset(buffer, line+1);
-            cursor.col_wanted = -1;
-        }
-        organise_cursors(editor);  // resolve overlapping selections
-    } else if !any_selection {
-        return;  // don't want to trash the clipboard when you accidentally press Ctrl+C
-    }
+    // We are sure to copying something, dump all the previous clipboard slices
+    array_reset(*global_clipboard_slices); 
 
-    array_reset(*global_clipboard_slices); // We are copying something so dump the previous clipboard slices
-
+    // Fill the internal clipboard and the slices from the current editor cursors
     b: String_Builder;
     offset := 0;
     for * cursor : editor.cursors {
-        str := get_selected_string(cursor, buffer);
+        if !has_selection(cursor) && !cut && !config.settings.copy_whole_line_without_selection continue;
+        
+        // Get string from the cursor and format it if necessary 
+        str := ifx has_selection(cursor) {
+            selected_str := get_selected_string(cursor, buffer);
+            ifx it_index != editor.cursors.count - 1 then join(selected_str, "\n") else selected_str; 
+        } else {
+            line_num := offset_to_line(buffer, cursor.pos);
+            get_line_as_string(buffer, line_num);
+        }
         append(*b, str);
-        if it_index < editor.cursors.count-1 && str && str[str.count-1] != #char "\n" then append(*b, "\n");
-        array_add(*global_clipboard_slices, .{ start = xx offset, count = xx str.count }); // Add a clipboard slice for each cursor
-        offset += str.count + 1;
+
+        // Add a new clipboard slice for each cursor
+        array_add(*global_clipboard_slices, .{ xx offset, xx str.count, has_selection(cursor) });
+ 
+        offset += str.count;
     }
 
     combined_str := builder_to_string(*b);
@@ -2176,19 +2176,7 @@ copy_selection_to_clipboard :: (editor: *Editor, buffer: *Buffer, cut := false) 
         global_clipboard = combined_str;  // now it owns it
     }
 
-    if cut {
-        offset_delta := 0;
-        for * cursor : editor.cursors {
-            cursor.pos -= xx offset_delta;
-            cursor.sel -= xx offset_delta;
-            selection := get_selection(cursor);
-            delete_range(buffer, selection);
-            cursor.col_wanted = -1;
-            cursor.pos = selection.start;
-            offset_delta += selection.end - selection.start;
-        }
-        editor.cursor_moved = .refresh_only;
-    }
+    if cut delete_line(editor, buffer);
 }
 
 paste_from_clipboard :: (editor: *Editor, buffer: *Buffer) {
@@ -2207,23 +2195,48 @@ paste_from_clipboard :: (editor: *Editor, buffer: *Buffer) {
     for * cursor : editor.cursors {
         cursor.pos += xx offset_delta;
         cursor.sel += xx offset_delta;
-        selection := get_selection(cursor);
-
-        // Paste one slice per cursor if they have the same number of entries
-        // else paste the entire clipboard for each cursor 
-        str:= ifx editor.cursors.count == global_clipboard_slices.count {
-            clipboard_slice := global_clipboard_slices[it_index];
-            slice(global_clipboard, clipboard_slice.start, clipboard_slice.count); 
-        } else {
-            global_clipboard;
-        }
-
-        replace_range(buffer, selection, str);
-        cursor.pos = xx (selection.start + str.count);
         cursor.col_wanted = -1;
-        offset_delta += str.count - (selection.end - selection.start);
 
-        add_paste_animation(editor, Offset_Range.{ start = selection.start, end = selection.start + cast(s32) str.count });
+        // If there is only one slice without selection, insert slice at cursor line
+        if !has_selection(cursor) && global_clipboard_slices.count == 1 && !global_clipboard_slices[0].was_selected {
+            line_num   := offset_to_line(buffer, cursor.pos); 
+            line_start := get_line_start_offset(buffer, line_num);
+            str        := global_clipboard;
+            
+            // insert_string_at_offset() make the buffer dirty
+            // we rescan to clean it else we can't call offset_to_line for the next cursors
+            insert_string_at_offset(buffer, line_start, str);
+            rescan_for_lines(buffer);
+
+            cursor.pos   += xx str.count;
+            offset_delta += str.count;
+            add_paste_animation(editor, .{ line_start, line_start + cast(s32) str.count });
+        } 
+        // If they have the same number of entries paste one slice per cursor
+        else if editor.cursors.count == global_clipboard_slices.count {
+            clipboard_slice := global_clipboard_slices[it_index];
+            selection       := get_selection(cursor);
+            count           := clipboard_slice.count - 1; // Don't paste the last newline of the slice
+            if it_index == global_clipboard_slices.count - 1 && clipboard_slice.was_selected then clipboard_slice.count += 1; // If the last slice was selected, it didn't have newline
+            str             := slice(global_clipboard, clipboard_slice.start, count); 
+
+            replace_range(buffer, selection, str);
+
+            cursor.pos    = xx (selection.start + str.count);
+            offset_delta += str.count - (selection.end - selection.start);
+            add_paste_animation(editor, .{ selection.start, selection.start + cast(s32) str.count });
+        } 
+        // Paste the entire clipboard for each cursor
+        else {
+            selection := get_selection(cursor);
+            str       := global_clipboard;
+
+            replace_range(buffer, selection, str);
+
+            cursor.pos    = xx (selection.start + str.count);
+            offset_delta += str.count - (selection.end - selection.start);
+            add_paste_animation(editor, .{ selection.start, selection.start + cast(s32) str.count });
+        }
     }
 
     editor.cursor_moved = .large_edit;
@@ -2476,6 +2489,7 @@ global_clipboard_slices: [..] Clipboard_Slice;
 Clipboard_Slice :: struct {
     start: s32; 
     count: s32;
+    was_selected: bool;
 }
 
 // Keyboard smooth scrolling

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -2157,8 +2157,7 @@ copy_selection_to_clipboard :: (editor: *Editor, buffer: *Buffer, cut := false) 
         return;  // don't want to trash the clipboard when you accidentally press Ctrl+C
     }
 
-    // We are copying something so dump the previous clipboard slices
-    array_reset(*global_clipboard_slices);
+    array_reset(*global_clipboard_slices); // We are copying something so dump the previous clipboard slices
 
     b: String_Builder;
     offset := 0;
@@ -2166,8 +2165,7 @@ copy_selection_to_clipboard :: (editor: *Editor, buffer: *Buffer, cut := false) 
         str := get_selected_string(cursor, buffer);
         append(*b, str);
         if it_index < editor.cursors.count-1 && str && str[str.count-1] != #char "\n" then append(*b, "\n");
-        // Add one global clipboard view for each current editor cursor
-        array_add(*global_clipboard_slices, .{ start = xx offset, count = xx str.count });
+        array_add(*global_clipboard_slices, .{ start = xx offset, count = xx str.count }); // Add a clipboard slice for each cursor
         offset += str.count + 1;
     }
 
@@ -2214,8 +2212,8 @@ paste_from_clipboard :: (editor: *Editor, buffer: *Buffer) {
         // Paste one slice per cursor if they have the same number of entries
         // else paste the entire clipboard for each cursor 
         str:= ifx editor.cursors.count == global_clipboard_slices.count {
-            clipboard_view := global_clipboard_slices[it_index];
-            slice(global_clipboard, clipboard_view.start, clipboard_view.count); 
+            clipboard_slice := global_clipboard_slices[it_index];
+            slice(global_clipboard, clipboard_slice.start, clipboard_slice.count); 
         } else {
             global_clipboard;
         }

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -485,7 +485,6 @@ move_cursor_to_viewport_center :: (editor: *Editor, buffer: Buffer) {
 leave_only_original_cursor :: (using editor: *Editor) -> *Cursor {
     // Remove all cursors except the original one
     cursor := cursors[min(original_cursor, cursors.count-1)];
-    cursor.clipboard = .{ start = 0, count = xx max(global_clipboard.count, 0) };
     cursors.count = 1;
     original_cursor = 0;
     main_cursor = 0;
@@ -533,16 +532,10 @@ organise_cursors :: (using editor: *Editor, selection_mode: *Selection_Mode = xx
 
     // Merge overlapping cursors
     i := 0;
-    reset_clipboard : = false;
     while (i < cursors.count - 1) {
         cursor      := *cursors[i];
         next_cursor := cursors[i+1];
         if maybe_subsume(cursor, next_cursor) {
-            if cursor.clipboard.start + cursor.clipboard.count + 1 == next_cursor.clipboard.start {
-                cursor.clipboard.count += 1 + next_cursor.clipboard.count;  // "\n" + whatever was selected
-            } else {
-                reset_clipboard = true;
-            }
             if selection_mode && (main_cursor == i || main_cursor == i+1) then selection_mode.min_range = get_selection(cursor);  // preserve the selection when dragging
             array_ordered_remove_by_index(*cursors, i+1);
             if main_cursor     > i then main_cursor -= 1;
@@ -550,11 +543,6 @@ organise_cursors :: (using editor: *Editor, selection_mode: *Selection_Mode = xx
         } else {
             i += 1;
         }
-    }
-
-    if reset_clipboard {
-        // Cursors have mixed beyond repair
-        cursors[main_cursor].clipboard = .{ start = 0, count = xx max(global_clipboard.count, 0) };
     }
 }
 
@@ -980,26 +968,6 @@ should_draw_cursors :: inline () -> bool {
     return (ms_since_start / CURSOR_BLINK_SPEED_MS) % 2 == 0;
 }
 
-cursors_have_the_same_clipboard :: (using editor: Editor) -> bool, clipboard: Cursor.Clipboard {
-    same_clipboard := true;
-    first_str := get_clipboard_string(cursors[0]);
-
-    for cursor : cursors {
-        if first_str != get_clipboard_string(cursor) {
-            same_clipboard = false;
-            break;
-        }
-    }
-
-    return same_clipboard, cursors[0].clipboard;
-}
-
-get_clipboard_string :: (cursor: Cursor) -> string {
-    start := clamp(cursor.clipboard.start, 0, cast(s32) global_clipboard.count - 1);
-    count := clamp(cursor.clipboard.count, 0, cast(s32) global_clipboard.count - start);
-    return slice(global_clipboard, max(start, 0), count);
-}
-
 remove_all_editors :: () {
     editors = Editor_State.{};
     for * open_editors free_editor(it);
@@ -1026,8 +994,6 @@ restore_cursor_state :: (using editor: *Editor, cursor_state: [] Cursor.State) {
     for * cursor, i : cursors {
         cursor.state = cursor_state[i];
         cursor.col_wanted = -1;
-        cursor.clipboard.start = 0;
-        cursor.clipboard.count = cast(s32)global_clipboard.count;
     }
     if main_cursor >= cursors.count then main_cursor = cursors.count - 1;  // maybe we should remember it too
 }
@@ -1135,12 +1101,9 @@ select_word_or_create_another_cursor :: (using editor: *Editor, buffer: Buffer) 
             return editor.search_whole_words;  // found no matches
         }
 
-        same_clipboard, clipboard := cursors_have_the_same_clipboard(editor);
-
         new_cursor := array_add(*cursors);
         new_cursor.sel = cast(s32) found_offset;
         new_cursor.pos = cast(s32) (found_offset + selected_text.count);
-        if same_clipboard then new_cursor.clipboard = clipboard;
 
         main_cursor = cursors.count - 1;
 
@@ -2194,13 +2157,17 @@ copy_selection_to_clipboard :: (editor: *Editor, buffer: *Buffer, cut := false) 
         return;  // don't want to trash the clipboard when you accidentally press Ctrl+C
     }
 
+    // We are copying something so dump the previous clipboard slices
+    array_reset(*global_clipboard_slices);
+
     b: String_Builder;
     offset := 0;
     for * cursor : editor.cursors {
         str := get_selected_string(cursor, buffer);
         append(*b, str);
         if it_index < editor.cursors.count-1 && str && str[str.count-1] != #char "\n" then append(*b, "\n");
-        cursor.clipboard = .{ start = xx offset, count = xx str.count };
+        // Add one global clipboard view for each current editor cursor
+        array_add(*global_clipboard_slices, .{ start = xx offset, count = xx str.count });
         offset += str.count + 1;
     }
 
@@ -2233,7 +2200,7 @@ paste_from_clipboard :: (editor: *Editor, buffer: *Buffer) {
         // Editor clipboard and system clipboard are out of sync - drop the editor one
         if global_clipboard free(global_clipboard);
         global_clipboard = system_clipboard_text;
-        for * cursor : editor.cursors { cursor.clipboard = .{ start = 0, count = xx global_clipboard.count }; }
+        array_reset(*global_clipboard_slices);
     } else {
         free(system_clipboard_text);
     }
@@ -2243,7 +2210,16 @@ paste_from_clipboard :: (editor: *Editor, buffer: *Buffer) {
         cursor.pos += xx offset_delta;
         cursor.sel += xx offset_delta;
         selection := get_selection(cursor);
-        str := get_clipboard_string(cursor);
+
+        // Paste one slice per cursor if they have the same number of entries
+        // else paste the entire clipboard for each cursor 
+        str:= ifx editor.cursors.count == global_clipboard_slices.count {
+            clipboard_view := global_clipboard_slices[it_index];
+            slice(global_clipboard, clipboard_view.start, clipboard_view.count); 
+        } else {
+            global_clipboard;
+        }
+
         replace_range(buffer, selection, str);
         cursor.pos = xx (selection.start + str.count);
         cursor.col_wanted = -1;
@@ -2497,6 +2473,12 @@ editor_history: Editor_History;
 current_editor_history_size := -1;
 
 global_clipboard: string;
+global_clipboard_slices: [..] Clipboard_Slice;
+
+Clipboard_Slice :: struct {
+    start: s32; 
+    count: s32;
+}
 
 // Keyboard smooth scrolling
 Smooth_Scroll_Direction :: enum {

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -485,7 +485,7 @@ move_cursor_to_viewport_center :: (editor: *Editor, buffer: Buffer) {
 leave_only_original_cursor :: (using editor: *Editor) -> *Cursor {
     // Remove all cursors except the original one
     cursor := cursors[min(original_cursor, cursors.count-1)];
-    cursor.clipboard = .{ start = 0, count = xx max(clipboard.count, 0) };
+    cursor.clipboard = .{ start = 0, count = xx max(global_clipboard.count, 0) };
     cursors.count = 1;
     original_cursor = 0;
     main_cursor = 0;
@@ -554,7 +554,7 @@ organise_cursors :: (using editor: *Editor, selection_mode: *Selection_Mode = xx
 
     if reset_clipboard {
         // Cursors have mixed beyond repair
-        cursors[main_cursor].clipboard = .{ start = 0, count = xx max(clipboard.count, 0) };
+        cursors[main_cursor].clipboard = .{ start = 0, count = xx max(global_clipboard.count, 0) };
     }
 }
 
@@ -982,10 +982,10 @@ should_draw_cursors :: inline () -> bool {
 
 cursors_have_the_same_clipboard :: (using editor: Editor) -> bool, clipboard: Cursor.Clipboard {
     same_clipboard := true;
-    first_str := get_clipboard_string(editor, cursors[0]);
+    first_str := get_clipboard_string(cursors[0]);
 
     for cursor : cursors {
-        if first_str != get_clipboard_string(editor, cursor) {
+        if first_str != get_clipboard_string(cursor) {
             same_clipboard = false;
             break;
         }
@@ -994,10 +994,10 @@ cursors_have_the_same_clipboard :: (using editor: Editor) -> bool, clipboard: Cu
     return same_clipboard, cursors[0].clipboard;
 }
 
-get_clipboard_string :: (editor: Editor, cursor: Cursor) -> string {
-    start := clamp(cursor.clipboard.start, 0, cast(s32) editor.clipboard.count - 1);
-    count := clamp(cursor.clipboard.count, 0, cast(s32) editor.clipboard.count - start);
-    return slice(editor.clipboard, max(start, 0), count);
+get_clipboard_string :: (cursor: Cursor) -> string {
+    start := clamp(cursor.clipboard.start, 0, cast(s32) global_clipboard.count - 1);
+    count := clamp(cursor.clipboard.count, 0, cast(s32) global_clipboard.count - start);
+    return slice(global_clipboard, max(start, 0), count);
 }
 
 remove_all_editors :: () {
@@ -1027,7 +1027,7 @@ restore_cursor_state :: (using editor: *Editor, cursor_state: [] Cursor.State) {
         cursor.state = cursor_state[i];
         cursor.col_wanted = -1;
         cursor.clipboard.start = 0;
-        cursor.clipboard.count = cast(s32)editor.clipboard.count;
+        cursor.clipboard.count = cast(s32)global_clipboard.count;
     }
     if main_cursor >= cursors.count then main_cursor = cursors.count - 1;  // maybe we should remember it too
 }
@@ -1233,10 +1233,6 @@ duplicate_active_editor :: () -> s64 {
     for current_editor.cursors { array_add(*duplicated_editor.cursors, it); }
     duplicated_editor.main_cursor     = current_editor.main_cursor;
     duplicated_editor.original_cursor = current_editor.original_cursor;
-
-    // Copy clipboard
-    if duplicated_editor.clipboard then free(duplicated_editor.clipboard);
-    duplicated_editor.clipboard = copy_string(current_editor.clipboard);
 
     // Move viewport
     duplicated_editor.viewport.scroll_x = current_editor.viewport.scroll_x;
@@ -2211,8 +2207,8 @@ copy_selection_to_clipboard :: (editor: *Editor, buffer: *Buffer, cut := false) 
     combined_str := builder_to_string(*b);
     if combined_str {
         os_clipboard_set_text(combined_str);
-        if editor.clipboard then free(editor.clipboard);
-        editor.clipboard = combined_str;  // now it owns it
+        if global_clipboard then free(global_clipboard);
+        global_clipboard = combined_str;  // now it owns it
     }
 
     if cut {
@@ -2233,11 +2229,11 @@ copy_selection_to_clipboard :: (editor: *Editor, buffer: *Buffer, cut := false) 
 paste_from_clipboard :: (editor: *Editor, buffer: *Buffer) {
     system_clipboard_text := os_clipboard_get_text();
 
-    if system_clipboard_text != editor.clipboard {
+    if system_clipboard_text != global_clipboard {
         // Editor clipboard and system clipboard are out of sync - drop the editor one
-        if editor.clipboard free(editor.clipboard);
-        editor.clipboard = system_clipboard_text;
-        for * cursor : editor.cursors { cursor.clipboard = .{ start = 0, count = xx editor.clipboard.count }; }
+        if global_clipboard free(global_clipboard);
+        global_clipboard = system_clipboard_text;
+        for * cursor : editor.cursors { cursor.clipboard = .{ start = 0, count = xx global_clipboard.count }; }
     } else {
         free(system_clipboard_text);
     }
@@ -2247,7 +2243,7 @@ paste_from_clipboard :: (editor: *Editor, buffer: *Buffer) {
         cursor.pos += xx offset_delta;
         cursor.sel += xx offset_delta;
         selection := get_selection(cursor);
-        str := get_clipboard_string(editor, cursor);
+        str := get_clipboard_string(cursor);
         replace_range(buffer, selection, str);
         cursor.pos = xx (selection.start + str.count);
         cursor.col_wanted = -1;
@@ -2356,7 +2352,6 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
 
 free_editor :: (using editor: *Editor) {
     array_reset(*cursors);
-    if clipboard free(clipboard);
     array_reset(*paste_animations);
     array_reset(*highlights);
     array_reset(*search_bar.results);
@@ -2370,8 +2365,6 @@ Editor :: struct {
     cursors: [..] Cursor;
     main_cursor: s64;      // newly added cursors become main so that we jump to them
     original_cursor: s64;  // we remember the original cursor when first creating multiple cursors (and go back to it on escape)
-
-    clipboard: string;
 
     search_whole_words := false;  // used when creating new cursors
     cursor_moved := Cursor_Movement.has_not_moved; // this may trigger a scroll so that the cursor is within acceptable bounds
@@ -2502,6 +2495,8 @@ open_buffers_lock: Mutex;  // must hold while adding a new buffer
 editors: Editor_State;
 editor_history: Editor_History;
 current_editor_history_size := -1;
+
+global_clipboard: string;
 
 // Keyboard smooth scrolling
 Smooth_Scroll_Direction :: enum {

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -2145,7 +2145,7 @@ copy_selection_to_clipboard :: (editor: *Editor, buffer: *Buffer, cut := false) 
     if !any_selection && !cut && !config.settings.copy_whole_line_without_selection return;
 
     // We are sure to copying something, dump all the previous clipboard slices
-    array_reset(*global_clipboard_slices); 
+    array_reset(*clipboard.slices); 
 
     // Fill the internal clipboard and the slices from the current editor cursors
     b: String_Builder;
@@ -2164,7 +2164,7 @@ copy_selection_to_clipboard :: (editor: *Editor, buffer: *Buffer, cut := false) 
         append(*b, str);
 
         // Add a new clipboard slice for each cursor
-        array_add(*global_clipboard_slices, .{ xx offset, xx str.count, has_selection(cursor) });
+        array_add(*clipboard.slices, .{ xx offset, xx str.count, has_selection(cursor) });
  
         offset += str.count;
     }
@@ -2172,8 +2172,8 @@ copy_selection_to_clipboard :: (editor: *Editor, buffer: *Buffer, cut := false) 
     combined_str := builder_to_string(*b);
     if combined_str {
         os_clipboard_set_text(combined_str);
-        if global_clipboard then free(global_clipboard);
-        global_clipboard = combined_str;  // now it owns it
+        if clipboard.text then free(clipboard.text);
+        clipboard.text = combined_str;  // now it owns it
     }
 
     if cut delete_line(editor, buffer);
@@ -2182,11 +2182,11 @@ copy_selection_to_clipboard :: (editor: *Editor, buffer: *Buffer, cut := false) 
 paste_from_clipboard :: (editor: *Editor, buffer: *Buffer) {
     system_clipboard_text := os_clipboard_get_text();
 
-    if system_clipboard_text != global_clipboard {
+    if system_clipboard_text != clipboard.text {
         // Editor clipboard and system clipboard are out of sync - drop the editor one
-        if global_clipboard free(global_clipboard);
-        global_clipboard = system_clipboard_text;
-        array_reset(*global_clipboard_slices);
+        if clipboard.text free(clipboard.text);
+        clipboard.text = system_clipboard_text;
+        array_reset(*clipboard.slices);
     } else {
         free(system_clipboard_text);
     }
@@ -2198,10 +2198,10 @@ paste_from_clipboard :: (editor: *Editor, buffer: *Buffer) {
         cursor.col_wanted = -1;
 
         // If there is only one slice without selection, insert slice at cursor line
-        if !has_selection(cursor) && global_clipboard_slices.count == 1 && !global_clipboard_slices[0].was_selected {
+        if !has_selection(cursor) && clipboard.slices.count == 1 && !clipboard.slices[0].was_selected {
             line_num   := offset_to_line(buffer, cursor.pos); 
             line_start := get_line_start_offset(buffer, line_num);
-            str        := global_clipboard;
+            str        := clipboard.text;
             
             // insert_string_at_offset() make the buffer dirty
             // we rescan to clean it else we can't call offset_to_line for the next cursors
@@ -2213,12 +2213,12 @@ paste_from_clipboard :: (editor: *Editor, buffer: *Buffer) {
             add_paste_animation(editor, .{ line_start, line_start + cast(s32) str.count });
         } 
         // If they have the same number of entries paste one slice per cursor
-        else if editor.cursors.count == global_clipboard_slices.count {
-            clipboard_slice := global_clipboard_slices[it_index];
+        else if editor.cursors.count == clipboard.slices.count {
+            clipboard_slice := clipboard.slices[it_index];
             selection       := get_selection(cursor);
             count           := clipboard_slice.count - 1; // Don't paste the last newline of the slice
-            if it_index == global_clipboard_slices.count - 1 && clipboard_slice.was_selected then clipboard_slice.count += 1; // If the last slice was selected, it didn't have newline
-            str             := slice(global_clipboard, clipboard_slice.start, count); 
+            if it_index == clipboard.slices.count - 1 && clipboard_slice.was_selected then clipboard_slice.count += 1; // If the last slice was selected, it didn't have newline
+            str             := slice(clipboard.text, clipboard_slice.start, count); 
 
             replace_range(buffer, selection, str);
 
@@ -2229,7 +2229,7 @@ paste_from_clipboard :: (editor: *Editor, buffer: *Buffer) {
         // Paste the entire clipboard for each cursor
         else {
             selection := get_selection(cursor);
-            str       := global_clipboard;
+            str       := clipboard.text;
 
             replace_range(buffer, selection, str);
 
@@ -2483,8 +2483,10 @@ editors: Editor_State;
 editor_history: Editor_History;
 current_editor_history_size := -1;
 
-global_clipboard: string;
-global_clipboard_slices: [..] Clipboard_Slice;
+clipboard: struct {
+    text: string;
+    slices: [..] Clipboard_Slice;
+}
 
 Clipboard_Slice :: struct {
     start: s32; 


### PR DESCRIPTION
Correct a bug when copy pasting with the same number of cursors if you set them up yourself (inside the same editor or in two different editors)

Previous:
![1](https://github.com/focus-editor/focus/assets/30574115/80887641-fa28-48a2-b0e6-501c37748308)

Now:
![2](https://github.com/focus-editor/focus/assets/30574115/62e1e871-0d58-4949-bb14-99aa564e0bdd)

To allow this, clipboard is now global to the application and not contained in editor state same for "global_clipboard_slices" which represent what previously was  "cursor clipboard".

Overall reduction of code complexity for clipboard handling.