### PR TITLE
Force a redraw on non-Windows when the editor window focus changes

### DIFF
--- a/modules/Linux_Display/ldx_input.jai
+++ b/modules/Linux_Display/ldx_input.jai
@@ -327,12 +327,19 @@ x11_handle_event :: (display: *Display, xev: *XEvent) {
             config := cast(*XConfigureEvent) xev;
             ld_win := get_by_native_handle(xx config.window);
             if ld_win add_resize_record(ld_win, config.width, config.height);
+        // Adding a dummy event to the queue, forcing a redraw when window's focus
+        // changes or it gets exposed (e.g. it's being asked to render itself but without
+        // it getting focus)
         case FocusIn;
             input_application_has_focus = true;
             XSetICFocus(win.ic);
+            array_add(*events_this_frame, .{type=.WINDOW});
         case FocusOut;
             input_application_has_focus = false;
             XUnsetICFocus(win.ic);
+            array_add(*events_this_frame, .{type=.WINDOW});
+        case Expose;
+            array_add(*events_this_frame, .{type=.WINDOW});
     }
 }
 


### PR DESCRIPTION
If we don't do this, the editor window doesn't render itself right after it goes into focus and stays in the broken state until a user makes an actual keyboard input or waves a mouse over it. Not sure if it consistently happens in all desktop environments, but it's very easy to get into in tiling wms, when you switch from some other workspace to a workspace with the editor in it without further keyboard or mouse movements.
For example, here's how it might look:
![image](https://github.com/focus-editor/focus/assets/7038954/15faa2e7-ecda-4b13-ad31-6c59e4a1eccf)

The bottom part of the screen supposed to be Focus. If you move mouse cursor over it, it detects an input and renders:
![image](https://github.com/focus-editor/focus/assets/7038954/f279ef74-76ec-49aa-8e40-c16870eda9c2)

This PR fixes that, forcing a redraw when a window focus changes compared to the previous frame.

I guess in the future we will have a better event loop for linux that will both not hog CPU and won't require this level of scrutiny over redrawing the window, but for now it's a cheap fix to remove quite some pain 