### PR TITLE
More x11 im hanling

### DIFF
--- a/FOCUS-CHANGELOG.txt
+++ b/FOCUS-CHANGELOG.txt
@@ -55,6 +55,7 @@
     + When editor width is limited in settings, the non-editor part of the window will be colored using the `background_dark` color
     + Linux: The editor shoudn't use any CPU while idle.
     + Linux: timers are now supported. As a result some animations (such as the text cursor blinking) should now actually work as expected.
+    + Linux: More robust and resilent mechanism to get user's locale and input method for X11 backend. Fix locale-related segfaults
     + Global search will now try to preserve search results and cursor position when searching using the same query
     + Windows: The editor window should open on the primary monitor by default
 

--- a/modules/Linux_Display/ldx_display.jai
+++ b/modules/Linux_Display/ldx_display.jai
@@ -44,13 +44,14 @@ x11_init_display :: (display: LDDisplay) -> bool {
 
     // Default locale, which is "C", doesn't support multibyte characters,
     // so we do this to get system locale which is hopefully set up correctly
-    // result will either by a correct locale from the environment,
+
+    // Result of setlocale will either be a correct locale from the environment,
     // or NULL if setlocale fails, or it will be "C" if somebody exported LC_ALL=""
     new_locale := to_string(setlocale(LC_ALL, ""));
 
     // We need to check whether current locale is supported by X server. It's not
     // guaranteed regardless of whether setlocale call is successful or not.
-    // If setting locale didn't work, we try our best to get it from few well-known
+    // If setting locale didn't work, we try our best to get it from a few well-known
     // environment variables in case one of them is set up correctly. glibc's setlocale
     // tries $LC_ALL first, then a category you specify in the first argument to setlocale,
     // and then $LANG env variable. The issue here is that glibc bails out of this sequence
@@ -62,9 +63,9 @@ x11_init_display :: (display: LDDisplay) -> bool {
         // getenv can have two "falsy" outcomes - env variable exists but is an empty string
         // and env variable doesn't exist. In first case we get a pointer to an empty string,
         // in the second case we get NULL as a result. Converting to jai string covers both cases
-        lc_ctype := to_string(getenv("LC_CTYPE"));
+        lc_ctype := trim(to_string(getenv("LC_CTYPE")));
         if !lc_ctype {
-            lang := to_string(getenv("LANG"));
+            lang := trim(to_string(getenv("LANG")));
 
             if !lang {
                 log_error("LANG environment variable is not found, trying to fall back to C.UTF-8\n");

--- a/modules/Linux_Display/ldx_display.jai
+++ b/modules/Linux_Display/ldx_display.jai
@@ -49,16 +49,35 @@ x11_init_display :: (display: LDDisplay) -> bool {
             free(old_xmods);
         }
     }
+    // NOTE: Support XMODIFIERS and XIM_SERVERS?
 
+    // Default locale, which is "C", doesn't support multibyte characters,
+    // so we do this to get system locale which is hopefully set up correctly
     setlocale(LC_ALL, "");
 
+    // We need to check whether current locale is supported by X server. It's not
+    // guaranteed regardless of whether setlocale call is successful or not
+    if !XSupportsLocale() {
+        log_error("Couldn't set locale from environment, falling back to default one: %\n", old_locale);
+        setlocale(LC_ALL, old_locale.data);
+    }
     init_global_display();
 
+    // Try the best we can to get the input method
     XSetLocaleModifiers("");
     im := XOpenIM(x_global_display, null, null, null);
     if !im {
-        XSetLocaleModifiers("@im=none");
+        // local seems like the same thing as none, but more examples use it!
+        XSetLocaleModifiers("@im=local");
         im = XOpenIM(x_global_display, null, null, null);
+        if !im {
+            XSetLocaleModifiers("@im=");
+            im = XOpenIM(x_global_display, null, null, null);
+            // Nothing more we can do
+            if !im {
+                log_error("Could not get X11 Input Method");
+            }
+        }
     }
 
     if !xcursor_initialized {
@@ -280,6 +299,10 @@ x11_create_window :: (x11_display: *X11Display, ld_win: LDWindow, width: int, he
         XNFocusWindow, win,
         XNInputStyle, XIMPreeditNothing | XIMStatusNothing,
         null);
+
+    if !ic {
+        log_error("Could not create X11 input context\n");
+    }
 
     array_add(*x_global_windows, win);
 

--- a/modules/Linux_Display/ldx_display.jai
+++ b/modules/Linux_Display/ldx_display.jai
@@ -30,39 +30,66 @@ preloaded_x_cursors :: string.[
 ];
 
 x11_init_display :: (display: LDDisplay) -> bool {
-    current_locale := setlocale(LC_ALL, null);
-    current_xmods  := XSetLocaleModifiers(null);
-
-    old_locale: string;
-    if current_locale old_locale = copy_string(to_string(current_locale));
-
-    old_xmods: string;
-    if current_xmods old_xmods = copy_string(to_string(current_xmods));
+    old_locale := setlocale(LC_ALL, null);
+    old_xmods  := XSetLocaleModifiers(null);
 
     defer {
-        if current_locale {
-            setlocale(LC_ALL, old_locale.data);
-            free(old_locale);
+        if old_locale {
+            setlocale(LC_ALL, old_locale);
         }
-        if current_xmods {
-            XSetLocaleModifiers(old_xmods.data);
-            free(old_xmods);
+        if old_xmods {
+            XSetLocaleModifiers(old_xmods);
         }
     }
-    // NOTE: Support XMODIFIERS and XIM_SERVERS?
 
     // Default locale, which is "C", doesn't support multibyte characters,
     // so we do this to get system locale which is hopefully set up correctly
-    setlocale(LC_ALL, "");
+    // result will either by a correct locale from the environment,
+    // or NULL if setlocale fails, or it will be "C" if somebody exported LC_ALL=""
+    new_locale := to_string(setlocale(LC_ALL, ""));
 
     // We need to check whether current locale is supported by X server. It's not
-    // guaranteed regardless of whether setlocale call is successful or not
-    if !XSupportsLocale() {
-        log_error("Couldn't set locale from environment, falling back to default one: %\n", old_locale);
-        setlocale(LC_ALL, old_locale.data);
+    // guaranteed regardless of whether setlocale call is successful or not.
+    // If setting locale didn't work, we try our best to get it from few well-known
+    // environment variables in case one of them is set up correctly. glibc's setlocale
+    // tries $LC_ALL first, then a category you specify in the first argument to setlocale,
+    // and then $LANG env variable. The issue here is that glibc bails out of this sequence
+    // as soon as it sees that something is set, even if it's set incorrectly. So the call to
+    // setlocale will fail. That's why we try this process manually.
+    // This process vaguely resembles the way musl gets current locale and looks reasonable enough
+    if !new_locale || new_locale == "C" || !XSupportsLocale() {
+
+        // getenv can have two "falsy" outcomes - env variable exists but is an empty string
+        // and env variable doesn't exist. In first case we get a pointer to an empty string,
+        // in the second case we get NULL as a result. Converting to jai string covers both cases
+        lc_ctype := to_string(getenv("LC_CTYPE"));
+        if !lc_ctype {
+            lang := to_string(getenv("LANG"));
+
+            if !lang {
+                log_error("LANG environment variable is not found, trying to fall back to C.UTF-8\n");
+                new_locale = to_string(setlocale(LC_ALL, "C.UTF-8"));
+            } else {
+                new_locale = to_string(setlocale(LC_ALL, temp_c_string(lang)));
+            }
+        } else {
+            new_locale = to_string(setlocale(LC_ALL, temp_c_string(lc_ctype)));
+        }
+
+        if !new_locale || !XSupportsLocale() {
+            error :: #string __error
+Couldn't set unicode-capable locale from environment, falling back to default one: %.
+This is likely an indicator that your locale is set incorrectly.
+Inspect available locales [$ locale -a] and the one you have set up: [$ locale]
+            __error
+            log_error(error, to_string(old_locale));
+            setlocale(LC_ALL, old_locale);
+        }
+
     }
     init_global_display();
 
+    // NOTE: Should we explicitly support XMODIFIERS and XIM_SERVERS such as dbus and fcitx?
     // Try the best we can to get the input method
     XSetLocaleModifiers("");
     im := XOpenIM(x_global_display, null, null, null);


### PR DESCRIPTION
This fixes a few potential segfaults related to X11 input methods and generally makes detecting locales way more robust.
We can still go further - explicitly support ibus and fcitx (with current method, they are supported indirectly with fallback to `"@im=none"`, but _technically_ it's not 100% correct) and also check applicable input styles before creating input context. But this is a good 90% solution