### PR TITLE
Updated toggle_comment to support tabs, and be more robust

### DIFF
--- a/src/editors.jai
+++ b/src/editors.jai
@@ -2733,60 +2733,6 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
         }
     }
 
-    whitespace_get_visual_width :: inline (whitespace: string, tab_size: int) -> int {
-        // Given a string of whitespace, will return the visual width of said whitespace.
-        // Example: tab_size=4, "\t  \t " has 5 characters but due to tab alignment it looks like it's 9 wide.
-        indent := 0;
-        for cast([]u8) whitespace { indent = add_visual_indent(indent, it, tab_size); }
-        return indent;
-    }
-
-    whitespace_count_chars_in_visual_width :: inline (whitespace: string, visual_width: int, tab_size: int) -> int {
-        // Given whitespace and a visual width, will count the number of characters that fill that visual space.
-        // Example: tab_size=4, whitespace="\t\t\t", visual_width=8, will return 2 because the the first 8 spaces are taken up by 2 tab characters
-        char_index, indent := 0;
-        while indent < visual_width {
-            indent = add_visual_indent(indent, whitespace[char_index], tab_size);
-            char_index += 1;
-        }
-
-        // Do not count tab characters that go outside the bounds of this visual region.
-        return ifx indent > visual_width then char_index - 1 else char_index;
-    }
-
-    macro_every_loop :: (i: int) #expand {
-        `start, end := line_starts[i], line_starts[i+1];
-        `str        := cast(string) array_view(buffer.bytes, start, end-start);
-
-        // NOTE: 'str' may actually be multiple lines! This happens when you have two cursors and they are spaced multiple lines apart.
-        //       You get the start offsets of both lines, and with start=[i] and end=[i+1] you are selecting the whole region in between
-        //       those lines. Having multiple lines inside 'str' may seem weird but it's usually not a problem. Since we are using
-        //       line-comments, placing or removing a comment from the start of 'str' will only affect the first line, the lines below
-        //       are unchanged. And that's exactly what should happen, since we only want to modify the first line and leave the rest
-        //       unaffected.
-
-        `whitespace, `trimmed_str: string = ---;
-        `is_empty_line := true;
-        for c : cast([]u8) str {
-            if c == {
-                case #char "\t"; #through;
-                case #char " ";
-                    continue c;
-
-                // In this case, this one line is empty, but str contains multiple lines. See the large comment above.
-                case #char "\r"; #through;
-                case #char "\n";
-                    break c;
-
-                case;
-                    whitespace    = slice(str, 0, it_index);
-                    trimmed_str   = slice(str, it_index, str.count - it_index);
-                    is_empty_line = false;
-                    break c;
-            }
-        }
-    }
-
     comment: string = ---;
     if buffer.lang == {
         case .C;            comment = "//";
@@ -2801,67 +2747,102 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
     // Get the affected lines
     line_starts, last_line_end_offset := get_line_starts_for_lines_with_cursors_tmp(editor, buffer);
     last_line := line_starts.count - 1;
-    array_add(*line_starts, last_line_end_offset); // So that line_starts[i+1] will always work.
+    array_add(*line_starts, last_line_end_offset); // So that line_starts[it+1] will always work.
 
-    // NOTE: Before commenting/uncommenting, we loop over the selected lines in order to
-    //       A. Determine whether we're adding or removing comments.
-    //       B. Find the minimum indent (which is only for adding comments, but we don't know if we need it until the end of the loop)
+    // NOTE: Before commenting/uncommenting, we loop over the selected lines once to do the following:
+    //       A. Remember if the line is empty, because empty lines are ignored.
+    //       B. Determine whether we're adding or removing comments.
+    //       C. Find the minimum indent (which is only for adding comments, but we don't know if we need it until the end of the loop)
     //       Minimum indent works as follows:
 
     //         if foo {
     //             bar();
     //         }
-    // ^^^^^^^^ <- minimum indent
-    //
-    //         // if foo {
-    //         //     bar();
-    //         // }
-    // ^^^^1^^^   ^^^^3^^^^^
-    //         ^2^
+    // ^^^^^^^^   <- minimum indent
 
-    //       1. is generated using the user-defined spacing character (tabs or spaces)
-    //       2. is the comment character(s) plus one whitespace
-    //       3. is the rest of each line, left completely as-is
     //       To make this work intuitively and robustly, we have to measure the VISUAL width of the minimum indent.
     //       We cannot count the whitespace characters because there may be tabs, and tabs have weird alignment rules.
 
-    tab_size                := config.settings.tab_size;
-    min_indent_visual_width := -1;
-    add_comment             := false;
-    for 0..last_line {
-        macro_every_loop(it); //vars: is_empty_line, start, str, whitespace, trimmed_str
-        if is_empty_line continue;
+    // We're using a single bit on the line start offset to mark lines as empty. This saves us from having to loop over every line *again*
+    // once we start adding/removing comments. Since it is the sign bit, this doesn't overwrite any bits that could be part of valid offsets.
+    // We set this bit manually instead of multiplying with -1 because this way it also works for offset 0.
+    EMPTY_LINE_BIT  :: (cast(s64) 1) >>> 1;
+    LINE_START_MASK :: ~EMPTY_LINE_BIT;
 
-        whitespace_visual_width := whitespace_get_visual_width(whitespace, tab_size);
-        if min_indent_visual_width < 0 || whitespace_visual_width < min_indent_visual_width then min_indent_visual_width = whitespace_visual_width;
+    tab_size    := config.settings.tab_size;
+    min_indent  := -1;
+    add_comment := false;
+    for 0..last_line {
+        start, end := line_starts[it], line_starts[it+1];
+        str := cast(string) array_view(buffer.bytes, start, end-start);
+
+        // NOTE: 'str' may actually be multiple lines! This happens when you have two cursors and they are spaced multiple lines apart.
+        //       You get the start offsets of both lines, and with start=[i] and end=[i+1] you are selecting the whole region in between
+        //       those lines. Having multiple lines inside 'str' may seem weird but it's usually not a problem. Since we are using
+        //       line-comments, placing or removing a comment from the start of 'str' will only affect the first line, the lines below
+        //       are unchanged. And that's exactly what should happen, since we only want to modify the first line and leave the rest
+        //       unaffected.
+
+        indent        := 0;
+        is_empty_line := true;
+        trimmed_str: string = ---;
+        for c : cast([]u8) str {
+            if c == {
+                case #char "\t"; #through;
+                case #char " ";
+                    indent = add_visual_indent(indent, c, tab_size);
+                    continue c;
+
+                // In this case, this one line is empty, but str contains multiple lines. See the large comment above.
+                case #char "\r"; #through;
+                case #char "\n";
+                    break c;
+
+                case;
+                    trimmed_str   = slice(str, it_index, str.count - it_index);
+                    is_empty_line = false;
+                    break c;
+            }
+        }
+
+        if is_empty_line { line_starts[it] |= EMPTY_LINE_BIT; continue; }
+        if min_indent < 0 || indent < min_indent then min_indent = indent;
         if !add_comment && !begins_with(trimmed_str, comment) then add_comment = true;
     }
 
-    if min_indent_visual_width < 0 then min_indent_visual_width = 0;
+    if min_indent < 0 then min_indent = 0;
+    print("min indent is %\n", min_indent);
 
     // Build a replacement string
     b: String_Builder;  // not using temp because the string may be too large
 
     if add_comment {
         use_spaces := config.settings.insert_spaces_when_pressing_tab;
-        new_whitespace := ifx use_spaces then get_tmp_spaces(min_indent_visual_width) else {
-            tab_count := min_indent_visual_width / tab_size; // Aligns the indentation with tab columns because of integer division.
-            min_indent_visual_width = tab_count * tab_size;  // Update min_indent too. If you use tabs, your comments will align with tab columns.
+        new_whitespace := ifx use_spaces then get_tmp_spaces(min_indent) else {
+            tab_count := min_indent / tab_size; // Aligns the indentation with tab columns because of integer division.
+            min_indent = tab_count * tab_size;  // Update min_indent too. If you use tabs, your comments will align with tab columns.
             get_tmp_tabs(tab_count);
         }
 
         adjustment := 0;
         for 0..last_line {
-            macro_every_loop(it); //vars: is_empty_line, start, str, whitespace, trimmed_str
-            if is_empty_line { append(*b, str); continue; }
+            start, end := line_starts[it] & LINE_START_MASK, line_starts[it+1] & LINE_START_MASK;
+            str        := cast(string) array_view(buffer.bytes, start, end-start);
+            if line_starts[it] & EMPTY_LINE_BIT { append(*b, str); continue; }
 
-            old_whitespace_count := whitespace_count_chars_in_visual_width(whitespace, min_indent_visual_width, tab_size);
-            rest_of_line         := advance(str, old_whitespace_count);
+            // Count how many characters are in the minimum indent, then cut off those characters since they will be replaced with new_whitespace
+            indent, old_whitespace_count: int = 0;
+            while indent < min_indent {
+                indent = add_visual_indent(indent, str[old_whitespace_count], tab_size);
+                old_whitespace_count += 1;
+            }
+            if indent > min_indent then old_whitespace_count -= 1;
+            trimmed_str := advance(str, old_whitespace_count);
 
             append(*b, new_whitespace);
             append(*b, comment);
             append(*b, " ");
-            append(*b, rest_of_line);
+            append(*b, trimmed_str);
 
             adjusted_start             := start + adjustment;
             adjusted_old_comment_start := start + adjustment + old_whitespace_count;
@@ -2880,16 +2861,18 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
     } else { // Remove comments
         adjustment := 0;
         for 0..last_line {
-            macro_every_loop(it); //vars: is_empty_line, start, str, whitespace, trimmed_str
-            if is_empty_line { append(*b, str); continue; }
+            start, end := line_starts[it] & LINE_START_MASK, line_starts[it+1] & LINE_START_MASK;
+            str        := cast(string) array_view(buffer.bytes, start, end-start);
+            if line_starts[it] & EMPTY_LINE_BIT { append(*b, str); continue; }
 
-            // Since we are un-commenting, we know for certain that any non-empty line begins with a comment.
-            // But is there also a space? If so, we remove that too.
-            len_comment  := comment.count + xx (trimmed_str.count > comment.count && trimmed_str[comment.count] == #char " ");
-            rest_of_line := advance(trimmed_str, len_comment);
+            found, whitespace, after_comment := split_from_left(str, comment);
+            assert(found, "When un-commenting, all non-empty lines should have a comment.");
+
+            len_comment := comment.count;
+            if begins_with(after_comment, " ") { advance(*after_comment, 1); len_comment += 1; }
 
             append(*b, whitespace);
-            append(*b, rest_of_line);
+            append(*b, after_comment);
 
             adjusted_comment_start := start + whitespace.count + adjustment;
             for * cursor : editor.cursors {
@@ -2903,7 +2886,7 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
     new_str := builder_to_string(*b);
     defer free(new_str);
 
-    range := Offset_Range.{ start = xx line_starts[0], end = xx last_line_end_offset };
+    range := Offset_Range.{ start = xx line_starts[0] & LINE_START_MASK, end = xx last_line_end_offset };
     replace_range(buffer, range, new_str);
 
     for * cursor : editor.cursors { cursor.col_wanted = -1; }

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -2725,14 +2725,6 @@ paste_from_clipboard :: (editor: *Editor, buffer: *Buffer) {
 
 toggle_comment :: (editor: *Editor, buffer: *Buffer) {
 
-    add_visual_indent :: inline (indent: int, char: u8, tab_size: int, $loc := #caller_location) -> new_indent: int {
-        if char == {
-            case #char " ";  return indent + 1;
-            case #char "\t"; return indent + tab_size - (indent % tab_size); // tab alignment is weird.
-            case;            assert(false, "Unexpected character 0x%, (expected only tabs/spaces)\n", FormatInt.{value=char, base=16}, loc = loc); return 0;
-        }
-    }
-
     comment: string = ---;
     if buffer.lang == {
         case .C;            comment = "//";
@@ -2788,10 +2780,8 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
         trimmed_str: string = ---;
         for c : cast([]u8) str {
             if c == {
-                case #char "\t"; #through;
-                case #char " ";
-                    indent = add_visual_indent(indent, c, tab_size);
-                    continue c;
+                case #char "\t"; indent += tab_size - (indent % tab_size); continue c;
+                case #char " ";  indent += 1;                              continue c;
 
                 // In this case, this one line is empty, but str contains multiple lines. See the large comment above.
                 case #char "\r"; #through;
@@ -2829,10 +2819,14 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
             str        := cast(string) array_view(buffer.bytes, start, end-start);
             if line_starts[it] & EMPTY_LINE_BIT { append(*b, str); continue; }
 
-            // Count how many characters are in the minimum indent, then cut off those characters since they will be replaced with new_whitespace
-            indent, old_whitespace_count: int = 0;
+            indent, old_whitespace_count := 0;
             while indent < min_indent {
-                indent = add_visual_indent(indent, str[old_whitespace_count], tab_size);
+                c := str[old_whitespace_count];
+                if c == {
+                    case #char " ";  indent += 1;
+                    case #char "\t"; indent += tab_size - (indent % tab_size);
+                    case;            assert(false, "Unexpected character 0x%, (expected only tabs/spaces)\n", formatInt(c, base=16));
+                }
                 old_whitespace_count += 1;
             }
             if indent > min_indent then old_whitespace_count -= 1;

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -2811,7 +2811,6 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
     }
 
     if min_indent < 0 then min_indent = 0;
-    print("min indent is %\n", min_indent);
 
     // Build a replacement string
     b: String_Builder;  // not using temp because the string may be too large

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -2743,7 +2743,7 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
 
     whitespace_count_chars_in_visual_width :: inline (whitespace: string, visual_width: int, tab_size: int) -> int {
         // Given whitespace and a visual width, will count the number of characters that fill that visual space.
-        // Example: tab_size=4, s="\t\t\t", visual_width=8, will return 2 because the the first 8 spaces are taken up by 2 tab characters
+        // Example: tab_size=4, whitespace="\t\t\t", visual_width=8, will return 2 because the the first 8 spaces are taken up by 2 tab characters
         char_index, indent := 0;
         while indent < visual_width {
             indent = add_visual_indent(indent, whitespace[char_index], tab_size);
@@ -2758,12 +2758,12 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
         `start, end := line_starts[i], line_starts[i+1];
         `str        := cast(string) array_view(buffer.bytes, start, end-start);
 
-        // Note that 'str' may actually be multiple lines! This happens when you have two cursors and they are spaced
-        // multiple lines apart. You get the start offsets of both lines, and with start=[i] and end=[i+1] you are selecting the
-        // whole region in between those lines.
-        // Having multiple lines inside 'str' may seem weird but it's usually not a problem. Since we are using line-comments,
-        // placing or removing a comment from the start of 'str' will only affect the first line, the lines below are unchanged.
-        // And that's exactly what should happen, since we only want to modify the first line and leave the rest unaffected.
+        // NOTE: 'str' may actually be multiple lines! This happens when you have two cursors and they are spaced multiple lines apart.
+        //       You get the start offsets of both lines, and with start=[i] and end=[i+1] you are selecting the whole region in between
+        //       those lines. Having multiple lines inside 'str' may seem weird but it's usually not a problem. Since we are using
+        //       line-comments, placing or removing a comment from the start of 'str' will only affect the first line, the lines below
+        //       are unchanged. And that's exactly what should happen, since we only want to modify the first line and leave the rest
+        //       unaffected.
 
         `whitespace, `trimmed_str: string = ---;
         `is_empty_line := true;
