### PR TITLE
Add option to disable curosr blinking

### DIFF
--- a/FOCUS-CHANGELOG.txt
+++ b/FOCUS-CHANGELOG.txt
@@ -25,6 +25,7 @@
     + Line wrap is now supported (use the toggle_line_wrap command - default shortcut on Windows is Alt-Z). If you want line wrap to be on by default, use `line_wrap_is_on_by_default: true`
     + New command: toggle_block_comment (for the supported languages)
     + New commands: move_to_previous_buffer, move_to_next_buffer. They work like normal editor history, but skip the cursor movements and jump right to the next buffer or layout change
+    + New config option: cursor_blinking
     + It is now possible to paste whatever was copied with N cursors into another file as long as the number of cursors there is also N (thanks @hfr4)
     + Syntax highlighting for GLSL (thanks @SentientCoffee)
     + Linux: The "Open Projects Directory" command as well as shift-clicking files/directories in the "open file" dialogs (Ctrl+O, Ctrl+Shift+O, Ctrl+P) should now work.

--- a/default.focus-config
+++ b/default.focus-config
@@ -40,6 +40,7 @@ __pycache__
 maximize_on_start:                      false
 open_on_the_biggest_monitor:            true
 cursor_as_block:                        true
+cursor_blinking:                        true
 highlight_selection_occurrences:        true
 disable_that_annoying_paste_effect:     false
 disable_file_open_close_animations:     false

--- a/default_macos.focus-config
+++ b/default_macos.focus-config
@@ -39,6 +39,7 @@ __pycache__
 maximize_on_start:                      false
 open_on_the_biggest_monitor:            false
 cursor_as_block:                        true
+cursor_blinking:                        true
 highlight_selection_occurrences:        true
 disable_that_annoying_paste_effect:     false
 disable_file_open_close_animations:     false

--- a/src/config.jai
+++ b/src/config.jai
@@ -322,6 +322,7 @@ Settings :: struct {
     maximize_on_start                   := false;
     open_on_the_biggest_monitor         := true;
     cursor_as_block                     := true;
+    cursor_blinking                     := true;
     highlight_selection_occurrences     := true;
     disable_that_annoying_paste_effect  := false;
     disable_file_open_close_animations  := false;

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -1009,6 +1009,8 @@ scan_through_similar_chars_on_the_right :: (using buffer: Buffer, offset: s32, o
 }
 
 cursors_start_blinking :: inline () {
+    if !config.settings.cursor_blinking return;
+
     cursor_blink_start = frame_time;
     platform_set_refresh_timer(window);
     cursors_blinking = true;
@@ -1020,7 +1022,7 @@ cursors_stop_blinking :: inline () {
 }
 
 should_draw_cursors :: inline () -> bool {
-    if !cursors_blinking return true;
+    if !cursors_blinking || !config.settings.cursor_blinking return true;
 
     ms_since_start := cast(s64) ((frame_time - cursor_blink_start) * 1000);
     if ms_since_start > CURSOR_BLINK_TIMEOUT_MS {


### PR DESCRIPTION
cursors_stop_blinking doesn't have a config check in case someone disables blinking with live-reloading. So we can successfully kill the refresh timer and set cursors_blinking to false