### PR TITLE
Fix save as behaviour with editor dialog

### DIFF
--- a/src/buffer.jai
+++ b/src/buffer.jai
@@ -558,11 +558,12 @@ offset_is_within_multiline_token :: (tokens: [] Indentation_Token, offset: s32) 
 }
 
 save_buffer_to_new_file_on_disk :: (buffer: *Buffer, buffer_id: s64, file_path: string) -> saved: bool {
-    if buffer.readonly return false;
+    // Don't modify if buffer is readonly, otherwise strip whitespace as if we were saving it
+    if !buffer.readonly {
+        if config.settings.strip_trailing_whitespace_on_save then strip_trailing_whitespace(buffer, buffer_id);
+    }
 
     // Save the file BEFORE making a new buffer so find_or_create_buffer can find it
-    if config.settings.strip_trailing_whitespace_on_save then strip_trailing_whitespace(buffer, buffer_id);
-
     success := write_entire_file(file_path, to_string(buffer.bytes));
     if !success return false;
 

--- a/src/widgets/open_file_dialog.jai
+++ b/src/widgets/open_file_dialog.jai
@@ -111,7 +111,9 @@ open_file_dialog_open_entry :: (selected: s64, placement: Editor_Placement, fold
                 while dir_path != "/" && ends_with(dir_path, #char "/") dir_path.count -= 1;
 
                 full_path := tprint("%/%", dir_path, to_string(input.text));
-                save_buffer_to_disk(buffer, buffer_id, full_path);
+
+                if         mode == .save_as then    save_buffer_to_new_file_on_disk(buffer, buffer_id, full_path);
+                else /* if mode == .save    then */ save_buffer_to_disk            (buffer, buffer_id, full_path);
 
                 hide_open_file_dialog();
             }


### PR DESCRIPTION
The open file dialog was only saving the current file, not making a new file and saving that.