@@ -2803,27 +2803,27 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
     last_line := line_starts.count - 1;
     array_add(*line_starts, last_line_end_offset); // So that line_starts[i+1] will always work.
 
-    // Before commenting/uncommenting, we loop over the selected lines in order to
-    // A. Determine whether we're adding or removing comments.
-    // B. Find the minimum indent (which is only needed when adding comments, but )
-    // Minimum indent works as follows:
-    /*
-        if foo {
-            bar();
-        }
-^^^^^^^^ <- minimum indent
+    // NOTE: Before commenting/uncommenting, we loop over the selected lines in order to
+    //       A. Determine whether we're adding or removing comments.
+    //       B. Find the minimum indent (which is only for adding comments, but we don't know if we need it until the end of the loop)
+    //       Minimum indent works as follows:
 
-        // if foo {
-        //     bar();
-        // }
-^^^^1^^^   ^^^^3^^^^^
-        ^2^
-    */
-    // 1. is generated using the user-defined spacing character (tabs or spaces)
-    // 2. is the comment character(s) plus one whitespace
-    // 3. is the rest of each line, left completely as-is
-    // To make this work intuitively and robustly, we have to measure the VISUAL width of the minimum indent.
-    // We cannot count the whitespace characters because there may be tabs, and tabs have weird alignment rules.
+    //         if foo {
+    //             bar();
+    //         }
+    // ^^^^^^^^ <- minimum indent
+    //
+    //         // if foo {
+    //         //     bar();
+    //         // }
+    // ^^^^1^^^   ^^^^3^^^^^
+    //         ^2^
+
+    //       1. is generated using the user-defined spacing character (tabs or spaces)
+    //       2. is the comment character(s) plus one whitespace
+    //       3. is the rest of each line, left completely as-is
+    //       To make this work intuitively and robustly, we have to measure the VISUAL width of the minimum indent.
+    //       We cannot count the whitespace characters because there may be tabs, and tabs have weird alignment rules.
 
     tab_size                := config.settings.tab_size;
     min_indent_visual_width := -1;
