### PR TITLE
Fix search bar dropdown crashing when there are no results in the list

### DIFF
--- a/src/editors.jai
+++ b/src/editors.jai
@@ -789,6 +789,11 @@ search_bar_move_cursor :: (using editor: *Editor, buffer: Buffer, delta: s64, wr
 
 search_bar_open_selected_result :: (editor: Editor, buffer: Buffer, placement: Editor_Placement) {
     using editor.search_bar;
+    if results.count <= 0 {
+        // Don't do anything because there aren't even any results to open
+        // @Todo: should we deactivate it and move to the other open editor (as if it wasn't open)?
+        return;
+    }
 
     active = false;  // close it immediately
 


### PR DESCRIPTION
If you hit the `switch_to_left_editor` keybind while in the dropdown search bar while the dropdown search bar has no results, the editor will fail on an array bounds check. This simple fix makes that not happen.