### PR TITLE
Improve X11 clipboard handling

### DIFF
--- a/FOCUS-CHANGELOG.txt
+++ b/FOCUS-CHANGELOG.txt
@@ -40,6 +40,7 @@
     + Fixed a bug with multi-cursor copying/pasting when some of the cursors don't have a selection
     + Fixed a bug with multi-cursor range replace by typing
     + Linux: fixed selection while scrolling due to "stuck" START and END states of the mouse button presses.
+    + Linux: Clipboard handling should become way faster on X11 because we let event loop to handle more requests before drawing.
 
 + Other changes:
     + When the workspace is done scanning, the open file dialog input will no longer be cleared

--- a/modules/Linux_Display/ldx_input.jai
+++ b/modules/Linux_Display/ldx_input.jai
@@ -148,19 +148,34 @@ x11_update_window_events :: (display: *Display) {
     x11_display: *X11_Display = display;
 
     xev: X11.XEvent;
-    while X11.XPending(x11_display.handle) {
+    // Some things in X11 happen across multiple events, and it
+    // doesn't make much sense to draw in-between. For example, clipboard handling.
+    // Other programs can send (and expect) a sequence of events just to pass the clipboard around.
+    // Chromium (and its children) is particularly notorious for initiating a  big series of clipboard
+    // events, and if we draw on every event then pasting into other program from Focus becomes slow.
+    // So instead event handler says that it expects more events to come, so we don't release the
+    // event loop right away and instead wait for more events. We don't want to wait forever though,
+    //so we'll release the loop at most after a second, so some buggy program doesn't hang the editor.
+    expect_more_events := false;
+    start_time := get_time();
+    elapsed_time := start_time;
+
+    while X11.XPending(x11_display.handle) || (expect_more_events && elapsed_time < 1000000) {
+
         result := X11.XCheckIfEvent(x11_display.handle, *xev, x11_event_predicate, null);
         if result {
-            x11_handle_event(x11_display, *xev);
+            expect_more_events = x11_handle_event(x11_display, *xev);
             timers_tick();
         }
+        elapsed_time = get_time() - start_time;
     }
 }
 
-x11_handle_event :: (x11_display: *X11_Display, xev: *X11.XEvent) {
+x11_handle_event :: (x11_display: *X11_Display, xev: *X11.XEvent) -> expect_more_events: bool = false {
     using Input.Key_Code;
 
     display := x11_display.handle;
+    // expect_more_events := false;
 
     if X11.XFilterEvent(xev, X11.None) return;
 
@@ -396,6 +411,8 @@ x11_handle_event :: (x11_display: *X11_Display, xev: *X11.XEvent) {
             }
 
             X11.XSendEvent(selreq.display, selreq.requestor, X11.True, 0, *out);
+            return true;
+
         case X11.ConfigureNotify;
             config := cast(*X11.XConfigureEvent) xev;
             ld_win := get_by_native_handle(xx x11_display, xx config.window);
@@ -414,6 +431,7 @@ x11_handle_event :: (x11_display: *X11_Display, xev: *X11.XEvent) {
         case X11.Expose;
             array_add(*x11_display.base.events_this_frame, .{type=.WINDOW});
     }
+    return;
 }
 
 x11_clipboard_get_text :: (win: X11.Window) -> string {  // Allocated via alloc; should be manually freed.

--- a/modules/Linux_Display/ldx_input.jai
+++ b/modules/Linux_Display/ldx_input.jai
@@ -162,7 +162,7 @@ x11_update_window_events :: (display: *Display) {
     start_time := get_time();
     elapsed_time := start_time;
 
-    while X11.XPending(x11_display.handle) || (expect_more_events && elapsed_time < 1_000_000) {
+    while X11.XPending(x11_display.handle) || (expect_more_events && elapsed_time < 1.0) {
         result := X11.XCheckIfEvent(x11_display.handle, *xev, x11_event_predicate, null);
         if result {
             expect_more_events = x11_handle_event(x11_display, *xev);

--- a/modules/Linux_Display/ldx_input.jai
+++ b/modules/Linux_Display/ldx_input.jai
@@ -154,14 +154,15 @@ x11_update_window_events :: (display: *Display) {
     // Chromium (and its children) is particularly notorious for initiating a  big series of clipboard
     // events, and if we draw on every event then pasting into other program from Focus becomes slow.
     // So instead event handler says that it expects more events to come, so we don't release the
-    // event loop right away and instead wait for more events. We don't want to wait forever though,
-    //so we'll release the loop at most after a second, so some buggy program doesn't hang the editor.
+    // event loop right away and instead wait for more events.
+    // We don't want to wait forever though, so we'll release the loop either if some other event arrives
+    // that doesn't expect other events, or at most after a second,
+    // so some buggy program doesn't hang the editor while handling our clipboard response.
     expect_more_events := false;
     start_time := get_time();
     elapsed_time := start_time;
 
-    while X11.XPending(x11_display.handle) || (expect_more_events && elapsed_time < 1000000) {
-
+    while X11.XPending(x11_display.handle) || (expect_more_events && elapsed_time < 1_000_000) {
         result := X11.XCheckIfEvent(x11_display.handle, *xev, x11_event_predicate, null);
         if result {
             expect_more_events = x11_handle_event(x11_display, *xev);


### PR DESCRIPTION
We wait for 1 second at most so we don't hang the editor, but otherwise, this speeds up clipboard handling by A LOT depending on how many requests another program sends. Check on X11 in any Chromium-based application with and without this change.