### PR TITLE
Add support for GLSL tess eval and tess compute shader extensions

### DIFF
--- a/src/editors.jai
+++ b/src/editors.jai
@@ -1049,7 +1049,8 @@ set_lang_from_path :: (buffer: *Buffer, path: string) {
             case "vert"; #through;
             case "frag"; #through;
             case "geom"; #through;
-            case "tess"; #through;
+            case "tese"; #through;
+            case "tesc"; #through;
             case "glsl";
                 buffer.lang = .Glsl;
 


### PR DESCRIPTION
Just changed the extensions because `tess` isn't actually used, it should be `tese` for tess eval and `tesc` for tess compute.