### PR TITLE
Preload cursors on X11 so you don't have to load them every time

### DIFF
--- a/modules/Linux_Display/ldx_display.jai
+++ b/modules/Linux_Display/ldx_display.jai
@@ -22,6 +22,12 @@ X11Window :: struct {
     glx_win: GLXWindow;
 }
 
+x_cursors: Table(string, Cursor);
+preloaded_x_cursors :: string.[
+    "default", "pointer", "not-allowed", "col-resize", "row-resize",
+    "all-scroll", "nw-resize", "se-resize", "text",
+];
+
 x11_init_display :: (display: LDDisplay) -> bool {
     current_locale := setlocale(LC_ALL, null);
     current_xmods  := XSetLocaleModifiers(null);
@@ -59,6 +65,12 @@ x11_init_display :: (display: LDDisplay) -> bool {
         if lib != null {
             XcursorLibraryLoadCursor = xx dlsym(lib, "XcursorLibraryLoadCursor");
             xcursor_initialized = (XcursorLibraryLoadCursor != null);
+            if xcursor_initialized {
+                init(*x_cursors);
+                for preloaded_x_cursors {
+                    table_add(*x_cursors, it, XcursorLibraryLoadCursor(x_global_display, it.data));
+                }
+            }
         }
     }
 
@@ -297,8 +309,10 @@ x11_set_icon_from_raw_data :: (win: X11Window, data: *u8, width: u32, height: u3
 
 x11_set_cursor_from_theme :: (win: *X11Window, name: string) {
     if xcursor_initialized {
-        cursor := XcursorLibraryLoadCursor(win.display.handle, name.data);
-        XDefineCursor(win.display.handle, win.handle, cursor);
+        cursor, found := table_find(*x_cursors, name);
+        if found {
+            XDefineCursor(win.display.handle, win.handle, cursor);
+        }
     }
 }
 

--- a/src/pointer_image.jai
+++ b/src/pointer_image.jai
@@ -79,20 +79,16 @@ Pointer_Image :: enum u16 {
     }
 
     pointers: [NUM_POINTERS] *NSCursor;
-} else {
+} else #if OS == .LINUX {
     LD :: #import "Linux_Display";
 
     set_pointer_image :: (image: Pointer_Image) {
-        if image == {
-            case .NORMAL; LD.set_cursor_from_theme(window, "default");
-            case .PRESSABLE; LD.set_cursor_from_theme(window, "pointer");
-            case .LOCKED; LD.set_cursor_from_theme(window, "not-allowed");
-            case .DRAGGING_HORIZONTAL; LD.set_cursor_from_theme(window, "col-resize");
-            case .DRAGGING_VERTICAL; LD.set_cursor_from_theme(window, "row-resize");
-            case .DRAGGING_FREE; LD.set_cursor_from_theme(window, "all-scroll");
-            case .DRAGGING_NW_SE; LD.set_cursor_from_theme(window, "nw-resize");
-            case .DRAGGING_NE_SW; LD.set_cursor_from_theme(window, "se-resize");
-            case .TEXT_SELECT; LD.set_cursor_from_theme(window, "text");
+        if (image >= 0) && (image <= cast(Pointer_Image) NUM_POINTERS) {
+            current_pointer_image = image;
+            pointer_image_was_set_this_frame = true;
+            already_reset_pointer_image = (image == .NORMAL);  // No need to reset the image if it was set to NORMAL.
+        } else {
+            log_error("Invalid pointer index %\n", image);
         }
     }
 }
@@ -111,6 +107,18 @@ pointer_end_frame :: () {
             Windows.SetCursor(pointers[current_pointer_image]);
         } else #if OS == .MACOS {
             NSCursor.set(pointers[current_pointer_image]);
+        } else #if OS == .LINUX {
+            if current_pointer_image == {
+                case .NORMAL; LD.set_cursor_from_theme(window, "default");
+                case .PRESSABLE; LD.set_cursor_from_theme(window, "pointer");
+                case .LOCKED; LD.set_cursor_from_theme(window, "not-allowed");
+                case .DRAGGING_HORIZONTAL; LD.set_cursor_from_theme(window, "col-resize");
+                case .DRAGGING_VERTICAL; LD.set_cursor_from_theme(window, "row-resize");
+                case .DRAGGING_FREE; LD.set_cursor_from_theme(window, "all-scroll");
+                case .DRAGGING_NW_SE; LD.set_cursor_from_theme(window, "nw-resize");
+                case .DRAGGING_NE_SW; LD.set_cursor_from_theme(window, "se-resize");
+                case .TEXT_SELECT; LD.set_cursor_from_theme(window, "text");
+            }
         }
     }
 


### PR DESCRIPTION
At the moment, every time the editor calls `set_pointer_image`, X11 backend loads and sets the cursor image. It both slows the editor down a lot and makes the cursor flicker constantly. With this PR, we preload X11 cursors during display initialization, when we load libXcursor, and we only set a new cursor when it actually changes, generating way fewer CursorNotify events