### PR TITLE
Linux: implement wait_message for X11 and Wayland

### DIFF
--- a/modules/Linux_Display/ldw_input.jai
+++ b/modules/Linux_Display/ldw_input.jai
@@ -253,39 +253,6 @@ pointer_listener :: wl_pointer_listener.{
 };
 
 wl_update_window_events :: (display: *WLDisplay) {
-    display_poll :: (display: *WLDisplay) -> s32 {
-        wlfd := wl_display.get_fd(display.handle);
-
-        pfd: [2]pollfd;
-        pfd[0].fd = wlfd;
-        pfd[0].events = POLLIN;
-        pfd[1].fd = display.epfd;
-        pfd[1].events = POLLIN;
-
-        ret := poll(pfd.data, 2, 5);
-        if ret <= 0 return ret;
-
-        has_wayland_events := false;
-        for 0..1 {
-            if !pfd[it].revents {
-                continue;
-            }
-            if pfd[it].fd == wlfd {
-                has_wayland_events = true;
-                continue;
-            }
-
-            assert(pfd[it].fd == display.epfd);
-            ev: epoll_event;
-            count := epoll_wait(display.epfd, *ev, 1, -1);
-            assert(count == 1);
-
-            if wl_tick_timers(display, ev.data.fd) continue;
-        }
-
-        return ifx has_wayland_events then cast(s32) 1 else 0;
-    }
-
     wl_display.flush(display.handle);
     if wl_display.prepare_read(display.handle) == 0 {
         err := display_poll(display);
@@ -312,8 +279,48 @@ wl_get_mouse_pointer_position :: (right_handed: bool) -> x: int, y: int, success
     return 0, 0, false;
 }
 
+wl_wait_message :: (wl_display: *WLDisplay) {
+    while !display_poll(wl_display) {
+        sleep_milliseconds(10);
+    }
+}
+
+
 #scope_file
 #import "POSIX";
 #import "libxkbcommon";
 
 current_hovered_window: *WLWindow;
+
+display_poll :: (display: *WLDisplay) -> s32 {
+    wlfd := wl_display.get_fd(display.handle);
+
+    pfd: [2]pollfd;
+    pfd[0].fd = wlfd;
+    pfd[0].events = POLLIN;
+    pfd[1].fd = display.epfd;
+    pfd[1].events = POLLIN;
+
+    ret := poll(pfd.data, 2, 5);
+    if ret <= 0 return ret;
+
+    has_wayland_events := false;
+    for 0..1 {
+        if !pfd[it].revents {
+            continue;
+        }
+        if pfd[it].fd == wlfd {
+            has_wayland_events = true;
+            continue;
+        }
+
+        assert(pfd[it].fd == display.epfd);
+        ev: epoll_event;
+        count := epoll_wait(display.epfd, *ev, 1, -1);
+        assert(count == 1);
+
+        if wl_tick_timers(display, ev.data.fd) continue;
+    }
+
+    return ifx has_wayland_events then cast(s32) 1 else 0;
+}

--- a/modules/Linux_Display/ldx_input.jai
+++ b/modules/Linux_Display/ldx_input.jai
@@ -436,6 +436,13 @@ x11_clipboard_set_bitmap :: (width: s32, height: s32, rgb: *u8) {
     x11_clipboard_set_bitmap(win, width, height, rgb);
 }
 
+x11_wait_message :: (x11_display: *X11Display) {
+    handle := x11_display.handle;
+    while !XEventsQueued(handle, QueuedAfterReading){
+      sleep_milliseconds(10);
+    }
+}
+
 #scope_file
 // Xdnd support by Jens Frederich. Send questions his way. Licensed under the MIT license; see copyright at the end
 // of the file.

--- a/modules/Linux_Display/module.jai
+++ b/modules/Linux_Display/module.jai
@@ -291,6 +291,15 @@ clipboard_set_text :: (text: string) {
     }
 }
 
+wait_message :: () {
+    if global_display.tag == {
+        case X11Display; x11_wait_message(isa(global_display, X11Display));
+        case WLDisplay; wl_wait_message(isa(global_display, WLDisplay));
+        case;
+    }
+}
+
+
 // Fonts
 find_font :: (name: string, allocator := temp) -> bool, string {
     ok, path := fc_find_font(name, allocator);

--- a/src/main.jai
+++ b/src/main.jai
@@ -128,21 +128,6 @@ main :: () {
         screen_with_title_bar := screen;
         screen_with_title_bar.h += 200;  // should be enough to include the title bar
 
-        #if OS != .WINDOWS {
-            if !Input.input_application_has_focus {
-                // Avoid changing the cursor when the window is not in Focus.
-                // This also fixes the Cmd+Tab cursor-spawning issue where the window still thinks Cmd is held down.
-                sleep_milliseconds(1);
-                continue;
-            }
-
-            // Try to avoid hot-looping on Linux/macOS
-            if !redraw_requested && !Input.events_this_frame.count && !mouse.moved_this_frame {
-                sleep_milliseconds(1);
-                continue;
-            }
-        }
-
         // NOTE: this optimisation has caused some problems, so commenting it out for now
         // // Don't redraw if we're mousing around outside the window
         // if !redraw_requested

--- a/src/platform/linux.jai
+++ b/src/platform/linux.jai
@@ -183,6 +183,7 @@ platform_set_window_title :: (title: string) {
 }
 
 platform_wait_message :: inline () {
+    LD.wait_message();
 }
 
 platform_set_refresh_timer :: (window: Window_Type) {


### PR DESCRIPTION
It's not ideal solution, but I would argue that it's much better solution that existing solution.
Downsides: 
 - up to 10ms delay on keystroke
 - still polling the OS (X11 or Wayland) for events, but with much lower frequency than before
 - no MacOS wait_message implementation

Upsides:
 - don't sleep if redraw_requested (no lags)
 - much less CPU consumption when idle
 - removed platform-dependent delays in main loop (could be bad for MacOS, since it has no wait_message implementation)