@@ -2872,7 +2872,6 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
             for * cursor : editor.cursors {
                 if      cursor.pos > adjusted_old_comment_start then cursor.pos += xx line_length_difference;
                 else if cursor.pos >= adjusted_start            then cursor.pos  = xx adjusted_new_comment_start;
-
                 if      cursor.sel > adjusted_old_comment_start then cursor.sel += xx line_length_difference;
                 else if cursor.sel >= adjusted_start            then cursor.sel  = xx adjusted_new_comment_start;
             }

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -2729,7 +2729,7 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
         if foo {
             bar();
         }
-^^^^^^^^ <- minimum indent  (visual width is different from character count because there may be tabs)
+^^^^^^^^ <- minimum indent
 
         // if foo {
         //     bar();
@@ -2737,55 +2737,38 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
 ^^^^1^^^   ^^^^3^^^^^
         ^2^
 
-    Notice how the comment preceding bar() is indented at the same level as the other comments even though that line had more whitespace.
-    To do that, we need to take note of the minimum indent, which is determined by the leftmost non-whistespace character in the selection.
+    1. is generated using the user-defined spacing character (tabs or spaces)
+    2. is the comment character(s) plus one whitespace
+    3. is the rest of each line, left completely as-is
 
-    To make this work intuitively and robustly, we have to measure the VISUAL with of the minimum indent.
+    To make this work intuitively and robustly, we have to measure the VISUAL width of the minimum indent.
     Why can't we just count characters? Because there may be tabs. And tabs ruin everything. (I actually prefer tabs, but from a text editor's POV they are hell)
     Tabs vary in size due to weird alignment rules people made up back when typewriters were still a thing.
 
