### PR TITLE
Tabs render correctly when vertical scrolling

### DIFF
--- a/FOCUS-CHANGELOG.txt
+++ b/FOCUS-CHANGELOG.txt
@@ -39,6 +39,7 @@
     + Duplicating a line near the end now duplicates a line as expected
     + Fixed a bug with multi-cursor copying/pasting when some of the cursors don't have a selection
     + Fixed a bug with multi-cursor range replace by typing
+    + Fixed visual bug where tabs would align to the wrong columns
     + Linux: fixed selection while scrolling due to "stuck" START and END states of the mouse button presses.
     + Linux: Clipboard handling should become way faster on X11 because we let event loop to handle more requests before drawing.
 

--- a/modules/Simp/font.jai
+++ b/modules/Simp/font.jai
@@ -144,7 +144,7 @@ convert_to_temporary_glyphs :: (font: *Dynamic_Font, s: string) -> width_in_pixe
     return width_in_pixels;
 }
 
-draw_code :: (font: *Dynamic_Font, x: s64, y: s64, char_x_advance: float, line_height: float, visible_lines: [] Code_Line, color_map: [] Vector4, tab_size: s64 = 4) {
+draw_code :: (font: *Dynamic_Font, x: s64, y: s64, char_x_advance: float, line_height: float, visible_lines: [] Code_Line, color_map: [] Vector4, tab_size: s64 = 4, start_col := 0) {
     // Setup OpenGL stuff. We do it all in one place because it's easier and there will be only one backend - GL.
     // Otherwise we would have to create temporary glyphs and pass them on to the backend draw function.
     CheckInit();
@@ -165,7 +165,7 @@ draw_code :: (font: *Dynamic_Font, x: s64, y: s64, char_x_advance: float, line_h
         colors := it.colors;
 
         sx  := cast(float) (x + it.tab_spaces * char_x_advance);
-        col := 0;
+        col := start_col + it.tab_spaces;
 
         // Draw one line
         t := line.data;

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -831,7 +831,7 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
             colors := ifx line then array_view(buffer.colors, line.data - buffer.bytes.data, line.count) else .[];
             code_lines[line_num-visible_lines_start] = .{ line = line, tab_spaces = tab_spaces, colors = colors };
         }
-        Simp.draw_code(font, xx pen.x, xx pen.y, char_x_advance, line_height, code_lines, CODE_COLOR_MAP, TAB_SIZE);
+        Simp.draw_code(font, xx pen.x, xx pen.y, char_x_advance, line_height, code_lines, CODE_COLOR_MAP, TAB_SIZE, hidden_chars_on_the_left);
 
         // Draw continuation markers for wrapped lines
         if line_wrap_is_active(editor) && !config.settings.show_line_numbers {


### PR DESCRIPTION
# Before
![focus_7SZFtZzbHl](https://github.com/focus-editor/focus/assets/76259603/f210af3a-5f01-40ee-993b-a144e62540da)

# After
![focus_debug_7ICwrnnLNO](https://github.com/focus-editor/focus/assets/76259603/db8231bd-5fbd-457b-a45b-801bac1c7331)
