### PR TITLE
Add highlighting for platform headers in the focus-config files

### DIFF
--- a/src/langs/focus_config.jai
+++ b/src/langs/focus_config.jai
@@ -65,6 +65,9 @@ try_parsing_header :: (using tokenizer: *Tokenizer, token: *Token) {
         case "[[settings]]";    section = .settings;  token.type = .header_top_level;
         case "[[keymap]]";      section = .keymap;    token.type = .header_top_level;
         case "[[style]]";       section = .style;     token.type = .header_top_level;
+        case "[[windows]]";     section = .style;     token.type = .header_top_level;
+        case "[[linux]]";       section = .style;     token.type = .header_top_level;
+        case "[[macos]]";       section = .style;     token.type = .header_top_level;
 
         case "[workspace dirs]";            token.type = .header;
         case "[ignore dirs]";               token.type = .header;


### PR DESCRIPTION
The platform-specific headers `[[linux]]` and `[[windows]]` don't get highlighted in the editor, so I've added them here. (Should there be one for MacOS as well?) Edit: I added macos anyway :P