-    After getting the visual width of the minimum indent, construct the commented out lines. Here's a description of the different parts
-    labeled in the example above:
-
-    1. A string built from the user-defined space character. (As wide as minimum indent, here that's 2 tabs or 8 spaces)
-    2. In between, we put the comment symbol + a single space. Usually that's "// ".
-    3. The rest of the line is kept as-is. That includes any whitespace that exceeded the minimum indent. For instance, if the line
-       with bar() on it was made of tabs, then after the "// " there would still be a single tab that did not get replaced by spaces.
-       This is very much on purpose. It keeps any weird alignment the user had (like half indents or whatever) exactly the same.
-       If they wanted us to align it for them then they would've used autoindent_region.
-
     */
 
-    // Helper procs
-
-    add_visual_indent :: inline (indent: int, char: u8, tab_size: int) -> new_indent: int, err := false #must {
+    add_visual_indent :: inline (indent: int, char: u8, tab_size: int, $loc := #caller_location) -> new_indent: int {
         if char == {
             case #char " ";  return indent + 1;
             case #char "\t"; return indent + tab_size - (indent % tab_size); // tab alignment is weird.
-            case;            return 0, err = true;
-            // err_msg := tprint("Unexpected character 0x%, (expected only tabs/spaces)\n", FormatInt.{value=char, base=16});
+            case; assert(false, "Unexpected character 0x%, (expected only tabs/spaces)\n", FormatInt.{value=char, base=16}, loc = loc); return 0;
         }
     }
 
-    whitespace_get_visual_width :: inline (s: string, tab_size: int) -> int, err := false {
+    whitespace_get_visual_width :: inline (whitespace: string, tab_size: int) -> int {
         // Given a string of whitespace, will return the visual width of said whitespace.
         // Example: tab_size=4, "\t  \t " has 5 characters but due to tab alignment it looks like it's 9 wide.
         indent := 0;
-        for char: cast([]u8) s {
-            indent=, err := add_visual_indent(indent, char, tab_size);
-            if err return 0, err;
-        }
+        for cast([]u8) whitespace  indent = add_visual_indent(indent, it, tab_size);
         return indent;
     }
 
-    whitespace_count_chars_in_visual_width :: inline (s: string, visual_width: int, tab_size: int) -> int, err := false #must {
+    whitespace_count_chars_in_visual_width :: inline (whitespace: string, visual_width: int, tab_size: int) -> int {
         // Given whitespace and a visual width, will count the number of characters that fill that visual space.
         // Example: tab_size=4, s="\t\t\t", visual_width=8, will return 2 because the the first 8 spaces are taken up by 2 tab characters
-        char_index := 0;
-        indent     := 0;
+        char_index, indent := 0;
         while indent < visual_width {
-            indent=, err := add_visual_indent(indent, s[char_index], tab_size);
-            if err return 0, err;
+            indent = add_visual_indent(indent, whitespace[char_index], tab_size);
             char_index += 1;
         }
 
@@ -2793,6 +2776,32 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
         return ifx indent > visual_width then char_index - 1 else char_index;
     }
 
+    macro_every_loop :: (i: int) #expand {
+        `start, end := line_starts[i], line_starts[i+1];
+        `str        := cast(string) array_view(buffer.bytes, start, end-start);
+
+        // Note that 'str' may actually be multiple lines! This happens when you have two cursors and they are spaced
+        // multiple lines apart. You get the start offsets of both lines, and with start=[i] and end=[i+1] you are selecting the
+        // whole region in between those lines.
+        // Having multiple lines inside 'str' may seem weird but it's usually not a problem. Since we are using line-comments,
+        // placing or removing a comment from the start of 'str' will only affect the first line, the lines below are unchanged.
+        // And that's exactly what should happen, since we only want to modify the first line and leave the rest unaffected.
+
+        `whitespace, `trimmed_str: string = ---;
+        `is_empty_line := true;
+        for c: cast([]u8) str  if c == {
+          case #char "\t"; #through; case #char " ";  continue c;
+
+          // In this case, this one line is empty, but str contains multiple lines. See the large comment above.
+          case #char "\r"; #through; case #char "\n"; break c;
+
+          case;
+            whitespace    = slice(str, 0, it_index);
+            trimmed_str   = slice(str, it_index, str.count - it_index);
+            is_empty_line = false;
+            break c;
+        }
+    }
 
 
     comment: string = ---;
@@ -2810,33 +2819,22 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
     // Get the affected lines
     line_starts, last_line_end_offset := get_line_starts_for_lines_with_cursors_tmp(editor, buffer);
     last_line := line_starts.count - 1;
-    array_add(*line_starts, last_line_end_offset);
-
-    get_str_or_continue :: (i: int, before_continue: Code = #code {}) #expand {
-        `start, `end  := line_starts[i], line_starts[i+1];
-        `str          := cast(string) array_view(buffer.bytes, start, end-start);
-        `trimmed_str  := trim_left(str, " \t\r\n");
-        // Besides spaces/tabs, we trim newlines because an empty line contains a newline at the end. Required for empty line detection.
-
-        if !trimmed_str { #insert before_continue; continue; }
-
-        `whitespace := to_string(str.data, str.count - trimmed_str.count);
-    }
+    array_add(*line_starts, last_line_end_offset); // So that line_starts[i+1] will always work.
 
     tab_size                := config.settings.tab_size;
     min_indent_visual_width := -1;
     add_comment             := false;
 
     for 0..last_line {
-        get_str_or_continue(it); // start, end, str, whitespace, trimmed_str
+        macro_every_loop(it); //vars: is_empty_line, start, str, whitespace, trimmed_str
+        if is_empty_line continue;
 
-        if !add_comment && !begins_with(trimmed_str, comment) then add_comment = true;
-
-        whitespace_visual_width, err := whitespace_get_visual_width(whitespace, tab_size);
-        if err continue;
+        whitespace_visual_width := whitespace_get_visual_width(whitespace, tab_size);
 
         if min_indent_visual_width < 0 || whitespace_visual_width < min_indent_visual_width
             then min_indent_visual_width = whitespace_visual_width;
+
+        if !add_comment && !begins_with(trimmed_str, comment) then add_comment = true;
     }
 
     if min_indent_visual_width < 0 then min_indent_visual_width = 0;
@@ -2846,23 +2844,21 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
     b: String_Builder;  // not using temp because the string may be too large
 
     if add_comment {
-        // Add comments to nonempty strings
 
-        use_tabs := !config.settings.insert_spaces_when_pressing_tab;
-
-        new_whitespace := ifx use_tabs then {
+        use_spaces := config.settings.insert_spaces_when_pressing_tab;
+        new_whitespace := ifx use_spaces then get_tmp_spaces(min_indent_visual_width) else {
             tab_count := min_indent_visual_width / tab_size; // Aligns the indentation with tab columns because of integer division.
             min_indent_visual_width = tab_count * tab_size;  // Update min_indent too. If you use tabs, your comments will align with tab columns.
             get_tmp_tabs(tab_count);
-        } else get_tmp_spaces(min_indent_visual_width);
+        }
 
         adjustment := 0;
         for 0..last_line {
-            get_str_or_continue(it, before_continue = #code append(*b, str)); // start, end, str, whitespace, trimmed_str
+            macro_every_loop(it); //vars: is_empty_line, start, str, whitespace, trimmed_str
+            if is_empty_line { append(*b, str); continue; }
 
-            old_whitespace_count, err := whitespace_count_chars_in_visual_width(whitespace, min_indent_visual_width, tab_size);
-            if err { append(*b, str); continue; }
-            rest_of_line              := advance(str, old_whitespace_count);
+            old_whitespace_count := whitespace_count_chars_in_visual_width(whitespace, min_indent_visual_width, tab_size);
+            rest_of_line         := advance(str, old_whitespace_count);
 
             append(*b, new_whitespace);
             append(*b, comment);
@@ -2885,16 +2881,18 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
 
             adjustment += line_length_difference;
         }
-    } else {
-        // Remove comments from nonempty strings
+
+    } else { // Remove comments
 
         adjustment := 0;
         for 0..last_line {
-            get_str_or_continue(it, before_continue = #code append(*b, str)); // start, end, str, whitespace, trimmed_str
+            macro_every_loop(it); //vars: is_empty_line, start, str, whitespace, trimmed_str
+            if is_empty_line { append(*b, str); continue; }
 
             // Since we are un-commenting, we know for certain that any non-empty line begins with a comment.
-            len_comment  := comment.count + xx (trimmed_str[comment.count] == #char " "); // Also cut off 1 space if there is one.
-            rest_of_line := advance(trimmed_str, len_comment); // Remove comment
+            // But is there also a space? If so, we remove that too.
+            len_comment  := comment.count + xx (trimmed_str.count > comment.count && trimmed_str[comment.count] == #char " ");
+            rest_of_line := advance(trimmed_str, len_comment);
 
             append(*b, whitespace);
             append(*b, rest_of_line);

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -2724,88 +2724,188 @@ paste_from_clipboard :: (editor: *Editor, buffer: *Buffer) {
 }
 
 toggle_comment :: (editor: *Editor, buffer: *Buffer) {
-    comment_without_space: string;
-    comment: string;
+    /*
+
+        if foo {
+            bar();
+        }
+^^^^^^^^ <- minimum indent  (visual width is different from character count because there may be tabs)
+
+        // if foo {
+        //     bar();
+        // }
+^^^^1^^^   ^^^^3^^^^^
+        ^2^
+
+    Notice how the comment preceding bar() is indented at the same level as the other comments even though that line had more whitespace.
+    To do that, we need to take note of the minimum indent, which is determined by the leftmost non-whistespace character in the selection.
+
+    To make this work intuitively and robustly, we have to measure the VISUAL with of the minimum indent.
+    Why can't we just count characters? Because there may be tabs. And tabs ruin everything. (I actually prefer tabs, but from a text editor's POV they are hell)
+    Tabs vary in size due to weird alignment rules people made up back when typewriters were still a thing.
+
+    After getting the visual width of the minimum indent, construct the commented out lines. Here's a description of the different parts
+    labeled in the example above:
+
+    1. A string built from the user-defined space character. (As wide as minimum indent, here that's 2 tabs or 8 spaces)
+    2. In between, we put the comment symbol + a single space. Usually that's "// ".
+    3. The rest of the line is kept as-is. That includes any whitespace that exceeded the minimum indent. For instance, if the line
+       with bar() on it was made of tabs, then after the "// " there would still be a single tab that did not get replaced by spaces.
+       This is very much on purpose. It keeps any weird alignment the user had (like half indents or whatever) exactly the same.
+       If they wanted us to align it for them then they would've used autoindent_region.
+
+    */
+
+    // Helper procs
+
+    add_visual_indent :: inline (indent: int, char: u8, tab_size: int) -> new_indent: int, err := false #must {
+        if char == {
+            case #char " ";  return indent + 1;
+            case #char "\t"; return indent + tab_size - (indent % tab_size); // tab alignment is weird.
+            case;            return 0, err = true;
+            // err_msg := tprint("Unexpected character 0x%, (expected only tabs/spaces)\n", FormatInt.{value=char, base=16});
+        }
+    }
+
+    whitespace_get_visual_width :: inline (s: string, tab_size: int) -> int, err := false {
+        // Given a string of whitespace, will return the visual width of said whitespace.
+        // Example: tab_size=4, "\t  \t " has 5 characters but due to tab alignment it looks like it's 9 wide.
+        indent := 0;
+        for char: cast([]u8) s {
+            indent=, err := add_visual_indent(indent, char, tab_size);
+            if err return 0, err;
+        }
+        return indent;
+    }
+
+    whitespace_count_chars_in_visual_width :: inline (s: string, visual_width: int, tab_size: int) -> int, err := false #must {
+        // Given whitespace and a visual width, will count the number of characters that fill that visual space.
+        // Example: tab_size=4, s="\t\t\t", visual_width=8, will return 2 because the the first 8 spaces are taken up by 2 tab characters
+        char_index := 0;
+        indent     := 0;
+        while indent < visual_width {
+            indent=, err := add_visual_indent(indent, s[char_index], tab_size);
+            if err return 0, err;
+            char_index += 1;
+        }
+
+        // Do not count tab characters that go outside the bounds of this visual region.
+        return ifx indent > visual_width then char_index - 1 else char_index;
+    }
+
+
+
+    comment: string = ---;
 
     if buffer.lang == {
-        case .C;            comment_without_space = "//";
-        case .CSharp;       comment_without_space = "//";
-        case .Golang;       comment_without_space = "//";
-        case .Glsl;         comment_without_space = "//";
-        case .Jai;          comment_without_space = "//";
-        case .Focus_Config; comment_without_space = "#";
+        case .C;            comment = "//";
+        case .CSharp;       comment = "//";
+        case .Golang;       comment = "//";
+        case .Glsl;         comment = "//";
+        case .Jai;          comment = "//";
+        case .Focus_Config; comment = "#";
         case;               return;
     }
-    comment = tprint("% ", comment_without_space);
 
     // Get the affected lines
     line_starts, last_line_end_offset := get_line_starts_for_lines_with_cursors_tmp(editor, buffer);
+    last_line := line_starts.count - 1;
     array_add(*line_starts, last_line_end_offset);
 
-    // Figure out whether we're commenting out or removing comments
-    min_whitespace := -1;
-    add_comment := false;
-    for 0..line_starts.count-2 {
-        start, end := line_starts[it], line_starts[it+1];
-        str := to_string(array_view(buffer.bytes, start, end-start));
-        trimmed_str := trim_left(str, " \r\n\t");
-        if !trimmed_str continue;
+    get_str_or_continue :: (i: int, before_continue: Code = #code {}) #expand {
+        `start, `end  := line_starts[i], line_starts[i+1];
+        `str          := cast(string) array_view(buffer.bytes, start, end-start);
+        `trimmed_str  := trim_left(str, " \t\r\n");
+        // Besides spaces/tabs, we trim newlines because an empty line contains a newline at the end. Required for empty line detection.
 
-        if !add_comment && !begins_with(trimmed_str, comment_without_space) then add_comment = true;
-        len_whitespace := str.count - trimmed_str.count;
-        if min_whitespace < 0 || len_whitespace < min_whitespace then min_whitespace = len_whitespace;
+        if !trimmed_str { #insert before_continue; continue; }
+
+        `whitespace := to_string(str.data, str.count - trimmed_str.count);
     }
-    if min_whitespace < 0 then min_whitespace = 0;
+
+    tab_size                := config.settings.tab_size;
+    min_indent_visual_width := -1;
+    add_comment             := false;
+
+    for 0..last_line {
+        get_str_or_continue(it); // start, end, str, whitespace, trimmed_str
+
+        if !add_comment && !begins_with(trimmed_str, comment) then add_comment = true;
+
+        whitespace_visual_width, err := whitespace_get_visual_width(whitespace, tab_size);
+        if err continue;
+
+        if min_indent_visual_width < 0 || whitespace_visual_width < min_indent_visual_width
+            then min_indent_visual_width = whitespace_visual_width;
+    }
+
+    if min_indent_visual_width < 0 then min_indent_visual_width = 0;
+
 
     // Build a replacement string
     b: String_Builder;  // not using temp because the string may be too large
+
     if add_comment {
         // Add comments to nonempty strings
-        spaces := get_tmp_spaces(min_whitespace);
-        chars_added := 0;
-        for 0..line_starts.count-2 {
-            start, end := line_starts[it], line_starts[it+1];
-            if start > buffer.bytes.count continue;
-            str := to_string(array_view(buffer.bytes, start, end-start));
-            trimmed_str := trim_left(str, " \r\n\t");
-            if !trimmed_str { append(*b, str); continue; }  // append as is
 
-            append(*b, spaces);
+        use_tabs := !config.settings.insert_spaces_when_pressing_tab;
+
+        new_whitespace := ifx use_tabs then {
+            tab_count := min_indent_visual_width / tab_size; // Aligns the indentation with tab columns because of integer division.
+            min_indent_visual_width = tab_count * tab_size;  // Update min_indent too. If you use tabs, your comments will align with tab columns.
+            get_tmp_tabs(tab_count);
+        } else get_tmp_spaces(min_indent_visual_width);
+
+        adjustment := 0;
+        for 0..last_line {
+            get_str_or_continue(it, before_continue = #code append(*b, str)); // start, end, str, whitespace, trimmed_str
+
+            old_whitespace_count, err := whitespace_count_chars_in_visual_width(whitespace, min_indent_visual_width, tab_size);
+            if err { append(*b, str); continue; }
+            rest_of_line              := advance(str, old_whitespace_count);
+
+            append(*b, new_whitespace);
             append(*b, comment);
-            append(*b, to_string(array_view(buffer.bytes, start + min_whitespace, end - start - min_whitespace)));
+            append(*b, " ");
+            append(*b, rest_of_line);
 
-            adjusted_start := start + chars_added + min_whitespace;
-            for * cursor : editor.cursors {
-                if cursor.pos >= adjusted_start then cursor.pos += xx comment.count;
-                if cursor.sel >= adjusted_start then cursor.sel += xx comment.count;
+            adjusted_start             := start + adjustment;
+            adjusted_old_comment_start := start + adjustment + old_whitespace_count;
+            adjusted_new_comment_start := start + adjustment + new_whitespace.count;
+
+            line_length_difference := -old_whitespace_count + new_whitespace.count + (comment.count + 1);
+
+            for * cursor: editor.cursors {
+                if      cursor.pos > adjusted_old_comment_start then cursor.pos += xx line_length_difference;
+                else if cursor.pos >= adjusted_start            then cursor.pos  = xx adjusted_new_comment_start;
+
+                if      cursor.sel > adjusted_old_comment_start then cursor.sel += xx line_length_difference;
+                else if cursor.sel >= adjusted_start            then cursor.sel  = xx adjusted_new_comment_start;
             }
 
-            chars_added += comment.count;
+            adjustment += line_length_difference;
         }
     } else {
         // Remove comments from nonempty strings
-        chars_removed := 0;
-        for 0..line_starts.count-2 {
-            start, end := line_starts[it], line_starts[it+1];
-            if start > buffer.bytes.count continue;
-            str := to_string(array_view(buffer.bytes, start, end-start));
-            trimmed_str := trim_left(str, " \r\n\t");
-            if !trimmed_str { append(*b, str); continue; }  // append as is
 
-            len_whitespace := str.count - trimmed_str.count;
-            append(*b, to_string(array_view(buffer.bytes, start, len_whitespace)));  // spaces before the comment
-            advance(*str, len_whitespace);
-            len_comment := ifx begins_with(str, comment) then comment.count else comment_without_space.count;
-            advance(*str, len_comment);
-            append(*b, str);
+        adjustment := 0;
+        for 0..last_line {
+            get_str_or_continue(it, before_continue = #code append(*b, str)); // start, end, str, whitespace, trimmed_str
 
-            adjusted_start := start - chars_removed + len_whitespace;
-            for * cursor : editor.cursors {
-                if cursor.pos >= adjusted_start then cursor.pos -= xx min(len_comment, cursor.pos - adjusted_start);
-                if cursor.sel >= adjusted_start then cursor.sel -= xx min(len_comment, cursor.sel - adjusted_start);
+            // Since we are un-commenting, we know for certain that any non-empty line begins with a comment.
+            len_comment  := comment.count + xx (trimmed_str[comment.count] == #char " "); // Also cut off 1 space if there is one.
+            rest_of_line := advance(trimmed_str, len_comment); // Remove comment
+
+            append(*b, whitespace);
+            append(*b, rest_of_line);
+
+            adjusted_comment_start := start + whitespace.count + adjustment;
+            for * cursor: editor.cursors {
+                if cursor.pos > adjusted_comment_start then cursor.pos -= xx min(len_comment, cursor.pos - adjusted_comment_start);
+                if cursor.sel > adjusted_comment_start then cursor.sel -= xx min(len_comment, cursor.sel - adjusted_comment_start);
             }
 
-            chars_removed += len_comment;
+            adjustment -= len_comment;
         }
     }
 

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -2821,6 +2821,7 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
             str        := cast(string) array_view(buffer.bytes, start, end-start);
             if line_starts[it] & EMPTY_LINE_BIT { append(*b, str); continue; }
 
+            // Count how many characters are in the minimum indent, then cut off those characters since they will be replaced with new_whitespace
             indent, old_whitespace_count := 0;
             while indent < min_indent {
                 c := str[old_whitespace_count];

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -2763,7 +2763,6 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
     EMPTY_LINE_BIT  :: (cast(s64) 1) >>> 1;
     LINE_START_MASK :: ~EMPTY_LINE_BIT;
 
-    tab_size    := config.settings.tab_size;
     min_indent  := -1;
     add_comment := false;
     for 0..last_line {
@@ -2782,7 +2781,7 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
         trimmed_str: string = ---;
         for c : cast([]u8) str {
             if c == {
-                case #char "\t"; indent += tab_size - (indent % tab_size); continue c;
+                case #char "\t"; indent += TAB_SIZE - (indent % TAB_SIZE); continue c;
                 case #char " ";  indent += 1;                              continue c;
 
                 // In this case, this one line is empty, but str contains multiple lines. See the large comment above.
@@ -2810,8 +2809,8 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
     if add_comment {
         use_spaces := config.settings.insert_spaces_when_pressing_tab;
         new_whitespace := ifx use_spaces then get_tmp_spaces(min_indent) else {
-            tab_count := min_indent / tab_size; // Aligns the indentation with tab columns because of integer division.
-            min_indent = tab_count * tab_size;  // Update min_indent too. If you use tabs, your comments will align with tab columns.
+            tab_count := min_indent / TAB_SIZE; // Aligns the indentation with tab columns because of integer division.
+            min_indent = tab_count * TAB_SIZE;  // Update min_indent too. If you use tabs, your comments will align with tab columns.
             get_tmp_tabs(tab_count);
         }
 
@@ -2827,7 +2826,7 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
                 c := str[old_whitespace_count];
                 if c == {
                     case #char " ";  indent += 1;
-                    case #char "\t"; indent += tab_size - (indent % tab_size);
+                    case #char "\t"; indent += TAB_SIZE - (indent % TAB_SIZE);
                     case;            assert(false, "Unexpected character 0x%, (expected only tabs/spaces)\n", formatInt(c, base=16));
                 }
                 old_whitespace_count += 1;

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -2724,34 +2724,12 @@ paste_from_clipboard :: (editor: *Editor, buffer: *Buffer) {
 }
 
 toggle_comment :: (editor: *Editor, buffer: *Buffer) {
-    /*
-
-        if foo {
-            bar();
-        }
-^^^^^^^^ <- minimum indent
-
-        // if foo {
-        //     bar();
-        // }
-^^^^1^^^   ^^^^3^^^^^
-        ^2^
-
-    1. is generated using the user-defined spacing character (tabs or spaces)
-    2. is the comment character(s) plus one whitespace
-    3. is the rest of each line, left completely as-is
-
-    To make this work intuitively and robustly, we have to measure the VISUAL width of the minimum indent.
-    Why can't we just count characters? Because there may be tabs. And tabs ruin everything. (I actually prefer tabs, but from a text editor's POV they are hell)
-    Tabs vary in size due to weird alignment rules people made up back when typewriters were still a thing.
-
-    */
 
     add_visual_indent :: inline (indent: int, char: u8, tab_size: int, $loc := #caller_location) -> new_indent: int {
         if char == {
             case #char " ";  return indent + 1;
             case #char "\t"; return indent + tab_size - (indent % tab_size); // tab alignment is weird.
-            case; assert(false, "Unexpected character 0x%, (expected only tabs/spaces)\n", FormatInt.{value=char, base=16}, loc = loc); return 0;
+            case;            assert(false, "Unexpected character 0x%, (expected only tabs/spaces)\n", FormatInt.{value=char, base=16}, loc = loc); return 0;
         }
     }
 
@@ -2759,7 +2737,7 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
         // Given a string of whitespace, will return the visual width of said whitespace.
         // Example: tab_size=4, "\t  \t " has 5 characters but due to tab alignment it looks like it's 9 wide.
         indent := 0;
-        for cast([]u8) whitespace  indent = add_visual_indent(indent, it, tab_size);
+        for cast([]u8) whitespace { indent = add_visual_indent(indent, it, tab_size); }
         return indent;
     }
 
@@ -2789,23 +2767,27 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
 
         `whitespace, `trimmed_str: string = ---;
         `is_empty_line := true;
-        for c: cast([]u8) str  if c == {
-          case #char "\t"; #through; case #char " ";  continue c;
+        for c : cast([]u8) str {
+            if c == {
+                case #char "\t"; #through;
+                case #char " ";
+                    continue c;
 
-          // In this case, this one line is empty, but str contains multiple lines. See the large comment above.
-          case #char "\r"; #through; case #char "\n"; break c;
+                // In this case, this one line is empty, but str contains multiple lines. See the large comment above.
+                case #char "\r"; #through;
+                case #char "\n";
+                    break c;
 
-          case;
-            whitespace    = slice(str, 0, it_index);
-            trimmed_str   = slice(str, it_index, str.count - it_index);
-            is_empty_line = false;
-            break c;
+                case;
+                    whitespace    = slice(str, 0, it_index);
+                    trimmed_str   = slice(str, it_index, str.count - it_index);
+                    is_empty_line = false;
+                    break c;
+            }
         }
     }
 
-
     comment: string = ---;
-
     if buffer.lang == {
         case .C;            comment = "//";
         case .CSharp;       comment = "//";
@@ -2821,30 +2803,46 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
     last_line := line_starts.count - 1;
     array_add(*line_starts, last_line_end_offset); // So that line_starts[i+1] will always work.
 
+    // Before commenting/uncommenting, we loop over the selected lines in order to
+    // A. Determine whether we're adding or removing comments.
+    // B. Find the minimum indent (which is only needed when adding comments, but )
+    // Minimum indent works as follows:
+    /*
+        if foo {
+            bar();
+        }
+^^^^^^^^ <- minimum indent
+
+        // if foo {
+        //     bar();
+        // }
+^^^^1^^^   ^^^^3^^^^^
+        ^2^
+    */
+    // 1. is generated using the user-defined spacing character (tabs or spaces)
+    // 2. is the comment character(s) plus one whitespace
+    // 3. is the rest of each line, left completely as-is
+    // To make this work intuitively and robustly, we have to measure the VISUAL width of the minimum indent.
+    // We cannot count the whitespace characters because there may be tabs, and tabs have weird alignment rules.
+
     tab_size                := config.settings.tab_size;
     min_indent_visual_width := -1;
     add_comment             := false;
-
     for 0..last_line {
         macro_every_loop(it); //vars: is_empty_line, start, str, whitespace, trimmed_str
         if is_empty_line continue;
 
         whitespace_visual_width := whitespace_get_visual_width(whitespace, tab_size);
-
-        if min_indent_visual_width < 0 || whitespace_visual_width < min_indent_visual_width
-            then min_indent_visual_width = whitespace_visual_width;
-
+        if min_indent_visual_width < 0 || whitespace_visual_width < min_indent_visual_width then min_indent_visual_width = whitespace_visual_width;
         if !add_comment && !begins_with(trimmed_str, comment) then add_comment = true;
     }
 
     if min_indent_visual_width < 0 then min_indent_visual_width = 0;
 
-
     // Build a replacement string
     b: String_Builder;  // not using temp because the string may be too large
 
     if add_comment {
-
         use_spaces := config.settings.insert_spaces_when_pressing_tab;
         new_whitespace := ifx use_spaces then get_tmp_spaces(min_indent_visual_width) else {
             tab_count := min_indent_visual_width / tab_size; // Aligns the indentation with tab columns because of integer division.
@@ -2871,19 +2869,16 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
 
             line_length_difference := -old_whitespace_count + new_whitespace.count + (comment.count + 1);
 
-            for * cursor: editor.cursors {
+            for * cursor : editor.cursors {
                 if      cursor.pos > adjusted_old_comment_start then cursor.pos += xx line_length_difference;
                 else if cursor.pos >= adjusted_start            then cursor.pos  = xx adjusted_new_comment_start;
 
                 if      cursor.sel > adjusted_old_comment_start then cursor.sel += xx line_length_difference;
                 else if cursor.sel >= adjusted_start            then cursor.sel  = xx adjusted_new_comment_start;
             }
-
             adjustment += line_length_difference;
         }
-
     } else { // Remove comments
-
         adjustment := 0;
         for 0..last_line {
             macro_every_loop(it); //vars: is_empty_line, start, str, whitespace, trimmed_str
@@ -2898,11 +2893,10 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
             append(*b, rest_of_line);
 
             adjusted_comment_start := start + whitespace.count + adjustment;
-            for * cursor: editor.cursors {
+            for * cursor : editor.cursors {
                 if cursor.pos > adjusted_comment_start then cursor.pos -= xx min(len_comment, cursor.pos - adjusted_comment_start);
                 if cursor.sel > adjusted_comment_start then cursor.sel -= xx min(len_comment, cursor.sel - adjusted_comment_start);
             }
-
             adjustment -= len_comment;
         }
     }


### PR DESCRIPTION
Try it out, comment some lines, set your settings to spaces, to tabs, place multiple cursors in random places. See if it does anything weird. Your code should look exactly the same after commenting and un-commenting it. I'm pretty sure I've covered my bases.

## Example
Before, it could mess with your code layout.
Take this example. Every `|` is a cursor, not a character.
```
some text
|



other text
|
```
Running toggle_comment would turn that, into this:
```
some text
    // other text

```
Which both comments out a line that it shouldn't have, and removed a bunch of lines in between.
Now, it just does nothing because it correctly realizes both cursors are placed on empty lines.