### PR TITLE
"auto_surround_with_brackets_and_quotes" config option

### DIFF
--- a/src/config.jai
+++ b/src/config.jai
@@ -341,31 +341,32 @@ Workspace :: struct {
 }
 
 Settings :: struct {
-    maximize_on_start                   := false;
-    open_on_the_biggest_monitor         := true;
-    cursor_as_block                     := true;
-    cursor_blink_time_in_seconds        := 5;
-    highlight_selection_occurrences     := true;
-    disable_that_annoying_paste_effect  := false;
-    disable_file_open_close_animations  := false;
-    double_shift_to_search_in_workspace := false;
-    max_entries_in_open_file_dialog     := 2000;
-    tab_size                            := 4;
-    insert_spaces_when_pressing_tab     := true;
-    strip_trailing_whitespace_on_save   := false;
-    smooth_scrolling                    := true;
-    line_height_scale_percent           := 120;
-    max_editor_width                    := -1;
-    can_cancel_go_to_line               := true;
-    copy_whole_line_without_selection   := false;
-    editor_history_size                 := 128;
-    line_wrap_is_on_by_default          := false;
-    show_line_numbers                   := false;
-    dark_titlebar                       := false;  // TODO: fix the issues with window resize first
-    colored_titlebar                    := true;
-    hide_mouse_when_typing              := true;
-    highlight_line_with_cursor          := false;
-    draw_indent_guides                  := false;
+    maximize_on_start                      := false;
+    open_on_the_biggest_monitor            := true;
+    cursor_as_block                        := true;
+    cursor_blink_time_in_seconds           := 5;
+    highlight_selection_occurrences        := true;
+    disable_that_annoying_paste_effect     := false;
+    disable_file_open_close_animations     := false;
+    double_shift_to_search_in_workspace    := false;
+    max_entries_in_open_file_dialog        := 2000;
+    tab_size                               := 4;
+    insert_spaces_when_pressing_tab        := true;
+    strip_trailing_whitespace_on_save      := false;
+    smooth_scrolling                       := true;
+    line_height_scale_percent              := 120;
+    max_editor_width                       := -1;
+    can_cancel_go_to_line                  := true;
+    copy_whole_line_without_selection      := false;
+    editor_history_size                    := 128;
+    line_wrap_is_on_by_default             := false;
+    show_line_numbers                      := false;
+    dark_titlebar                          := false;  // TODO: fix the issues with window resize first
+    colored_titlebar                       := true;
+    hide_mouse_when_typing                 := true;
+    highlight_line_with_cursor             := false;
+    draw_indent_guides                     := false;
+    auto_surround_with_brackets_and_quotes := false;
 
     // TODO
     // convert_tabs_to_spaces_on_load:     false

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -309,6 +309,10 @@ active_editor_type_char :: (char: u32) {
 
     offset_delta: s32 = 0;
     buf_len := cast(s32) buffer.bytes.count;
+
+    all_have_selection := all_cursors_have_selection(editor);
+    is_balanceable     := is_balanceable_char(char);
+
     for * cursor : editor.cursors {
         new_len := cast(s32) buffer.bytes.count;
         if new_len != buf_len {
@@ -318,7 +322,7 @@ active_editor_type_char :: (char: u32) {
         cursor.pos += offset_delta;
         cursor.sel += offset_delta;
 
-        if all_cursors_have_selection(editor) && is_balancable_char(char) {
+        if config.settings.auto_surround_with_brackets_and_quotes && all_have_selection && is_balanceable {
             selection := get_selection(cursor);
             insert_char_at_offset(buffer, selection.end  , convert_utf32_to_utf8(get_balancing_char(char)));
             insert_char_at_offset(buffer, selection.start, utf8_char);

--- a/src/utils.jai
+++ b/src/utils.jai
@@ -278,7 +278,7 @@ is_separator_char :: inline (ch: u8) -> bool {
         ch == #char "." || ch == #char "<" || ch == #char ">" || ch == #char "/" || ch == #char "\"" || ch == #char "\\";
 }
 
-is_balancable_char :: (ch: u32) -> bool {
+is_balanceable_char :: (ch: u32) -> bool {
     return ch == #char "{" || ch == #char "(" || ch == #char "[" || ch == #char "\"";
 }
 


### PR DESCRIPTION
This PR was reverted because of a compiler bug, look like it's working now.

https://github.com/focus-editor/focus/pull/154