### PR TITLE
Improved viewport scrolling smoothness (particularly on windows)

### DIFF
--- a/src/draw.jai
+++ b/src/draw.jai
@@ -518,8 +518,8 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
 
             cursor_pos_from_left := cursor_coords[main_cursor].pos.col  * char_x_advance + text_offset.x;
             cursor_pos_from_top  := cursor_coords[main_cursor].pos.line * line_height;
-            left_target          := max(0, cast(s32)(cursor_pos_from_left - editor_width + char_x_advance * 3));
-            top_target           := max(0, cast(s32)(cursor_pos_from_top  - rect.h / 2));
+            left_target          := cast(s32) max(cursor_pos_from_left - editor_width + char_x_advance * 3, 0);
+            top_target           := cast(s32) max(cursor_pos_from_top  - rect.h / 2,  0);
             if left_target != scroll_x.target then start_animation(*viewport.scroll_x, viewport.left, left_target);
             if top_target  != scroll_y.target then start_animation(*viewport.scroll_y, viewport.top,  top_target);
 

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -480,7 +480,7 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
             using editor.viewport;
             new_target := clamp(scroll_y.target - mouse.scroll_y_delta, 0, max_y_scroll);
             if mouse.smooth_scroll {
-                start_animation(*scroll_y, top, new_target);
+                start_animation(*scroll_y, top, new_target, snappy=true);
             } else {
                 scroll_y.target = new_target;
                 top = new_target;
@@ -507,8 +507,8 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
                 left_target := max(viewport.left + cast(s32) offset.x, 0);
                 top_target  := clamp(viewport.top - cast(s32) offset.y, 0, max_y_scroll);
 
-                if left_target != viewport.scroll_x.target then start_animation(*viewport.scroll_x, viewport.left, left_target);
-                if top_target  != viewport.scroll_y.target then start_animation(*viewport.scroll_y, viewport.top,  top_target);
+                if left_target != viewport.scroll_x.target then start_animation(*viewport.scroll_x, viewport.left, left_target, snappy = true);
+                if top_target  != viewport.scroll_y.target then start_animation(*viewport.scroll_y, viewport.top,  top_target,  snappy = true);
             }
         } else if scroll_to_cursor != .no {
             using editor.viewport;

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -480,7 +480,7 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
             using editor.viewport;
             new_target := clamp(scroll_y.target - mouse.scroll_y_delta, 0, max_y_scroll);
             if mouse.smooth_scroll {
-                start_animation(*scroll_y, top, new_target, snappy=true);
+                start_animation(*scroll_y, top, new_target);
             } else {
                 scroll_y.target = new_target;
                 top = new_target;
@@ -504,11 +504,11 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
                 if right < screen_pos.x  then offset.x = screen_pos.x - right;
                 if top   < screen_pos.y  then offset.y = screen_pos.y - top;
 
-                left_target := max(viewport.left + cast(s32) offset.x, 0);
+                left_target := max(viewport.left  + cast(s32) offset.x, 0);
                 top_target  := clamp(viewport.top - cast(s32) offset.y, 0, max_y_scroll);
 
-                if left_target != viewport.scroll_x.target then start_animation(*viewport.scroll_x, viewport.left, left_target, snappy = true);
-                if top_target  != viewport.scroll_y.target then start_animation(*viewport.scroll_y, viewport.top,  top_target,  snappy = true);
+                if left_target != viewport.scroll_x.target then start_animation(*viewport.scroll_x, viewport.left, left_target);
+                if top_target  != viewport.scroll_y.target then start_animation(*viewport.scroll_y, viewport.top,  top_target);
             }
         } else if scroll_to_cursor != .no {
             using editor.viewport;
@@ -516,15 +516,12 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
             // Use the target editor width (not current width) when a new editor is appearing
             editor_width := ifx scroll_to_cursor == .yes_new_editor then total_editor_area.w / 2 else rect.w;
 
-            cursor_pos_from_left := cursor_coords[main_cursor].pos.col * char_x_advance + text_offset.x;
-            left_target := cast(s32)(cursor_pos_from_left - editor_width + char_x_advance * 3);
-            if left_target < 0 then left_target = 0;
+            cursor_pos_from_left := cursor_coords[main_cursor].pos.col  * char_x_advance + text_offset.x;
+            cursor_pos_from_top  := cursor_coords[main_cursor].pos.line * line_height;
+            left_target          := max(0, cast(s32)(cursor_pos_from_left - editor_width + char_x_advance * 3));
+            top_target           := max(0, cast(s32)(cursor_pos_from_top  - rect.h / 2));
             if left_target != scroll_x.target then start_animation(*viewport.scroll_x, viewport.left, left_target);
-
-            cursor_pos_from_top := cursor_coords[main_cursor].pos.line * line_height;
-            top_target := cast(s32)(cursor_pos_from_top - rect.h / 2);
-            if top_target < 0 then top_target = 0;
-            if top_target != scroll_y.target then start_animation(*viewport.scroll_y, viewport.top, top_target);
+            if top_target  != scroll_y.target then start_animation(*viewport.scroll_y, viewport.top,  top_target);
 
             scroll_to_cursor = .no;
 
@@ -2617,7 +2614,7 @@ draw_text_input :: (using input: *Text_Input, rect_: Rect, ui_id: Ui_Id, active 
     if total_text_width - scroll_x_target < cast(s32) input_rect.w then {
         scroll_x_target = max(cast(s32) total_text_width - cast(s32) input_rect.w, 0);  // always show as much text as possible
     }
-    if scroll_x_target != scroll_anim.target then start_animation(*scroll_anim, scroll_x, scroll_x_target, snappy = true);
+    if scroll_x_target != scroll_anim.target then start_animation(*scroll_anim, scroll_x, scroll_x_target);
 
     if scroll_x != scroll_anim.target {
         redraw_requested = true;

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -507,8 +507,8 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
                 left_target := max(viewport.left + cast(s32) offset.x, 0);
                 top_target  := clamp(viewport.top - cast(s32) offset.y, 0, max_y_scroll);
 
-                if left_target != viewport.scroll_x.target then start_animation(*viewport.scroll_x, viewport.left, left_target, snappy = true);
-                if top_target  != viewport.scroll_y.target then start_animation(*viewport.scroll_y, viewport.top,  top_target,  snappy = true);
+                if left_target != viewport.scroll_x.target then start_animation(*viewport.scroll_x, viewport.left, left_target);
+                if top_target  != viewport.scroll_y.target then start_animation(*viewport.scroll_y, viewport.top,  top_target);
             }
         } else if scroll_to_cursor != .no {
             using editor.viewport;

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -507,8 +507,8 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
                 left_target := max(viewport.left + cast(s32) offset.x, 0);
                 top_target  := clamp(viewport.top - cast(s32) offset.y, 0, max_y_scroll);
 
-                if left_target != viewport.scroll_x.target then start_animation(*viewport.scroll_x, viewport.left, left_target);
-                if top_target  != viewport.scroll_y.target then start_animation(*viewport.scroll_y, viewport.top,  top_target);
+                if left_target != viewport.scroll_x.target then start_animation(*viewport.scroll_x, viewport.left, left_target, snappy = true);
+                if top_target  != viewport.scroll_y.target then start_animation(*viewport.scroll_y, viewport.top,  top_target,  snappy = true);
             }
         } else if scroll_to_cursor != .no {
             using editor.viewport;

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -500,25 +500,6 @@ editors_open_buffer :: (buffer_id: s64, placement: Editor_Placement = .in_place)
     cursors_start_blinking();
 }
 
