### PR TITLE
balances brackets and quotes if selected

### DIFF
--- a/default.focus-config
+++ b/default.focus-config
@@ -59,6 +59,7 @@ line_wrap_is_on_by_default:             false
 show_line_numbers:                      false
 colored_titlebar:                       true   # Windows 11+ only
 hide_mouse_when_typing:                 true
+auto_surround_with_brackets_and_quotes: false
 
 [[keymap]]
 

--- a/default_macos.focus-config
+++ b/default_macos.focus-config
@@ -56,7 +56,7 @@ max_editor_width:                       -1
 editor_history_size:                    1024
 line_wrap_is_on_by_default:             false
 show_line_numbers:                      false
-
+auto_surround_with_brackets_and_quotes: false
 
 [[keymap]]
 

--- a/src/config.jai
+++ b/src/config.jai
@@ -322,29 +322,30 @@ Workspace :: struct {
 }
 
 Settings :: struct {
-    maximize_on_start                   := false;
-    open_on_the_biggest_monitor         := true;
-    cursor_as_block                     := true;
-    cursor_blink_time_in_seconds        := 5;
-    highlight_selection_occurrences     := true;
-    disable_that_annoying_paste_effect  := false;
-    disable_file_open_close_animations  := false;
-    double_shift_to_search_in_workspace := false;
-    max_entries_in_open_file_dialog     := 2000;
-    tab_size                            := 4;
-    insert_spaces_when_pressing_tab     := true;
-    strip_trailing_whitespace_on_save   := false;
-    smooth_scrolling                    := true;
-    line_height_scale_percent           := 120;
-    max_editor_width                    := -1;
-    can_cancel_go_to_line               := true;
-    copy_whole_line_without_selection   := false;
-    editor_history_size                 := 128;
-    line_wrap_is_on_by_default          := false;
-    show_line_numbers                   := false;
-    dark_titlebar                       := false;  // TODO: fix the issues with window resize first
-    colored_titlebar                    := true;
-    hide_mouse_when_typing              := true;
+    maximize_on_start                      := false;
+    open_on_the_biggest_monitor            := true;
+    cursor_as_block                        := true;
+    cursor_blink_time_in_seconds           := 5;
+    highlight_selection_occurrences        := true;
+    disable_that_annoying_paste_effect     := false;
+    disable_file_open_close_animations     := false;
+    double_shift_to_search_in_workspace    := false;
+    max_entries_in_open_file_dialog        := 2000;
+    tab_size                               := 4;
+    insert_spaces_when_pressing_tab        := true;
+    strip_trailing_whitespace_on_save      := false;
+    smooth_scrolling                       := true;
+    line_height_scale_percent              := 120;
+    max_editor_width                       := -1;
+    can_cancel_go_to_line                  := true;
+    copy_whole_line_without_selection      := false;
+    editor_history_size                    := 128;
+    line_wrap_is_on_by_default             := false;
+    show_line_numbers                      := false;
+    dark_titlebar                          := false;  // TODO: fix the issues with window resize first
+    colored_titlebar                       := true;
+    hide_mouse_when_typing                 := true;
+    auto_surround_with_brackets_and_quotes := false;
 
     // TODO
     // convert_tabs_to_spaces_on_load:     false

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -317,15 +317,24 @@ active_editor_type_char :: (char: u32) {
         cursor.pos += offset_delta;
         cursor.sel += offset_delta;
 
-        if has_selection(cursor) {
+        if all_cursors_have_selection(editor) && is_balancable_char(char) {
             selection := get_selection(cursor);
-            delete_range(buffer, selection);
-            cursor.pos = selection.start;
-        }
-        insert_char_at_offset(buffer, cursor.pos, utf8_char);
+            insert_char_at_offset(buffer, selection.end  , convert_utf32_to_utf8(get_balancing_char(char)));
+            insert_char_at_offset(buffer, selection.start, utf8_char);
 
-        cursor.pos = next_char_offset(buffer.bytes, cursor.pos);
-        cursor.sel = cursor.pos;
+            cursor.pos = selection.end   + 1;
+            cursor.sel = selection.start + 1;
+        } else {
+            if has_selection(cursor) {
+                selection := get_selection(cursor);
+                delete_range(buffer, selection);
+                cursor.pos = selection.start;
+            }
+            insert_char_at_offset(buffer, cursor.pos, utf8_char);
+
+            cursor.pos = next_char_offset(buffer.bytes, cursor.pos);
+            cursor.sel = cursor.pos;
+        }
     }
 
     if new_group then new_edit_group(buffer, editor);  // make sure selection operations have a dedicated group
@@ -651,6 +660,11 @@ get_selected_text_all_cursors :: (using editor: Editor, buffer: Buffer) -> strin
     }
 
     return text;
+}
+
+all_cursors_have_selection ::  (using editor: Editor) -> bool {
+    for cursors { if !has_selection(it) return false; }
+    return true;
 }
 
 new_edit_group :: (buffer: *Buffer, editor: *Editor) {

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -308,6 +308,10 @@ active_editor_type_char :: (char: u32) {
 
     offset_delta: s32 = 0;
     buf_len := cast(s32) buffer.bytes.count;
+
+    all_have_selection := all_cursors_have_selection(editor);
+    is_balanceable     := is_balanceable_char(char);
+
     for * cursor : editor.cursors {
         new_len := cast(s32) buffer.bytes.count;
         if new_len != buf_len {
@@ -317,7 +321,7 @@ active_editor_type_char :: (char: u32) {
         cursor.pos += offset_delta;
         cursor.sel += offset_delta;
 
-        if all_cursors_have_selection(editor) && is_balancable_char(char) {
+        if config.settings.auto_surround_with_brackets_and_quotes && all_have_selection && is_balanceable {
             selection := get_selection(cursor);
             insert_char_at_offset(buffer, selection.end  , convert_utf32_to_utf8(get_balancing_char(char)));
             insert_char_at_offset(buffer, selection.start, utf8_char);

--- a/src/utils.jai
+++ b/src/utils.jai
@@ -278,7 +278,7 @@ is_separator_char :: inline (ch: u8) -> bool {
         ch == #char "." || ch == #char "<" || ch == #char ">" || ch == #char "/" || ch == #char "\"" || ch == #char "\\";
 }
 
-is_balancable_char :: (ch: u32) -> bool {
+is_balanceable_char :: (ch: u32) -> bool {
     return ch == #char "{" || ch == #char "(" || ch == #char "[" || ch == #char "\"";
 }
 

--- a/src/utils.jai
+++ b/src/utils.jai
@@ -278,6 +278,20 @@ is_separator_char :: inline (ch: u8) -> bool {
         ch == #char "." || ch == #char "<" || ch == #char ">" || ch == #char "/" || ch == #char "\"" || ch == #char "\\";
 }
 
+is_balancable_char :: (ch: u32) -> bool {
+    return ch == #char "{" || ch == #char "(" || ch == #char "[" || ch == #char "\"";
+}
+
+get_balancing_char :: (ch: u32) -> u32 {
+    if ch == {
+        case #char "{";  return #char "}";
+        case #char "(";  return #char ")";
+        case #char "[";  return #char "]";
+        case #char "\""; return #char "\"";
+        case; return 0;
+    }
+}
+
 get_char_type :: (ch: u32) -> Char_Type {
     if is_word_char(ch) {
         return .word;


### PR DESCRIPTION
Instead of replacing a selection when typing __*( [ { "*__, balance with the matching char.

https://github.com/focus-editor/focus/assets/30574115/e45d5dcd-6851-4ef9-83c0-f1cdedeb2c77

