### PR TITLE
add windows window border color effect

### DIFF
--- a/default.focus-config
+++ b/default.focus-config
@@ -57,6 +57,9 @@ copy_whole_line_without_selection:      false
 editor_history_size:                    1024
 line_wrap_is_on_by_default:             false
 show_line_numbers:                      false
+dark_titlebar:                          true
+# Windows 11 compatible only
+colored_titlebar:                       true
 
 
 [[keymap]]

--- a/src/config.jai
+++ b/src/config.jai
@@ -342,6 +342,8 @@ Settings :: struct {
     editor_history_size                 := 128;
     line_wrap_is_on_by_default          := false;
     show_line_numbers                   := false;
+    dark_titlebar                       := true;
+    colored_titlebar                    := true;
 
     // TODO
     // convert_tabs_to_spaces_on_load:     false

--- a/src/config.jai
+++ b/src/config.jai
@@ -169,6 +169,7 @@ load_and_merge_config :: (file_path: string, into: Config, hash: *u64) -> succes
     // Apply colors
     Colors = config.colors;
     CODE_COLOR_MAP = refresh_code_color_map();
+    platform_set_border_color();
 
     // Make sure the values are within the acceptable range
     clamp_warnings := false;

--- a/src/platform/linux.jai
+++ b/src/platform/linux.jai
@@ -248,6 +248,10 @@ platform_path_contains :: inline (path: string, subpath: string) -> bool {
     return contains(path, subpath);
 }
 
+platform_set_border_color :: inline () {
+
+}
+
 #scope_file
 
 LD  :: #import "Linux_Display";

--- a/src/platform/macos.jai
+++ b/src/platform/macos.jai
@@ -105,6 +105,10 @@ platform_path_contains :: inline (path: string, subpath: string) -> bool {
     return contains(path, subpath);
 }
 
+platform_set_border_color :: inline () {
+
+}
+
 #scope_file
 
 Monitor :: struct {

--- a/src/platform/windows.jai
+++ b/src/platform/windows.jai
@@ -64,6 +64,7 @@ platform_get_centered_window_dimensions :: (open_on_biggest: bool) -> s32, s32, 
 
 platform_create_window :: () {
     window = create_window(window_width, window_height, window_generic_title, window_x, window_y, background_color_rgb = as_3_floats(Colors.BACKGROUND));
+    platform_set_border_color();
 }
 
 platform_maximize_window :: (window: Window_Type) {
@@ -226,6 +227,21 @@ platform_path_contains :: inline (path: string, subpath: string) -> bool {
     return contains_nocase(path, subpath);
 }
 
+platform_set_border_color :: () {
+    using DwmAttribute;
+    background := Colors.BACKGROUND;
+    r : u32 = cast(u32)(background.r * 255.0);
+    g : u32 = cast(u32)(background.g * 255.0);
+    b : u32 = cast(u32)(background.b * 255.0);
+    // COLORREF format is 0x00bbggrr
+    col : u32 = 0x00000000;
+    col |= b << 16;
+    col |= g << 8;
+    col |= r;
+    DwmSetWindowAttribute(window, BORDER_COLOR, *col, size_of(u32));
+    DwmSetWindowAttribute(window, CAPTION_COLOR, *col, size_of(u32));
+}
+
 #scope_file
 
 fonts_dir: string;
@@ -283,3 +299,34 @@ CoTaskMemFree :: (pv: *void) #foreign ole32;
 #import "Windows";
 #import "Windows_Registry";
 #import "Process";
+
+Dwmapi :: #system_library "Dwmapi";
+DwmSetWindowAttribute :: (handle: HANDLE, dwAttribute: DwmAttribute, pvAttributde :*void, cbAttribute :DWORD) -> HRESULT #foreign Dwmapi;
+
+DwmAttribute :: enum u32 {
+  NCRENDERING_ENABLED;
+  NCRENDERING_POLICY;
+  TRANSITIONS_FORCEDISABLED;
+  ALLOW_NCPAINT;
+  CAPTION_BUTTON_BOUNDS;
+  NONCLIENT_RTL_LAYOUT;
+  FORCE_ICONIC_REPRESENTATION;
+  FLIP3D_POLICY;
+  EXTENDED_FRAME_BOUNDS;
+  HAS_ICONIC_BITMAP;
+  DISALLOW_PEEK;
+  EXCLUDED_FROM_PEEK;
+  CLOAK;
+  CLOAKED;
+  FREEZE_REPRESENTATION;
+  PASSIVE_UPDATE_MODE;
+  USE_HOSTBACKDROPBRUSH;
+  USE_IMMERSIVE_DARK_MODE :: 20;
+  WINDOW_CORNER_PREFERENCE :: 33;
+  BORDER_COLOR;
+  CAPTION_COLOR;
+  TEXT_COLOR;
+  VISIBLE_FRAME_BORDER_THICKNESS;
+  SYSTEMBACKDROP_TYPE;
+  LAST;
+}

--- a/src/platform/windows.jai
+++ b/src/platform/windows.jai
@@ -229,17 +229,22 @@ platform_path_contains :: inline (path: string, subpath: string) -> bool {
 
 platform_set_border_color :: () {
     using DwmAttribute;
-    background := Colors.BACKGROUND;
-    r : u32 = cast(u32)(background.r * 255.0);
-    g : u32 = cast(u32)(background.g * 255.0);
-    b : u32 = cast(u32)(background.b * 255.0);
-    // COLORREF format is 0x00bbggrr
-    col : u32 = 0x00000000;
-    col |= b << 16;
-    col |= g << 8;
-    col |= r;
-    DwmSetWindowAttribute(window, BORDER_COLOR, *col, size_of(u32));
+    col : u32 = 0xFFFFFFFF;
+    if config.settings.colored_titlebar {
+        background := Colors.BACKGROUND;
+        r : u32 = cast(u32)(background.r * 255.0);
+        g : u32 = cast(u32)(background.g * 255.0);
+        b : u32 = cast(u32)(background.b * 255.0);
+        // COLORREF format is 0x00bbggrr
+        col = 0x00000000;
+        col |= b << 16;
+        col |= g << 8;
+        col |= r;
+    }
     DwmSetWindowAttribute(window, CAPTION_COLOR, *col, size_of(u32));
+
+    darkmode := ifx config.settings.dark_titlebar then 1 else 0;
+    DwmSetWindowAttribute(window, USE_IMMERSIVE_DARK_MODE , *darkmode, size_of(type_of(darkmode)));
 }
 
 #scope_file


### PR DESCRIPTION
<img width="855" alt="Screenshot 2023-08-10 225615" src="https://github.com/focus-editor/focus/assets/5068750/ab3b05f9-b643-4e1f-83d7-0643c13050c3">

This makes the editor window look a lot cleaner on Windows. Requires bringing in DwmSetWindowAttribute from Dwmapi, which is not yet defined in jai's Windows module. Stubbed in noop procedures for the other platforms. I can take a look at a macOS implementation too. MacVim has it. 