### PR TITLE
Fixed compiler errors introduced by the new arithmetic overflow checks.

### DIFF
--- a/first.jai
+++ b/first.jai
@@ -30,6 +30,7 @@ build :: () {
             options.array_bounds_check = .ON;
             options.null_pointer_check = .ON;
           case "debug";
+            options.arithmetic_overflow_check = .FATAL;
           case;
             compiler_report(tprint("Command-line argument #%, '%', is invalid. Valid options are: 'debug', 'release'.\n", it_index+1, arg));
         }

--- a/first.jai
+++ b/first.jai
@@ -19,6 +19,7 @@ build :: () {
     optimized := false;
     options.output_executable_name = "focus_debug";
     set_optimization(*options, .DEBUG);
+    options.arithmetic_overflow_check = .FATAL;
 
     for arg: args {
         if arg == {
@@ -29,8 +30,8 @@ build :: () {
             options.output_executable_name = "focus";
             options.array_bounds_check = .ON;
             options.null_pointer_check = .ON;
+            options.arithmetic_overflow_check = .OFF;
           case "debug";
-            options.arithmetic_overflow_check = .FATAL;
           case;
             compiler_report(tprint("Command-line argument #%, '%', is invalid. Valid options are: 'debug', 'release'.\n", it_index+1, arg));
         }

--- a/modules/Runtime_Support.jai
+++ b/modules/Runtime_Support.jai
@@ -272,6 +272,37 @@ __null_pointer_check_fail :: (index: s64, line_number: s64, filename: *u8) #no_c
     my_panic();
 }
 
+__arithmetic_overflow :: (left: s64, right: s64, type_code: u16, line_number: s64, filename: *u8) #no_context #no_aoc {
+    // We have some free bits in type_code...!
+    fatal  := (type_code & 0x8000);
+    signed := (type_code & 0x4000);
+    operator_index := (type_code >> 7) & 0x3;
+    size := (cast(u64)(type_code & 0x000f))*8;
+
+    signed_string := ifx signed then "s" else "u";
+    operator_string := " / ";
+    
+    if      operator_index == 1 then operator_string = " + ";
+    else if operator_index == 2 then operator_string = " - ";
+    else if operator_index == 3 then operator_string = " * ";
+    
+    write_string("Arithmetic overflow. We tried to compute:\n    ", to_standard_error = true);
+
+    if signed  write_number(left, to_standard_error = true);
+    else       write_nonnegative_number(cast,no_check(u64)left, to_standard_error = true);
+
+    write_string(operator_string, to_standard_error = true);
+    
+    if signed  write_number(right, to_standard_error = true);
+    else       write_nonnegative_number(cast,no_check(u64)right, to_standard_error = true);
+    
+    write_strings("\nThe operand type is ", signed_string, to_standard_error = true);
+    write_nonnegative_number(size, to_standard_error = true);
+    write_string(", but the result does not fit into this type.\n", to_standard_error = true);
+    
+    if fatal my_panic();
+}
+
 __relative_pointer_bounds_check_fail :: (delta: s64, size: u8, line_number: s64, filename: *u8) #no_context {
     // @Volatile: It is a good idea for these to match the error reports in constant-expression evaluation inside the compiler.
     upper_limit := (1 << (size * 8 - 1)) - 1;

--- a/src/main.jai
+++ b/src/main.jai
@@ -751,7 +751,7 @@ File_Async :: #import "File_Async";
 Simp  :: #import "Simp";
 Input :: #import "Input";
 
-DEBUG :: #run get_build_options().math_bounds_check == .FATAL;  // this is a sloppy way of checking whether we're in debug mode!
+DEBUG :: #run get_build_options().arithmetic_overflow_check == .FATAL;  // this is a sloppy way of checking whether we're in debug mode!
 
 MAX_BUFFER_SIZE_FOR_HIGHLIGHTS :: 5 * 1024 * 1024;
 


### PR DESCRIPTION
Tried compiling with compiler version 0.1.71 and the new arithmetic bounds checks broke some code that relied on the old math bounds check. Also turned on the arithmetic overflow check for debug builds.