### PR TITLE
Odin syntax highlighting bug fixes

### DIFF
--- a/src/langs/odin.jai
+++ b/src/langs/odin.jai
@@ -126,7 +126,8 @@ get_next_token :: (using tokenizer: *Tokenizer) -> Token {
         // For example, 0b10002 will highlight 0b1000 as one number and 2 as another number,
         // but when highlit in editor it looks like one number literal rather than two
         // The solution here is to not highlight more numbers if there are many number tokens in a row
-        if tokenizer.last_tokens[1].type != .number || !is_digit((t - 1).*) {
+        last_char := (t - 1).*;
+        if tokenizer.last_tokens[1].type != .number || (!is_digit(last_char) && last_char != #char "_") {
             parse_number(tokenizer, *token);
         }
         else {
@@ -191,6 +192,19 @@ parse_identifier :: (using tokenizer: *Tokenizer, token: *Token) {
     }
 }
 
+maybe_parse_attribute :: (using tokenizer: *Tokenizer, token: *Token) {
+    attr_str: string;
+    attr_str.data  = start_t;
+    attr_str.count = token.len;
+
+    if attr_str.count > MAX_ATTRIBUTE_LENGTH then return;
+    attr, ok := table_find(*ATTRIBUTES_MAP, attr_str);
+    if !ok then return;
+
+    token.type = .attribute;
+    token.attribute = attr;
+}
+
 parse_number :: (using tokenizer: *Tokenizer, token: *Token) {
     token.type = .number;
 
@@ -198,11 +212,14 @@ parse_number :: (using tokenizer: *Tokenizer, token: *Token) {
     if t >= max_t return;
 
     is_decimal_variant :: inline (c: u8) -> bool {
-        return is_digit(c) || c == #char "." || c == #char "e" || c == #char "i" || c == #char "j" || c == #char "k";
+        return is_digit(c)    || c == #char "." || c == #char "-" ||
+               c == #char "e" || c == #char "E" ||
+               c == #char "i" || c == #char "j" || c == #char "k";
     }
 
     if is_decimal_variant(t.*) || t.* == #char "_" {
-        seen_decimal_point := false;
+        seen_decimal_point  := false;
+        scientific_notation := false;
         while t < max_t && (is_decimal_variant(t.*) || t.* == #char "_") {
             if t.* == #char "." {
                 // Handle 0..<1 / 0..=1 (gets interpreted as a float-period-lessthan-int rather than int-rangeop-int)
@@ -213,7 +230,7 @@ parse_number :: (using tokenizer: *Tokenizer, token: *Token) {
                 }
 
                 // else handle float decimal
-                if seen_decimal_point break;
+                if seen_decimal_point then break;
                 seen_decimal_point = true;
             }
             else if t.* == #char "i" || t.* == #char "j" || t.* == #char "k" {
@@ -221,15 +238,21 @@ parse_number :: (using tokenizer: *Tokenizer, token: *Token) {
                 t += 1;
                 break;
             }
+            else if t.* == #char "e" || t.* == #char "E" {
+                // Scientific notation (10e9, 1.0e-34)
+                if scientific_notation then break;
+                scientific_notation = true;
+            }
+            else if t.* == #char "-" {
+                // Handle scientific notation negative exponent (1.0e-34)
+                if !scientific_notation then break;
+                if (t - 1).* != #char "e" || (t - 1).* != #char "E" then break;
+            }
 
             t += 1;
         }
     }
