### PR TITLE
Only sleep when there's nothing else to do this frame

### DIFF
--- a/src/main.jai
+++ b/src/main.jai
@@ -135,15 +135,17 @@ main :: () {
         screen_with_title_bar.h += 200;  // should be enough to include the title bar
 
         #if OS != .WINDOWS {
-            if !Input.input_application_has_focus {
-                // Avoid changing the cursor when the window is not in Focus.
-                // This also fixes the Cmd+Tab cursor-spawning issue where the window still thinks Cmd is held down.
+            nothing_to_do_this_frame := !redraw_requested && !Input.events_this_frame.count && !mouse.moved_this_frame;
+
+            if !Input.input_application_has_focus && nothing_to_do_this_frame {
+                // Avoid changing the cursor when the window is not in Focus, but only when we don't have anything else to
+                // do this frame. This also fixes the Cmd+Tab cursor-spawning issue where the window still thinks Cmd is held down.
                 sleep_milliseconds(1);
                 continue;
             }
 
             // Try to avoid hot-looping on Linux/macOS
-            if !redraw_requested && !Input.events_this_frame.count && !mouse.moved_this_frame {
+            if nothing_to_do_this_frame {
                 sleep_milliseconds(1);
                 continue;
             }


### PR DESCRIPTION
Even when the window doesn't have focus, let it exhaust the event queue first. At least on X11, when you press the window manager's/DE's "close window" shortcut, it sends DestroyWindow event and FocusOut event right away, so the editor records `.QUIT` event and then sets `input_application_has_focus` to false right away, which prevents `.QUIT` event to be handled this frame and it gets lost, so you can't close the editor unless you press close combination from your config.

Hopefully, this doesn't conflict with the initial purpose of sleeping when the application loses focus