### PR TITLE
Add more character to altgr "hack"

### DIFF
--- a/modules/Input/windows.jai
+++ b/modules/Input/windows.jai
@@ -243,10 +243,12 @@ MyWindowProc :: (hwnd: HWND, message: u32,
           case WM_CHAR;
             keycode := wParam;
 
-            // @Hack to allow AltGr shortcuts for AZERTY layout...
+            // @Hack to allow AltGr shortcuts for AZERTY and QERTZ/Y layout...
             altgr_keycode := keycode == #char "~" || keycode == #char "#" || keycode == #char "{"  || keycode == #char "[" ||
                              keycode == #char "|" || keycode == #char "`" || keycode == #char "\\" || keycode == #char "^" ||
-                             keycode == #char "@" || keycode == #char "]" || keycode == #char "}";
+                             keycode == #char "@" || keycode == #char "]" || keycode == #char "}"  || keycode == #char ";" ||
+                             keycode == #char ";" || keycode == #char "<" || keycode == #char ">"  || keycode == #char "$" ||
+                             keycode == #char "&" || keycode == #char "*";
 
             if (keycode > 31 && keycode < 127 && !(ctrl_state || alt_state)) || (altgr_keycode && alt_state) || keycode > 255 {
                 // Control characters generate key codes < 32, but these are redundant


### PR DESCRIPTION
BTW, some characters (áőúű....) ignored, because of this statement but it's not important now.

(keycode > 31 && keycode < 127 && !(ctrl_state || alt_state)) || (altgr_keycode && alt_state) || keycode > 255