-    else if t.* == #char "e" {
-        t += 1;
-        while t < max_t && (is_digit(t.*))  t += 1;
-    }
-    else if t.* == #char "x" || t.* == #char "h" {
+    else if t.* == #char "x" || t.* == #char "X" || t.* == #char "h" || t.* == #char "H" {
         // Hex
         is_hex :: inline (c: u8) -> bool {
             return is_digit(c) || (c >= #char "a" && c <= #char "f") || (c >= #char "A" && c <= #char "F");
@@ -254,19 +277,6 @@ parse_number :: (using tokenizer: *Tokenizer, token: *Token) {
     }
 
     if t > max_t then t = max_t;
-}
-
-maybe_parse_attribute :: (using tokenizer: *Tokenizer, token: *Token) {
-    attr_str : string;
-    attr_str.data  = start_t;
-    attr_str.count = token.len;
-
-    if attr_str.count > MAX_ATTRIBUTE_LENGTH then return;
-    attr, ok := table_find(*ATTRIBUTES_MAP, attr_str);
-    if !ok then return;
-
-    token.type = .attribute;
-    token.attribute = attr;
 }
 
 parse_directive :: (using tokenizer: *Tokenizer, token: *Token) {

--- a/src/langs/odin.jai
+++ b/src/langs/odin.jai
@@ -8,6 +8,7 @@ highlight_odin_syntax :: (using buffer: *Buffer) {
 
         using tokenizer;
 
+        // Maybe highlight a function
         before_prev, prev := last_tokens[0], last_tokens[1];
         if token.type == .identifier {
             // Highlight an attribute if we have specific last tokens
@@ -19,22 +20,23 @@ highlight_odin_syntax :: (using buffer: *Buffer) {
         }
         else if token.type == .punctuation {
             if token.punctuation == .l_paren {
-                // Maybe retroactively highlight a function
-                if prev.type == .identifier {
-                    // Handle "func("
-                    memset(colors.data + prev.start, xx Code_Color.FUNCTION, prev.len);
-                }
-                else if prev.type == .keyword && prev.keyword == .kw_proc {
-                    // Handle "func :: proc("
+                if prev.type == .identifier && !(before_prev.type == .operation && before_prev.operation == .colon) {
+                    // Handle "func(" but not ": Type("
                     memset(colors.data + prev.start, xx Code_Color.FUNCTION, prev.len);
                 }
             }
-            if token.punctuation == .r_paren && inside_attribute {
+            else if token.punctuation == .r_paren && inside_attribute {
                 inside_attribute = false;
             }
-        } else if token.type == .directive && (token.directive == .directive_force_inline || token.directive == .directive_no_force_inline) {
+        }
+        else if token.type == .keyword && token.keyword == .kw_proc {
+            // Handle "func :: proc"
+            if (prev.type == .operation && prev.operation == .double_colon) && before_prev.type == .identifier {
+                memset(colors.data + before_prev.start, xx Code_Color.FUNCTION, before_prev.len);
+            }
+        }
+        else if token.type == .directive && (token.directive == .directive_force_inline || token.directive == .directive_no_force_inline) {
             // Handle "func :: #force_inline" / "func :: #no_force_inline"
-            before_prev, prev := last_tokens[0], last_tokens[1];
             if before_prev.type == .identifier && prev.type == .operation && prev.operation == .double_colon {
                 memset(colors.data + before_prev.start, xx Code_Color.FUNCTION, before_prev.len);
             }

--- a/src/langs/odin.jai
+++ b/src/langs/odin.jai
@@ -812,7 +812,7 @@ ATTRIBUTES :: string.[
     "init", "cold",
     "optimization_mode",
     "static", "thread_local",
-    "objc_name", "objc_type", "objc_is_class_method",
+    "objc_name", "objc_class", "objc_type", "objc_is_class_method",
     "require_target_feature", "enable_target_feature",
 ];
 

--- a/src/langs/odin.jai
+++ b/src/langs/odin.jai
@@ -246,7 +246,7 @@ parse_number :: (using tokenizer: *Tokenizer, token: *Token) {
             else if t.* == #char "-" {
                 // Handle scientific notation negative exponent (1.0e-34)
                 if !scientific_notation then break;
-                if (t - 1).* != #char "e" || (t - 1).* != #char "E" then break;
+                if (t - 1).* != #char "e" && (t - 1).* != #char "E" then break;
             }
 
             t += 1;
@@ -351,7 +351,9 @@ parse_minus :: (using tokenizer: *Tokenizer, token: *Token) {
                 token.operation = .unknown;  // -- is not a valid token
             }
         case;
-            if is_digit(t.*) parse_number(tokenizer, token);
+            if tokenizer.last_tokens[1].type != .number && is_digit(t.*) {
+                parse_number(tokenizer, token);
+            }
     }
 }
 

--- a/src/langs/odin.jai
+++ b/src/langs/odin.jai
@@ -8,7 +8,7 @@ highlight_odin_syntax :: (using buffer: *Buffer) {
 
         using tokenizer;
 
-        // Maybe highlight a function
+        // Maybe highlight a function or attribute
         before_prev, prev := last_tokens[0], last_tokens[1];
         if token.type == .identifier {
             // Highlight an attribute if we have specific last tokens
@@ -20,10 +20,16 @@ highlight_odin_syntax :: (using buffer: *Buffer) {
         }
         else if token.type == .punctuation {
             if token.punctuation == .l_paren {
-                if prev.type == .identifier && !(before_prev.type == .operation && before_prev.operation == .colon) {
-                    // Handle "func(" but not ": Type("
-                    memset(colors.data + prev.start, xx Code_Color.FUNCTION, prev.len);
+                if prev.type == .identifier {
+                    // Handle "func(" but not ":Type(" or "^Type(" or "$Type(" or "]Type("
+                    if      before_prev.type != .operation && before_prev.type != .punctuation {}
+                    else if before_prev.type == .operation && before_prev.operation == .colon {}
+                    else if before_prev.type == .punctuation && (before_prev.punctuation == .caret || before_prev.punctuation == .dollar || before_prev.punctuation == .r_bracket) {}
+                    else {
+                        memset(colors.data + prev.start, xx Code_Color.FUNCTION, prev.len);
+                    }
                 }
+
             }
             else if token.punctuation == .r_paren && inside_attribute {
                 inside_attribute = false;
@@ -60,7 +66,7 @@ tokenize_odin_for_indentation :: (using buffer: Buffer) -> [] Indentation_Token 
     while true {
         src := get_next_token(*tokenizer);
 
-        tokenizer.last_tokens[0] = tokenizer.last_tokens[1];  // if we don't remember last 2 tokens, here strings won't be detected properly
+        tokenizer.last_tokens[0] = tokenizer.last_tokens[1];
         tokenizer.last_tokens[1] = src;
 
         token: Indentation_Token = ---;
@@ -440,13 +446,14 @@ parse_percent :: (using tokenizer: *Tokenizer, token: *Token) {
     if t >= max_t return;
 
     if t.* == {
-        case #char "%";
-            token.operation = .double_percent;
-            t += 1;
-
         case #char "=";
             token.operation = .percent_equal;
             t += 1;
+
+        case #char "%";
+            token.operation = .double_percent;
+            t += 1;
+            if t >= max_t return;
 
             if t.* == #char "=" {
                 token.operation = .double_percent_equal;
@@ -682,7 +689,6 @@ Token :: struct {
         keyword;
         type_keyword;
         value_keyword;
-        builtin;
         attribute;
         directive;
         invalid;
@@ -704,7 +710,6 @@ COLOR_MAP :: Code_Color.[
     .KEYWORD,       // keyword
     .TYPE,          // type_keyword
     .VALUE_KEYWORD, // value_keyword
-    .KEYWORD,       // builtin
     .KEYWORD,       // attribute
     .KEYWORD,       // directive
     .ERROR,         // invalid
@@ -833,21 +838,6 @@ DIRECTIVES :: string.[
     "soa", "relative",
 ];
 
-COMMON_BUILTINS :: string.[
-    "len", "cap", "raw_data",
-    "new", "new_clone", "make", "make_non_zeroed", "delete", "free", "free_all",
-    "resize", "reserve", "shrink", "copy",
-    "append", "assign_at", "inject_at",
-    "pop", "clear", "ordered_remove", "unordered_remove", "remove_range",
-    "incl", "excl", "card",
-    "soa_zip", "soa_unzip",
-    "make_soa", "delete_soa", "resize_soa", "reserve_soa", "append_soa",
-    "swizzle", "complex", "quaternion", "real", "imag", "jmag", "kmag", "conj",
-    "expand_values",
-    "min", "max", "abs", "clamp",
-    "assert", "panic", "unimplemented",
-];
-
 #insert -> string {
     b: String_Builder;
     init_string_builder(*b);
@@ -862,7 +852,7 @@ COMMON_BUILTINS :: string.[
 
     define_enum(*b, "Punctuation", "",           .[PUNCTUATION]);
     define_enum(*b, "Operation",   "",           .[OPERATIONS]);
-    define_enum(*b, "Keyword",     "kw_",        .[KEYWORDS, TYPE_KEYWORDS, VALUE_KEYWORDS, COMMON_BUILTINS]);
+    define_enum(*b, "Keyword",     "kw_",        .[KEYWORDS, TYPE_KEYWORDS, VALUE_KEYWORDS]);
     define_enum(*b, "Directive",   "directive_", .[DIRECTIVES]);
     define_enum(*b, "Attribute",   "attr_",      .[ATTRIBUTES]);
 
@@ -876,7 +866,7 @@ Keyword_Token :: struct {
 
 KEYWORD_MAP :: #run -> Table(string, Keyword_Token) {
     table: Table(string, Keyword_Token);
-    size := 10 * (KEYWORDS.count + TYPE_KEYWORDS.count + VALUE_KEYWORDS.count + COMMON_BUILTINS.count);
+    size := 10 * (KEYWORDS.count + TYPE_KEYWORDS.count + VALUE_KEYWORDS.count);
     init(*table, size);
 
     #insert -> string {
@@ -884,7 +874,6 @@ KEYWORD_MAP :: #run -> Table(string, Keyword_Token) {
         for KEYWORDS        append(*b, sprint("table_add(*table, \"%1\", Keyword_Token.{ type = .keyword,       keyword = .kw_%1 });\n", it));
         for TYPE_KEYWORDS   append(*b, sprint("table_add(*table, \"%1\", Keyword_Token.{ type = .type_keyword,  keyword = .kw_%1 });\n", it));
         for VALUE_KEYWORDS  append(*b, sprint("table_add(*table, \"%1\", Keyword_Token.{ type = .value_keyword, keyword = .kw_%1 });\n", it));
-        for COMMON_BUILTINS append(*b, sprint("table_add(*table, \"%1\", Keyword_Token.{ type = .builtin,       keyword = .kw_%1 });\n", it));
         return builder_to_string(*b);
     }
 
@@ -926,7 +915,6 @@ MAX_KEYWORD_LENGTH :: #run -> s32 {
     for KEYWORDS        { if it.count > result then result = it.count; }
     for TYPE_KEYWORDS   { if it.count > result then result = it.count; }
     for VALUE_KEYWORDS  { if it.count > result then result = it.count; }
-    for COMMON_BUILTINS { if it.count > result then result = it.count; }
     return xx result;
 }
 
@@ -941,7 +929,6 @@ MAX_DIRECTIVE_LENGTH :: #run -> s32 {
     for DIRECTIVES { if it.count > result then result = it.count; }
     return xx result;
 }
-
 
 eat_white_space :: inline (start: *u8, max_t: *u8) -> *u8 {
     t := start;


### PR DESCRIPTION
- Fix some bugs with scientific notation number parsing
- Fixed a bug with some proc identifiers not being highlighted
- Added missing `objc_class` attribute
- Fixed `%%=` not being parsed correctly (was parsing `%==` instead lol)
- Removed builtin proc handling and just treating them like normal procs
- Added some checking so as to not highlight polymorphic types as procs in certain situations
- General reorganizing.