### PR TITLE
Highlight line with cursor

### DIFF
--- a/default.focus-config
+++ b/default.focus-config
@@ -59,6 +59,7 @@ line_wrap_is_on_by_default:             false
 show_line_numbers:                      false
 colored_titlebar:                       true   # Windows 11+ only
 hide_mouse_when_typing:                 true
+highlight_line_with_cursor:             false
 
 [[keymap]]
 

--- a/src/config.jai
+++ b/src/config.jai
@@ -345,6 +345,7 @@ Settings :: struct {
     dark_titlebar                       := false;  // TODO: fix the issues with window resize first
     colored_titlebar                    := true;
     hide_mouse_when_typing              := true;
+    // highlight_line_with_cursor          := false;  // TODO for cursor line highlighting
 
     // TODO
     // convert_tabs_to_spaces_on_load:     false

--- a/src/config.jai
+++ b/src/config.jai
@@ -345,7 +345,7 @@ Settings :: struct {
     dark_titlebar                       := false;  // TODO: fix the issues with window resize first
     colored_titlebar                    := true;
     hide_mouse_when_typing              := true;
-    // highlight_line_with_cursor          := false;  // TODO for cursor line highlighting
+    highlight_line_with_cursor          := false;
 
     // TODO
     // convert_tabs_to_spaces_on_load:     false

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -759,7 +759,7 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
                     color := ifx cursors_active then Colors.SELECTION_ACTIVE else Colors.SELECTION_INACTIVE;
                     draw_range(selection, editor, buffer, visible_lines_start, visible_lines_end, text_origin, color);
                 }
-                else if cursors_active /* && if config.settings.highlight_line_with_cursor */{  // TODO
+                else if cursors_active && config.settings.highlight_line_with_cursor {
                     // Draw current line highlight
                     coords := cursor_coords[it_index];
                     line_start_offset := get_line_start_offset(editor, buffer, coords.pos.line);

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -745,11 +745,11 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
 
         cursors_active := editor_is_active && active_global_widget == .editors;
 
-        // Draw selections
         if !search_bar_is_open(editor) {
             Simp.set_shader_for_rects();
             for cursor : cursors {
                 if has_selection(cursor) {
+                    // Draw selections
                     range := get_selection(cursor);
                     if range.end   < visible_offset_range.start continue;
                     if range.start > visible_offset_range.end   break;
@@ -759,7 +759,8 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
                     color := ifx cursors_active then Colors.SELECTION_ACTIVE else Colors.SELECTION_INACTIVE;
                     draw_range(selection, editor, buffer, visible_lines_start, visible_lines_end, text_origin, color);
                 }
-                else {
+                else/* if config.settings.highlight_line_with_cursor */{  // TODO
+                    // Draw current line highlight
                     coords := cursor_coords[it_index];
                     line_start_offset := get_line_start_offset(editor, buffer, coords.pos.line);
                     line_start_coords := offset_to_coords(editor, buffer, line_start_offset);

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -765,10 +765,13 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
                     line_start_offset := get_line_start_offset(editor, buffer, coords.pos.line);
                     line_start_coords := offset_to_coords(editor, buffer, line_start_offset);
 
+                    // @Note: modified from hidden_chars_on_the_left below, get the x offset if we are scrolled horizontally
+                    x_offset := max((viewport.left / char_x_advance) - 1, 0);
+
                     line_rect := Rect.{
-                        x = text_origin.x + line_start_coords.col * char_x_advance,
+                        x = text_origin.x + (x_offset * char_x_advance),
                         y = text_origin.y - coords.pos.line * line_height,
-                        w = rect.w - scrollbar_size - char_x_advance, // @Note: text_origin.x is 1 char_x_advance in so we need to subtract it here
+                        w = rect.w - scrollbar_size - ifx x_offset == 0 then char_x_advance,   // @Note: text_origin.x is 1 char_x_advance in, so if we can see the beginning of the line, shorten the rect
                         h = line_height,
                     };
                     draw_rect(line_rect, Colors.BACKGROUND_BRIGHT);
@@ -826,8 +829,8 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
         // Draw text
         if buffer.needs_coloring || buffer.colors.count != buffer.bytes.count then recalculate_colors(buffer);  // right before drawing
 
-        hidden_chars_on_the_left := cast(s32) max((viewport.left / char_x_advance) - 2, 0);
         max_chars_horizontally   := cast(s32) (rect.w / char_x_advance) + 2;
+        hidden_chars_on_the_left := cast(s32) max((viewport.left / char_x_advance) - 2, 0);
 
         pen := text_origin;
         pen.y += (line_height - char_x_advance) / 2 - visible_lines_start * line_height;

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -759,6 +759,20 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
                     color := ifx cursors_active then Colors.SELECTION_ACTIVE else Colors.SELECTION_INACTIVE;
                     draw_range(selection, editor, buffer, visible_lines_start, visible_lines_end, text_origin, color);
                 }
+                else {
+                    coords := cursor_coords[it_index];
+                    line_start_offset := get_line_start_offset(editor, buffer, coords.pos.line);
+                    line_start_coords := offset_to_coords(editor, buffer, line_start_offset);
+
+                    line_rect := Rect.{
+                        x = text_origin.x + line_start_coords.col * char_x_advance,
+                        y = text_origin.y - coords.pos.line * line_height,
+                        w = rect.w,
+                        h = line_height,
+                    };
+                    color := ifx cursors_active then Colors.BACKGROUND_BRIGHT else Colors.BACKGROUND;
+                    draw_rect(line_rect, color);
+                }
             }
         }
 

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -759,7 +759,7 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
                     color := ifx cursors_active then Colors.SELECTION_ACTIVE else Colors.SELECTION_INACTIVE;
                     draw_range(selection, editor, buffer, visible_lines_start, visible_lines_end, text_origin, color);
                 }
-                else/* if config.settings.highlight_line_with_cursor */{  // TODO
+                else if cursors_active /* && if config.settings.highlight_line_with_cursor */{  // TODO
                     // Draw current line highlight
                     coords := cursor_coords[it_index];
                     line_start_offset := get_line_start_offset(editor, buffer, coords.pos.line);
@@ -768,11 +768,10 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
                     line_rect := Rect.{
                         x = text_origin.x + line_start_coords.col * char_x_advance,
                         y = text_origin.y - coords.pos.line * line_height,
-                        w = rect.w,
+                        w = rect.w - scrollbar_size - char_x_advance, // @Note: text_origin.x is 1 char_x_advance in so we need to subtract it here
                         h = line_height,
                     };
-                    color := ifx cursors_active then Colors.BACKGROUND_BRIGHT else Colors.BACKGROUND;
-                    draw_rect(line_rect, color);
+                    draw_rect(line_rect, Colors.BACKGROUND_BRIGHT);
                 }
             }
         }


### PR DESCRIPTION
Highlight the line(s) with cursors on them, since without this the cursor can be lost easily if you don't know where it is. Configurable within the config file.

NOTE: DO NOT MERGE THIS YET!!
As of 29 August 2023, there is a compiler bug that doesn't allow me to add to the Settings struct, something to do with compile time code generation. Once that is fixed I will update this to _actually_ be configurable in the config file.