-move_viewport :: (editor: *Editor, dir: enum { left; up; right; down; }) {
-    using editor.viewport;
-    if dir == {
-        case .left; #through;
-        case .right;
-            horiz_delta := cast(s32) (10 * char_size);
-            new_target := ifx dir == .left then scroll_x.target - horiz_delta else scroll_x.target + horiz_delta;
-            if new_target < 0 then new_target = 0;
-            start_animation(*scroll_x, left, new_target, snappy = true);
-
-        case .up; #through;
-        case .down;
-            vert_delta := cast(s32) (10 * line_height);
-            new_target := ifx dir == .up then scroll_y.target - vert_delta else scroll_y.target + vert_delta;
-            new_target = clamp(new_target, 0, get_max_y_scroll(editor, open_buffers[editor.buffer_id]));
-            start_animation(*scroll_y, top, new_target, snappy = true);
-    }
-}
-
 center_viewport_on_cursor :: (using editor: *Editor, buffer: Buffer) {
     editor.scroll_to_cursor = .yes;
 }
@@ -799,11 +780,8 @@ close_search_bar :: inline (editor: *Editor, jump_to_original_cursor := false, j
 search_bar_toggle_expand :: (using editor: *Editor) {
     using search_bar;
 
-    if width_percentage != WIDTH_EXPANDED {
-        start_animation(*width_anim, width_percentage, WIDTH_EXPANDED, snappy = true);
-    } else {
-        start_animation(*width_anim, width_percentage, WIDTH_NORMAL, snappy = true);
-    }
+    target_width := ifx width_percentage != WIDTH_EXPANDED then WIDTH_EXPANDED else WIDTH_NORMAL;
+    start_animation(*width_anim, width_percentage, target_width);
 }
 
 search_bar_toggle_whole_word :: (using editor: *Editor, buffer: Buffer) {
@@ -940,7 +918,7 @@ editors_snap_splitter :: (pos: float) {
 editors_start_moving_splitter :: (target: float, start := -1.0) {
     if start >= 0 then splitter_pos = start;
     if !config.settings.disable_file_open_close_animations {
-        start_animation(*splitter_anim, splitter_pos, target, snappy = true);
+        start_animation(*splitter_anim, splitter_pos, target);
     } else {
         splitter_anim.target = target;
         splitter_pos = target;

--- a/src/utils.jai
+++ b/src/utils.jai
@@ -339,18 +339,14 @@ get_tmp_tabs :: (num: int) -> string {
     return tabs;
 }
 
-start_animation :: (anim: *Tween_Animation(T), start: $T, target: T, speed: Time = xx 0.0, $snappy := false) {
+start_animation :: (anim: *Tween_Animation(T), start: $T, target: T, speed: Time = xx 0.0) {
     anim.start  = start;
     anim.target = target;
     if speed > 0 then anim.speed = speed;
 
-    #if snappy {
-        // Pretend the animation started last frame so we start moving right away
-        anim.started_at = frame_time - frame_dt;
-    } else {
-        // The current frame is t=0, therefore things will start moving next frame
-        anim.started_at = frame_time;
-    }
+    // Pretend the animation started last frame so we start moving right away.
+    // If the current frame was t=0, then the movement would simply be delayed one frame.
+    anim.started_at = frame_time - frame_dt;
 }
 
 get_animation_value :: (using anim: Tween_Animation($T)) -> T {

--- a/src/utils.jai
+++ b/src/utils.jai
@@ -344,16 +344,17 @@ start_animation :: (anim: *Tween_Animation(T), start: $T, target: T, speed: Time
     anim.target = target;
     if speed > 0 then anim.speed = speed;
 
-    #if OS == .LINUX {
-        // Don't restart the animation at the current frame if it's already started.
-        // But still cap it's starting time at just a single frame delta to be conservative.
-        // This lets us start animation smoothly, as in the "else" branch below, but
-        // continue in a snappy way as we scroll.
-        if anim.started_at {
-            anim.started_at = frame_time - MAX_FRAME_DT;
-            return;
-        }
+    // Don't restart the animation at the current frame if it's already started.
+    // But still cap it's starting time at just a single frame delta to be conservative.
+    // This lets us start animation smoothly, as in the "else" branch below, but
+    // continue in a snappy way as we scroll.
+    if anim.started_at {
+        anim.started_at = frame_time - MAX_FRAME_DT;
+        return;
+    } else {
+        print("animation started_at was 0");
     }
+
     #if snappy {
         // Pretend the animation started last frame so we start moving right away
         anim.started_at = frame_time - MAX_FRAME_DT;

--- a/src/utils.jai
+++ b/src/utils.jai
@@ -344,22 +344,11 @@ start_animation :: (anim: *Tween_Animation(T), start: $T, target: T, speed: Time
     anim.target = target;
     if speed > 0 then anim.speed = speed;
 
-    // Don't restart the animation at the current frame if it's already started.
-    // But still cap it's starting time at just a single frame delta to be conservative.
-    // This lets us start animation smoothly, as in the "else" branch below, but
-    // continue in a snappy way as we scroll.
-    if anim.started_at {
-        anim.started_at = frame_time - MAX_FRAME_DT;
-        return;
-    } else {
-        print("animation started_at was 0");
-    }
-
     #if snappy {
         // Pretend the animation started last frame so we start moving right away
-        anim.started_at = frame_time - MAX_FRAME_DT;
+        anim.started_at = frame_time - frame_dt;
     } else {
-        // Things will start moving next frame - but usually in a more smooth way
+        // The current frame is t=0, therefore things will start moving next frame
         anim.started_at = frame_time;
     }
 }

--- a/src/widgets/finder.jai
+++ b/src/widgets/finder.jai
@@ -329,11 +329,8 @@ free_task :: (task: *Search_Task) {
 toggle_expand :: () {
     using finder;
 
-    if width_percentage != WIDTH_EXPANDED {
-        start_animation(*width_anim, width_percentage, WIDTH_EXPANDED, snappy = true);
-    } else {
-        start_animation(*width_anim, width_percentage, WIDTH_NORMAL, snappy = true);
-    }
+    target_width := ifx width_percentage != WIDTH_EXPANDED then WIDTH_EXPANDED else WIDTH_NORMAL;
+    start_animation(*width_anim, width_percentage, target_width);
 }
 
 #scope_export

--- a/src/widgets/open_file_dialog.jai
+++ b/src/widgets/open_file_dialog.jai
@@ -452,11 +452,8 @@ scan_current_folder :: () {
 toggle_expand :: () {
     using open_file_dialog;
 
-    if width_percentage != WIDTH_EXPANDED {
-        start_animation(*width_anim, width_percentage, WIDTH_EXPANDED, snappy = true);
-    } else {
-        start_animation(*width_anim, width_percentage, WIDTH_NORMAL, snappy = true);
-    }
+    target_width := ifx width_percentage != WIDTH_EXPANDED then WIDTH_EXPANDED else WIDTH_NORMAL;
+    start_animation(*width_anim, width_percentage, target_width);
 }
 
 get_pool_allocator :: () -> Allocator {


### PR DESCRIPTION
- After converting all scroll-related animations to be snappy, there weren't any that were NOT snappy. So the setting was removed, animations are now always snappy. _Not delayed by 1 frame_ is a better way to describe it, all animations now begin moving the frame they are started, rather than one frame later.
- Shortened some calls to `start_animation` to be be more concise
- Came across an old procedure that was no longer used anywhere, removed that. 