### PR TITLE
Add "Save as" and "Delete current file" functionality

### DIFF
--- a/src/buffer.jai
+++ b/src/buffer.jai
@@ -421,10 +421,10 @@ recalculate_colors :: (buffer: *Buffer) {
     }
 }
 
-save_buffer_to_disk :: (using buffer: *Buffer, buffer_id: s64) -> saved: bool {
+save_buffer_to_disk :: (using buffer: *Buffer, buffer_id: s64, save_new_file := false) -> saved: bool {
     if readonly return false;
 
-    if !has_file {
+    if save_new_file || !has_file {
         file_path, success := platform_get_save_file_name(get_buffer_name(buffer));
         if success && file_path {
             has_file = true;

--- a/src/buffer.jai
+++ b/src/buffer.jai
@@ -421,50 +421,88 @@ recalculate_colors :: (buffer: *Buffer) {
     }
 }
 
-save_buffer_to_disk :: (using buffer: *Buffer, buffer_id: s64, save_new_file := false) -> saved: bool {
+save_buffer_to_new_file_on_disk :: (buffer: *Buffer, buffer_id: s64) -> saved: bool {
+    if buffer.readonly return false;
+
+    file_path, success := platform_get_save_file_name(get_buffer_name(buffer));
+    if !(success && file_path) {
+        return false;
+    }
+
+    // Save the file BEFORE making a new buffer so find_or_create_buffer can find it
+    if config.settings.strip_trailing_whitespace_on_save then strip_trailing_whitespace(buffer, buffer_id);
+
+    success = write_entire_file(file_path, to_string(buffer.bytes));
+    if !success then return false;
+
+    new_id, created := find_or_create_buffer(file_path);
+    redraw_requested = true;
+
+    // Reroute all editors using the old id
+    for * editor : open_editors {
+        if editor.buffer_id == buffer_id {
+            editor.buffer_id = new_id;
+            editor.scroll_to_cursor = .yes;
+            for * cursor : editor.cursors { put_cursor_in_valid_spot(cursor, buffer); }
+            organise_cursors(editor);
+        }
+    }
+
+    if !file_is_watched(file_path) then start_watching_file(file_path);
+    update_window_title(open_editors[editors.active].buffer_id);
+
+    return true;
+}
+
+save_buffer_to_disk :: (using buffer: *Buffer, buffer_id: s64) -> saved: bool {
     if readonly return false;
 
-    if save_new_file || !has_file {
+    if !has_file {
+        // Save new file buffer
         file_path, success := platform_get_save_file_name(get_buffer_name(buffer));
-        if success && file_path {
-            has_file = true;
-            file = get_file_info_from_full_path(file_path);
-            set_lang_from_path(buffer, file_path);
-            needs_coloring = true;
-            redraw_requested = true;
+        if !(success && file_path) {
+            return false;
+        }
 
-            lock(*open_buffers_lock);
+        has_file = true;
+        file = get_file_info_from_full_path(file_path);
+        set_lang_from_path(buffer, file_path);
+        needs_coloring = true;
+        redraw_requested = true;
+
+        lock(*open_buffers_lock);
+        {
             existing_buffer_id, found_existing := table_find(*buffers_table, file_path);
-            if found_existing && buffer_id != existing_buffer_id {
-                // The user chose to save the new buffer into an existing file. OK.
-                // Mark the old buffer as deleted and use the new one
-                removed := table_remove(*buffers_table, file_path);
-                assert(removed, "For some reason table_remove failed. This is a very unexpected bug.");
-                existing_buffer := *open_buffers[existing_buffer_id];
-                existing_buffer.deleted  = true;
-                existing_buffer.modified = false;
-                existing_buffer.modified_on_disk = false;
+            if found_existing {
+                if buffer_id != existing_buffer_id {
+                    // The user chose to save the new buffer into an existing file. OK.
+                    // Mark the old buffer as deleted and use the new one
+                    removed := table_remove(*buffers_table, file_path);
+                    assert(removed, "For some reason table_remove failed. This is a very unexpected bug.");
+                    existing_buffer := *open_buffers[existing_buffer_id];
+                    existing_buffer.deleted  = true;
+                    existing_buffer.modified = false;
+                    existing_buffer.modified_on_disk = false;
 
-                // Reroute all editors which use it to the new buffer id
-                for * editor : open_editors {
-                    if editor.buffer_id == existing_buffer_id {
-                        editor.buffer_id = buffer_id;
-                        editor.scroll_to_cursor = .yes;
-                        for * cursor : editor.cursors { put_cursor_in_valid_spot(cursor, buffer); }
-                        organise_cursors(editor);
+                    // Reroute all editors which use it to the new buffer id
+                    for * editor : open_editors {
+                        if editor.buffer_id == existing_buffer_id {
+                            editor.buffer_id = buffer_id;
+                            editor.scroll_to_cursor = .yes;
+                            for * cursor : editor.cursors { put_cursor_in_valid_spot(cursor, buffer); }
+                            organise_cursors(editor);
+                        }
                     }
+                } else {
+                    assert(false, "Buffer without a file somehow got into the buffers hash table. This is a bug.");
                 }
-            } else if found_existing && buffer_id == existing_buffer_id {
-                assert(false, "Buffer without a file somehow got into the buffers hash table. This is a bug.");
             }
 
             table_add(*buffers_table, copy_string(file_path), buffer_id);
-            unlock(*open_buffers_lock);
-
-            if !file_is_watched(file_path) start_watching_file(file_path);
-        } else {
-            return false;
         }
+        unlock(*open_buffers_lock);
+
+        if !file_is_watched(file_path) then start_watching_file(file_path);
     }
 
     if config.settings.strip_trailing_whitespace_on_save then strip_trailing_whitespace(buffer, buffer_id);
@@ -483,10 +521,34 @@ save_buffer_to_disk :: (using buffer: *Buffer, buffer_id: s64, save_new_file := 
         error_when_saving = true;
     }
     remember_last_modtime_and_size(buffer);
-
     update_window_title(open_editors[editors.active].buffer_id);
 
     return !error_when_saving;
+}
+
+delete_buffer_from_disk :: (using buffer: *Buffer) -> deleted: bool {
+    if readonly  return false;
+    if !has_file return false;
+
+    file_path := buffer.file.full_path;
+
+    success := file_delete(file_path);
+    if !success then return false;
+
+    deleted          = true;
+    has_file         = false;
+    modified         = false;
+    modified_on_disk = false;
+
+    lock(*open_buffers_lock);
+    {
+        removed := table_remove(*buffers_table, file_path);
+        assert(removed, "For some reason table_remove failed. This is a very unexpected bug.");
+    }
+    unlock(*open_buffers_lock);
+
+    if file_is_watched(file_path) then stop_watching_file(file_path);
+    return true;
 }
 
 strip_trailing_whitespace :: (using buffer: *Buffer, buffer_id: s64) {
@@ -680,7 +742,9 @@ find_or_create_buffer :: (path: string) -> buffer_id: s64, created: bool {
 }
 
 get_buffer_name :: (buffer: Buffer) -> string {
-    if buffer.has_file return buffer.file.name;
+    // NOTE: After deleting using "Delete Current File", `has_file` could be false while buffer.file still exists (because we don't override it).
+    //       So if we fail the `has_file` check, check the `file.full_path` as well to see if there is still a valid name that the buffer can draw.
+    if buffer.has_file || buffer.file.full_path return buffer.file.name;
 
     for 0..buffer.line_starts.count-2 {
         line := trim(get_real_line_as_string(buffer, xx it), "\t \r\n");

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -1818,7 +1818,9 @@ draw_delete_file_dialog :: () {
         push_scissor(buffers_rect);
         defer pop_scissor();
 
-        buffer := get_buffer_to_delete();
+        // Not locking here because we're not modifying the buffer
+        buffer_id := get_buffer_id_to_delete();
+        buffer    := open_buffers[buffer_id];
 
         entry_rect := cut_top(buffers_rect, entry_height);
         {

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -1820,7 +1820,7 @@ draw_delete_file_dialog :: () {
 
         // Not locking here because we're not modifying the buffer
         buffer_id := get_buffer_id_to_delete();
-        buffer    := open_buffers[buffer_id];
+        buffer    := *open_buffers[buffer_id];
 
         entry_rect := cut_top(buffers_rect, entry_height);
         {

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -61,11 +61,12 @@ draw_frame :: () {
 
     if active_global_widget == {
         case .open_file_dialog;         draw_open_file_dialog();
+        case .delete_file_dialog;       draw_delete_file_dialog();
         case .finder;                   draw_finder();
         case .go_to_line_dialog;        draw_go_to_line_dialog(active_pane_rect);
+        case .open_project_dialog;      draw_open_project_dialog();
         case .unsaved_buffers_dialog;   draw_unsaved_buffers_dialog();
         case .commands_dialog;          draw_commands_dialog();
-        case .open_project_dialog;      draw_open_project_dialog();
     }
 
     draw_user_messages(screen, footer_height);
@@ -1773,6 +1774,91 @@ draw_commands_dialog :: () {
     }
 }
 
+draw_delete_file_dialog :: () {
+    ui_id := Ui_Id.delete_file_dialog;
+
+    margin  := floor(12 * dpi_scale);
+    padding := floor( 4 * dpi_scale);
+    entry_height  := font_ui_line_height + padding * 2;
+    button_height := font_ui_medium_line_height + 2 * padding;
+    header_height := font_ui_medium_line_height + 2 * margin + 4 * dpi_scale;
+
+    box_rect := Rect.{
+        w = floor(clamp(screen.w * 0.3, 600 * dpi_scale, 1500 * dpi_scale)),
+        h = header_height + (entry_height + margin / 2) + margin + padding + button_height + margin,
+    };
+    box_rect.x = floor((screen.w - box_rect.w) / 2);
+    box_rect.y = screen.h - box_rect.h - floor(clamp(100 * dpi_scale, 0, (screen.h - box_rect.h) / 2));
+
+    maybe_set_hot_or_active(ui_id, box_rect, .NORMAL);
+
+    draw_rounded_rect_with_shadow(box_rect, Colors.BACKGROUND_LIGHT);
+
+    header_rect, buffers_rect := cut_top(box_rect, header_height);
+    buffers_rect = shrink(buffers_rect, margin);
+
+     // Header
+    {
+        push_scissor(header_rect);
+        defer pop_scissor();
+
+        draw_rounded_rect_with_corners(header_rect, Colors.BACKGROUND_BRIGHT, tl = .in, tr = .in, br = .none, bl = .none);
+
+        pen_x := cast(s32) (header_rect.x + 2 * margin);
+        pen_y := cast(s32) (header_rect.y + (header_rect.h - font_ui_medium.character_height) / 2 + 2);
+        header_text := "Are you sure you want to delete this file?";
+        Simp.draw_text(font_ui_medium, pen_x, pen_y, header_text, Colors.UI_DEFAULT);
+
+        hr := cut_bottom(header_rect, 1);
+        draw_rect(hr, Colors.BACKGROUND_DARK);
+    }
+
+    // File to delete
+    {
+        push_scissor(buffers_rect);
+        defer pop_scissor();
+
+        buffer := get_buffer_to_delete();
+
+        entry_rect := cut_top(buffers_rect, entry_height);
+        {
+            push_scissor(entry_rect);
+            defer pop_scissor();
+
+            pen := Vector2.{
+                x = entry_rect.x + margin,
+                y = entry_rect.y + (entry_rect.h - font_ui.character_height) / 2 + 2 * dpi_scale,
+            };
+            width: float;
+
+            width, _ = draw_file_info(buffer, width, padding, pen);
+        }
+
+        entry_rect.y -= entry_rect.h + margin / 2;
+    }
+
+    // Buttons
+    {
+        buttons_row_rect := cut_bottom(buffers_rect, button_height);
+
+        cancel_button, delete_button: Rect;
+
+        activated, width := draw_button(font_ui, "Cancel", Colors.UI_NEUTRAL, Colors.UI_DEFAULT, ui_id, buttons_row_rect, .right, margin / 2, margin);
+        if activated close_delete_file_dialog();
+
+        buttons_row_rect.w -= width + margin;
+
+        activated, width = draw_button(font_ui, "Delete", Colors.UI_ERROR, Colors.UI_DEFAULT, ui_id, buttons_row_rect, .right, margin / 2, margin);
+        if activated delete_buffer_file_and_update_editor();
+    }
+
+    if ui.active != .none && ui.active != ui_id && !is_child(ui.active, ui_id) {
+        // Close the dialog on clicks elsewhere
+        close_delete_file_dialog();
+        return;
+    }
+}
+
 draw_open_project_dialog :: () {
     using open_project_dialog;
 
@@ -1989,7 +2075,7 @@ draw_unsaved_buffers_dialog :: () {
                 };
                 width: float;
 
-                width, pen = draw_file_info(buffer, width, padding, pen);
+                width, _ = draw_file_info(buffer, width, padding, pen);
             }
 
             entry_rect.y -= entry_rect.h + margin / 2;
@@ -2832,6 +2918,7 @@ Ui_Id :: enum s64 {
     unsaved_buffers     :: -10;
     commands_dialog     :: -11;
     open_project_dialog :: -12;
+    delete_file_dialog  :: -13;
 
     // The rest will be derived from loc
 }

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -151,7 +151,7 @@ active_editor_handle_event :: (event: Input.Event, action: Action_Editors) -> ha
         case .save;                             save_buffer(editor, buffer);
         case .save_as;                          save_buffer(editor, buffer, save_new_file = true);
         case .save_all;                         save_all   (editor, buffer);
-        case .delete_current_file;              show_delete_file_dialog(editor, buffer);
+        case .delete_current_file;              show_delete_file_dialog(editor);
         case .switch_to_left_editor;            switch_to_editor(.left);
         case .switch_to_right_editor;           switch_to_editor(.right);
         case .switch_to_other_editor;           switch_to_editor(.other);
@@ -1191,7 +1191,7 @@ save_buffer :: (editor: *Editor, buffer: *Buffer, save_new_file := false) {
 
     if buffer.has_file {
         maybe_mark_buffer_as_deleted(editor.buffer_id);   // check in case we missed that it's deleted
-        session_notify_modified_buffer(editor.buffer_id); // @Cleanup? This doesn't seem to do anything.
+        session_notify_modified_buffer(editor.buffer_id);
     }
 
     if save_new_file then save_buffer_to_new_file_on_disk(buffer, editor.buffer_id);

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -151,7 +151,7 @@ active_editor_handle_event :: (event: Input.Event, action: Action_Editors) -> ha
         case .save;                             save_buffer(editor, buffer);
         case .save_as;                          save_buffer(editor, buffer, save_new_file = true);
         case .save_all;                         save_all   (editor, buffer);
-        case .delete_current_file;              delete_buffer_file(editor, buffer);
+        case .delete_current_file;              show_delete_file_dialog(editor, buffer);
         case .switch_to_left_editor;            switch_to_editor(.left);
         case .switch_to_right_editor;           switch_to_editor(.right);
         case .switch_to_other_editor;           switch_to_editor(.other);
@@ -1196,15 +1196,6 @@ save_buffer :: (editor: *Editor, buffer: *Buffer, save_new_file := false) {
 
     if save_new_file then save_buffer_to_new_file_on_disk(buffer, editor.buffer_id);
     else                  save_buffer_to_disk(buffer, editor.buffer_id);
-}
-
-delete_buffer_file :: (editor: *Editor, buffer: *Buffer) {
-    if !buffer.has_file then return;
-    new_edit_group(buffer, editor);
-
-    _ := delete_buffer_from_disk(buffer);               // TODO: handle delete fail
-    maybe_mark_buffer_as_deleted(editor.buffer_id);     // check in case we missed that it's deleted
-    session_notify_modified_buffer(editor.buffer_id);   // @Cleanup? This doesn't seem to do anything.
 }
 
 save_all :: (editor: *Editor, buffer: *Buffer) {

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -149,6 +149,7 @@ active_editor_handle_event :: (event: Input.Event, action: Action_Editors) -> ha
         case .close_left_editor;                close_editor(.left);
         case .close_right_editor;               close_editor(.right);
         case .save;                             save_buffer(editor, buffer);
+        case .save_as;                          save_buffer(editor, buffer, save_new_file = true);
         case .save_all;                         save_all   (editor, buffer);
         case .switch_to_left_editor;            switch_to_editor(.left);
         case .switch_to_right_editor;           switch_to_editor(.right);
@@ -1184,14 +1185,14 @@ select_word_or_create_another_cursor :: (using editor: *Editor, buffer: Buffer) 
     return editor.search_whole_words;
 }
 
-save_buffer :: (editor: *Editor, buffer: *Buffer) {
+save_buffer :: (editor: *Editor, buffer: *Buffer, save_new_file := false) {
     new_edit_group(buffer, editor);
 
     if buffer.has_file {
         maybe_mark_buffer_as_deleted(editor.buffer_id);  // check in case we missed that it's deleted
         session_notify_modified_buffer(editor.buffer_id);
     }
-    save_buffer_to_disk(buffer, editor.buffer_id);
+    save_buffer_to_disk(buffer, editor.buffer_id, save_new_file);
 }
 
 save_all :: (editor: *Editor, buffer: *Buffer) {

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -151,6 +151,7 @@ active_editor_handle_event :: (event: Input.Event, action: Action_Editors) -> ha
         case .save;                             save_buffer(editor, buffer);
         case .save_as;                          save_buffer(editor, buffer, save_new_file = true);
         case .save_all;                         save_all   (editor, buffer);
+        case .delete_current_file;              delete_buffer_file(editor, buffer);
         case .switch_to_left_editor;            switch_to_editor(.left);
         case .switch_to_right_editor;           switch_to_editor(.right);
         case .switch_to_other_editor;           switch_to_editor(.other);
@@ -1189,18 +1190,29 @@ save_buffer :: (editor: *Editor, buffer: *Buffer, save_new_file := false) {
     new_edit_group(buffer, editor);
 
     if buffer.has_file {
-        maybe_mark_buffer_as_deleted(editor.buffer_id);  // check in case we missed that it's deleted
-        session_notify_modified_buffer(editor.buffer_id);
+        maybe_mark_buffer_as_deleted(editor.buffer_id);   // check in case we missed that it's deleted
+        session_notify_modified_buffer(editor.buffer_id); // @Cleanup? This doesn't seem to do anything.
     }
-    save_buffer_to_disk(buffer, editor.buffer_id, save_new_file);
+
+    if save_new_file then save_buffer_to_new_file_on_disk(buffer, editor.buffer_id);
+    else                  save_buffer_to_disk(buffer, editor.buffer_id);
+}
+
+delete_buffer_file :: (editor: *Editor, buffer: *Buffer) {
+    if !buffer.has_file then return;
+    new_edit_group(buffer, editor);
+
+    _ := delete_buffer_from_disk(buffer);               // TODO: handle delete fail
+    maybe_mark_buffer_as_deleted(editor.buffer_id);     // check in case we missed that it's deleted
+    session_notify_modified_buffer(editor.buffer_id);   // @Cleanup? This doesn't seem to do anything.
 }
 
 save_all :: (editor: *Editor, buffer: *Buffer) {
     new_edit_group(buffer, editor);
 
-    for * buffer, buffer_id : open_buffers {
-        if !buffer.modified continue;
-        save_buffer_to_disk(buffer, buffer_id);
+    for * b, b_id : open_buffers {
+        if !b.modified continue;
+        save_buffer_to_disk(b, b_id);
     }
 }
 

--- a/src/keymap.jai
+++ b/src/keymap.jai
@@ -342,6 +342,7 @@ ACTIONS_EDITORS :: #run arrays_concat(ACTIONS_COMMON, string.[
     "save",
     "save_as",
     "save_all",
+    "delete_current_file",
     "toggle_comment",
     "toggle_block_comment",
     "select_line",

--- a/src/keymap.jai
+++ b/src/keymap.jai
@@ -340,6 +340,7 @@ ACTIONS_EDITORS :: #run arrays_concat(ACTIONS_COMMON, string.[
     "unindent",
     "indent",
     "save",
+    "save_as",
     "save_all",
     "toggle_comment",
     "toggle_block_comment",

--- a/src/main.jai
+++ b/src/main.jai
@@ -242,10 +242,11 @@ main :: () {
                     case .editors;                  handled = editors_handle_event(event);
                     case .finder;                   handled = finder_handle_event(event);
                     case .open_file_dialog;         handled = open_file_dialog_handle_event(event);
+                    case .delete_file_dialog;       handled = delete_file_dialog_handle_event(event);
                     case .go_to_line_dialog;        handled = go_to_line_dialog_handle_event(event);
+                    case .open_project_dialog;      handled = open_project_dialog_handle_event(event);
                     case .unsaved_buffers_dialog;   handled = unsaved_buffers_dialog_handle_event(event);
                     case .commands_dialog;          handled = commands_dialog_handle_event(event);
-                    case .open_project_dialog;      handled = open_project_dialog_handle_event(event);
                 }
             }
 
@@ -656,10 +657,11 @@ active_global_widget: enum {
     editors;
     finder;
     open_file_dialog;
+    delete_file_dialog;
     go_to_line_dialog;
     commands_dialog;
-    unsaved_buffers_dialog;
     open_project_dialog;
+    unsaved_buffers_dialog;
 } = .editors;
 
 Project_Dir :: struct {
@@ -698,6 +700,7 @@ dont_ignore_next_window_resize := false;
 
 #load "widgets/text_input.jai";
 #load "widgets/open_file_dialog.jai";
+#load "widgets/delete_file_dialog.jai";
 #load "widgets/go_to_line_dialog.jai";
 #load "widgets/finder.jai";
 #load "widgets/unsaved_buffers.jai";

--- a/src/platform/windows.jai
+++ b/src/platform/windows.jai
@@ -122,6 +122,12 @@ platform_enumerate_logical_drives :: () -> [] string {
 platform_get_save_file_name :: (name := "") -> string /* temp */, success: bool {
     buffer: [512] u16;
 
+    if name && name != "<new file>" {
+        // Get the name to populate it in the filename box (convenient if we're resaving a deleted file)
+        wide_name, _, length := utf8_to_wide(name); // @Todo: handle error here
+        memcpy(buffer.data, wide_name, length);
+    }
+
     ofn: OPENFILENAMEW;
     ofn.lStructSize = size_of(OPENFILENAMEW);
     ofn.hwndOwner   = window;

--- a/src/platform/windows.jai
+++ b/src/platform/windows.jai
@@ -125,7 +125,7 @@ platform_get_save_file_name :: (name := "") -> string /* temp */, success: bool 
     if name && name != "<new file>" {
         // Get the name to populate it in the filename box (convenient if we're resaving a deleted file)
         wide_name, _, length := utf8_to_wide(name); // @Todo: handle error here
-        memcpy(buffer.data, wide_name, length);
+        memcpy(buffer.data, wide_name, min(buffer.count, length));
     }
 
     ofn: OPENFILENAMEW;

--- a/src/widgets/commands.jai
+++ b/src/widgets/commands.jai
@@ -159,6 +159,7 @@ commands := #run Command.[
     .{ .close_right_editor,                                 "Close Right File",                   0, .Double },
 
     .{ .save,                                               "Save",                               0, .Single },
+    .{ .save_as,                                            "Save As",                            0, .Single },
     .{ .save_all,                                           "Save All",                           0, .Single },
 
     .{ .join_lines,                                         "Join Lines",                         0, .Single },

--- a/src/widgets/commands.jai
+++ b/src/widgets/commands.jai
@@ -162,6 +162,8 @@ commands := #run Command.[
     .{ .save_as,                                            "Save As",                            0, .Single },
     .{ .save_all,                                           "Save All",                           0, .Single },
 
+    .{ .delete_current_file,                                "Delete Current File",                0, .Single },
+
     .{ .join_lines,                                         "Join Lines",                         0, .Single },
     .{ .join_lines_no_spaces_in_between,                    "Join Lines (no spaces in between)",  0, .Single },
 

--- a/src/widgets/delete_file_dialog.jai
+++ b/src/widgets/delete_file_dialog.jai
@@ -13,8 +13,8 @@ delete_file_dialog_handle_event :: (event: Input.Event) -> bool {
 }
 
 show_delete_file_dialog :: (editor: *Editor) {
-    // Getting a copy of the buffer here (since we're not modifying it) so no need to lock
-    buffer := open_buffers[editor.buffer_id];
+    // Not locking here because we're not modifying the buffer
+    buffer := *open_buffers[editor.buffer_id];
     if !buffer.has_file then return;   // Nothing to do if in new buffer
 
     buffer_id_to_delete = editor.buffer_id;
@@ -26,9 +26,6 @@ close_delete_file_dialog :: () {
 }
 
 delete_buffer_file_and_update_editor :: () {
-    lock(*open_buffers_lock);  // Is this necessary here?
-    defer unlock(*open_buffers_lock);
-
     buffer_to_delete := *open_buffers[buffer_id_to_delete];
     deleted := delete_buffer_from_disk(buffer_to_delete);
     if !deleted return; // TODO: handle delete fail

--- a/src/widgets/delete_file_dialog.jai
+++ b/src/widgets/delete_file_dialog.jai
@@ -1,0 +1,45 @@
+delete_file_dialog_handle_event :: (event: Input.Event) -> bool {
+    if event.type == .KEYBOARD && event.key_pressed {
+        if event.key_code == {
+            case .ESCAPE;   #through;
+            case #char "N"; #through;
+            case #char "C"; close_delete_file_dialog();             return true;
+
+            case .ENTER; #through;
+            case #char "Y"; delete_buffer_file_and_update_editor(); return true;
+        }
+    }
+    return false;
+}
+
+show_delete_file_dialog :: (editor: *Editor, buffer: *Buffer) {
+    if !buffer.has_file then return;   // Nothing to do if in new buffer
+
+    editor_to_update = editor;
+    buffer_to_delete = buffer;
+    active_global_widget = .delete_file_dialog;
+}
+
+close_delete_file_dialog :: () {
+    editor_to_update = null;
+    buffer_to_delete = null;
+    activate_editors();
+}
+
+delete_buffer_file_and_update_editor :: () {
+    deleted := delete_buffer_from_disk(buffer_to_delete);
+    if !deleted return; // TODO: handle delete fail
+
+    maybe_mark_buffer_as_deleted(editor_to_update.buffer_id);   // check in case we missed that it's deleted
+    session_notify_modified_buffer(editor_to_update.buffer_id); // @Cleanup? This doesn't seem to do anything.
+    close_delete_file_dialog();
+}
+
+get_buffer_to_delete :: () -> *Buffer {
+    return buffer_to_delete;
+}
+
+#scope_file
+
+editor_to_update: *Editor;
+buffer_to_delete: *Buffer;

--- a/src/widgets/delete_file_dialog.jai
+++ b/src/widgets/delete_file_dialog.jai
@@ -12,34 +12,40 @@ delete_file_dialog_handle_event :: (event: Input.Event) -> bool {
     return false;
 }
 
-show_delete_file_dialog :: (editor: *Editor, buffer: *Buffer) {
+show_delete_file_dialog :: (editor: *Editor) {
+    // Getting a copy of the buffer here (since we're not modifying it) so no need to lock
+    buffer := open_buffers[editor.buffer_id];
     if !buffer.has_file then return;   // Nothing to do if in new buffer
 
-    editor_to_update = editor;
-    buffer_to_delete = buffer;
+    buffer_id_to_delete = editor.buffer_id;
     active_global_widget = .delete_file_dialog;
 }
 
 close_delete_file_dialog :: () {
-    editor_to_update = null;
-    buffer_to_delete = null;
     activate_editors();
 }
 
 delete_buffer_file_and_update_editor :: () {
+    lock(*open_buffers_lock);  // Is this necessary here?
+    defer unlock(*open_buffers_lock);
+
+    buffer_to_delete := *open_buffers[buffer_id_to_delete];
     deleted := delete_buffer_from_disk(buffer_to_delete);
     if !deleted return; // TODO: handle delete fail
 
-    maybe_mark_buffer_as_deleted(editor_to_update.buffer_id);   // check in case we missed that it's deleted
-    session_notify_modified_buffer(editor_to_update.buffer_id); // @Cleanup? This doesn't seem to do anything.
-    close_delete_file_dialog();
+    for e : open_editors {
+        if e.buffer_id != buffer_id_to_delete then continue;
+
+        maybe_mark_buffer_as_deleted(e.buffer_id);   // check in case we missed that it's deleted
+        session_notify_modified_buffer(e.buffer_id);
+        close_delete_file_dialog();
+    }
 }
 
-get_buffer_to_delete :: () -> *Buffer {
-    return buffer_to_delete;
+get_buffer_id_to_delete :: () -> s64 {
+    return buffer_id_to_delete;
 }
 
 #scope_file
 
-editor_to_update: *Editor;
-buffer_to_delete: *Buffer;
+buffer_id_to_delete: s64;

--- a/src/workspace.jai
+++ b/src/workspace.jai
@@ -205,7 +205,7 @@ hard_reload_workspace :: () {
     init_buffers();
     reopen_visible_editors(old_editor_state);
     start_initial_workspace_scan();
-;
+
     add_success_message("Workspace has been reloaded", dismiss_in_seconds=3);
 }
 
@@ -312,6 +312,15 @@ start_watching_file :: (file_path: string) {
     full_path = copy_string(full_path);
     path_overwrite_separators(full_path, #char "/");
     array_add_if_unique(*watch_files, full_path);
+}
+
+stop_watching_file :: (file_path: string) {
+    full_path, success := get_absolute_path(file_path);
+    if !success then return;
+    path_overwrite_separators(full_path, #char "/");
+
+    found, index := array_find(watch_files, full_path);
+    if found then array_unordered_remove_by_index(*watch_files, index);
 }
 
 file_is_watched :: (file_path: string) -> bool {


### PR DESCRIPTION
Sometimes you want to duplicate a file on your filesystem or just delete it because you goofed. Well now you can do it from the editor without having to switch from your file explorer and back all the time :)

The delete current file option pops up a confirmation dialog just to be sure you want to delete the file, and even if you get past that and decide after that it was an accident, the buffer with all your file data is preserved so you can resave it if necessary.

With both of these functionalities in, a patch for renaming files should be pretty easy, if that's also something we want.