### PR TITLE
Sketch out built-in Save File Dialog (#66)

### DIFF
--- a/src/draw.jai
+++ b/src/draw.jai
@@ -61,6 +61,7 @@ draw_frame :: () {
 
     if active_global_widget == {
         case .open_file_dialog;         draw_open_file_dialog();
+        case .save_file_dialog;         draw_save_file_dialog();
         case .delete_file_dialog;       draw_delete_file_dialog();
         case .finder;                   draw_finder();
         case .go_to_line_dialog;        draw_go_to_line_dialog(active_pane_rect);
@@ -1346,6 +1347,45 @@ draw_splitter :: (splitter_rect: Rect, split_x: float, ui_id: Ui_Id) {
     }
 
     draw_rect(rect, color);
+}
+
+draw_save_file_dialog :: () {
+    using save_file_dialog;
+
+    ui_id := Ui_Id.save_file_dialog;
+
+    if ui.active != .none && ui.active != ui_id && !is_child(ui.active, ui_id) {
+        // Close the dialog on clicks elsewhere
+        hide_save_file_dialog();
+        return;
+    }
+
+    margin  := floor(12 * dpi_scale);
+    padding := floor( 4 * dpi_scale);
+    input_rect_height := font_ui_line_height + 2 * padding + 2 * margin + 2;
+    entry_height := font_ui_line_height + padding * 2;
+
+    // Figure out the dialog box size
+    box_rect: Rect = ---;
+    {
+        if width_percentage != width_anim.target {
+            width_percentage = get_animation_value(width_anim);
+            redraw_requested = true;
+        }
+        width  := floor(clamp(screen.w * width_percentage, 400 * dpi_scale, 2000 * dpi_scale));
+        height := floor(clamp(input_rect_height + entry_height * 1/*entries.filtered.count*/ + padding, 0, screen.h / 1.5));
+        x := floor((screen.w - width) / 2);
+        y := floor(clamp(100 * dpi_scale, 0, (screen.h - height) / 2));
+        box_rect = make_rect(x, screen.h - height - y, width, height);
+        if !is_valid(box_rect) return;
+    }
+    draw_rounded_rect_with_shadow(box_rect, Colors.BACKGROUND_LIGHT, radius = rounding_radius_large);
+
+    // Draw the filter input
+    input_rect, files_rect := cut_top(box_rect, input_rect_height);
+    input_rect = shrink(input_rect, margin);
+    input_id := get_ui_id_from_loc(parent_id = ui_id);
+    draw_text_input(*save_file_dialog.input, input_rect, ui_id = input_id, active = true, label = "Path");
 }
 
 draw_open_file_dialog :: () {
@@ -2925,6 +2965,7 @@ Ui_Id :: enum s64 {
     commands_dialog     :: -11;
     open_project_dialog :: -12;
     delete_file_dialog  :: -13;
+    save_file_dialog    :: -14;
 
     // The rest will be derived from loc
 }

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -1194,8 +1194,40 @@ save_buffer :: (editor: *Editor, buffer: *Buffer, save_new_file := false) {
         session_notify_modified_buffer(editor.buffer_id);
     }
 
+#if OS != .WINDOWS {
+    if !buffer.readonly {
+        if save_new_file {
+            show_save_file_dialog(buffer, editor.buffer_id, save_new_file);
+        } else {
+            if !buffer.has_file {
+                show_save_file_dialog(buffer, editor.buffer_id, save_new_file);
+            } else {
+                using buffer;
+
+                if config.settings.strip_trailing_whitespace_on_save then strip_trailing_whitespace(buffer, editor.buffer_id);
+
+                success := write_entire_file(file.full_path, to_string(bytes));
+                if success {
+                    modified = false;
+                    modified_on_disk = false;
+                    deleted = false;
+
+                    meow_hash = calculate_meow_hash(bytes);
+
+                    error_when_saving = false;
+                    crlf = false;
+                } else {
+                    error_when_saving = true;
+                }
+                remember_last_modtime_and_size(buffer);
+                update_window_title(open_editors[editors.active].buffer_id);
+            }
+        }
+    }
+} else {
     if save_new_file then save_buffer_to_new_file_on_disk(buffer, editor.buffer_id);
     else                  save_buffer_to_disk(buffer, editor.buffer_id);
+}
 }
 
 save_all :: (editor: *Editor, buffer: *Buffer) {

--- a/src/main.jai
+++ b/src/main.jai
@@ -242,6 +242,7 @@ main :: () {
                     case .editors;                  handled = editors_handle_event(event);
                     case .finder;                   handled = finder_handle_event(event);
                     case .open_file_dialog;         handled = open_file_dialog_handle_event(event);
+                    case .save_file_dialog;         handled = save_file_dialog_handle_event(event);
                     case .delete_file_dialog;       handled = delete_file_dialog_handle_event(event);
                     case .go_to_line_dialog;        handled = go_to_line_dialog_handle_event(event);
                     case .open_project_dialog;      handled = open_project_dialog_handle_event(event);
@@ -657,6 +658,7 @@ active_global_widget: enum {
     editors;
     finder;
     open_file_dialog;
+    save_file_dialog;
     delete_file_dialog;
     go_to_line_dialog;
     commands_dialog;
@@ -700,6 +702,7 @@ dont_ignore_next_window_resize := false;
 
 #load "widgets/text_input.jai";
 #load "widgets/open_file_dialog.jai";
+#load "widgets/save_file_dialog.jai";
 #load "widgets/delete_file_dialog.jai";
 #load "widgets/go_to_line_dialog.jai";
 #load "widgets/finder.jai";

--- a/src/widgets/save_file_dialog.jai
+++ b/src/widgets/save_file_dialog.jai
@@ -1,0 +1,144 @@
+
+init_save_file_dialog :: () {
+    // There never was any stuff in here
+    save_file_dialog.initted = true;
+}
+
+save_file_dialog_handle_event :: (event: Input.Event) -> handled: bool {
+    using save_file_dialog;
+
+    if event.type == .KEYBOARD && event.key_pressed {
+        if event.key_code ==  {
+            case .ESCAPE; hide_save_file_dialog(); return true;
+            case .ENTER; {
+                file_path := copy_temporary_string(to_string(input.text));
+
+                if save_new_file {
+                    // Save the file BEFORE making a new buffer so find_or_create_buffer can find it
+                    if config.settings.strip_trailing_whitespace_on_save then strip_trailing_whitespace(buffer, buffer_id);
+
+                    success := write_entire_file(file_path, to_string(buffer.bytes));
+                    if !success then return false;
+
+                    new_id, created := find_or_create_buffer(file_path);
+                    redraw_requested = true;
+
+                    // Reroute all editors using the old id
+                    for * editor : open_editors {
+                        if editor.buffer_id == buffer_id {
+                            editor.buffer_id = new_id;
+                            editor.scroll_to_cursor = .yes;
+                            for * cursor : editor.cursors { put_cursor_in_valid_spot(cursor, buffer); }
+                            organise_cursors(editor);
+                        }
+                    }
+
+                    if !file_is_watched(file_path) then start_watching_file(file_path);
+                    update_window_title(open_editors[editors.active].buffer_id);
+                    hide_save_file_dialog();
+                    return true;
+                } else {
+                    using buffer;
+
+                    if !has_file {
+                        has_file = true;
+                        file = get_file_info_from_full_path(file_path);
+                        set_lang_from_path(buffer, file_path);
+                        needs_coloring = true;
+                        redraw_requested = true;
+
+                        lock(*open_buffers_lock);
+                        {
+                            existing_buffer_id, found_existing := table_find(*buffers_table, file_path);
+                            if found_existing {
+                                if buffer_id != existing_buffer_id {
+                                    // The user chose to save the new buffer into an existing file. OK.
+                                    // Mark the old buffer as deleted and use the new one
+                                    removed := table_remove(*buffers_table, file_path);
+                                    assert(removed, "For some reason table_remove failed. This is a very unexpected bug.");
+                                    existing_buffer := *open_buffers[existing_buffer_id];
+                                    existing_buffer.deleted  = true;
+                                    existing_buffer.modified = false;
+                                    existing_buffer.modified_on_disk = false;
+
+                                    // Reroute all editors which use it to the new buffer id
+                                    for * editor : open_editors {
+                                        if editor.buffer_id == existing_buffer_id {
+                                            editor.buffer_id = buffer_id;
+                                            editor.scroll_to_cursor = .yes;
+                                            for * cursor : editor.cursors { put_cursor_in_valid_spot(cursor, buffer); }
+                                            organise_cursors(editor);
+                                        }
+                                    }
+                                } else {
+                                    assert(false, "Buffer without a file somehow got into the buffers hash table. This is a bug.");
+                                }
+                            }
+
+                            table_add(*buffers_table, copy_string(file_path), buffer_id);
+                        }
+                        unlock(*open_buffers_lock);
+
+                        if !file_is_watched(file_path) then start_watching_file(file_path);
+                    }
+
+                    if config.settings.strip_trailing_whitespace_on_save then strip_trailing_whitespace(buffer, buffer_id);
+
+                    success := write_entire_file(file.full_path, to_string(bytes));
+                    if success {
+                        modified = false;
+                        modified_on_disk = false;
+                        deleted = false;
+
+                        meow_hash = calculate_meow_hash(bytes);
+
+                        error_when_saving = false;
+                        crlf = false;
+                    } else {
+                        error_when_saving = true;
+                    }
+                    remember_last_modtime_and_size(buffer);
+                    update_window_title(open_editors[editors.active].buffer_id);
+
+                    hide_save_file_dialog();
+                    return !error_when_saving;
+                }
+            }
+        }
+        return text_input_handle_event(*input, event);
+    } else if event.type == .TEXT_INPUT {
+        char := event.utf32;
+        if char == 127 return true;  // there seems to be a bug in the Input module
+                                // which generates a TEXT_INPUT event for DEL
+                                // when Ctrl+Backspace is pressed
+        text_input_type_char(*save_file_dialog.input, char);
+    }
+
+    return false;
+}
+
+show_save_file_dialog :: (buffer: *Buffer, buffer_id: s64, save_new_file: bool) {
+    active_global_widget = .save_file_dialog;
+    save_file_dialog.buffer = buffer;
+    save_file_dialog.buffer_id = buffer_id;
+    save_file_dialog.save_new_file = save_new_file;
+}
+
+hide_save_file_dialog :: () {
+    activate_editors();
+}
+
+save_file_dialog: Save_File_Dialog;
+
+#scope_file
+
+Save_File_Dialog :: struct {
+    initted := false;
+    input: Text_Input;
+    width_percentage := WIDTH_NORMAL;  // how much of the screen the popup occupies
+    width_anim := #run Tween_Animation(float).{ start = WIDTH_NORMAL, target = WIDTH_NORMAL };
+    WIDTH_NORMAL   :: 0.4;
+    buffer: *Buffer;
+    buffer_id: s64;
+    save_new_file: bool;
+}

--- a/src/workspace.jai
+++ b/src/workspace.jai
@@ -129,6 +129,7 @@ maybe_update_workspace_buffers :: () {
 
             start_file_watcher();
             init_open_file_dialog();
+            init_save_file_dialog();
             init_finder();
         }
         return;


### PR DESCRIPTION
Related to #66

This is the beginning of the built-in Save File Dialog implementation. Since implementing it properly is a relatively significant task (especially for somebody like myself who's not familiar with the inner workings of the Editor that well), this commit simply outlines how it might potentially work.

What's needs to be done

1. Cool Open File Dialog Style navigation. Save File Dialog is just a single input and you have to type out the full path to the file you want to save
2. I took the save logic from `save_buffer_to_new_file_on_disk()` and `save_buffer_to_disk()` and tried to replicate it in an asynchronous fashion in `save_file_dialog_handle_event()`. It seems to work alright for me. The occurred code duplication between `save_buffer_*()` and `save_file_dialog_handle_event()` needs to be compressed properly somehow, otherwise it may create problems in the future when the logic needs to be updated. We don't want to update it in 2 places separately.
3. Configuration flag that controls whether to use the built-in Save File Dialog or the Native OS one.

Please, let me know if there are any problems with the Pull Request or if you want me to make any changes.

Thanks!