### PR TITLE
Remove usages of `to_string` with u8 arrays

### DIFF
--- a/src/buffer.jai
+++ b/src/buffer.jai
@@ -610,7 +610,7 @@ save_buffer_to_file :: (buffer: *Buffer, buffer_id: s64, file_path: string) {
         save_buffer(buffer, buffer_id);
     } else {
         // We're "saving as", in which case we want to create a new buffer and also keep the current buffer
-        success := write_entire_file(file_path, to_string(buffer.bytes));
+        success := write_entire_file(file_path, cast(string) buffer.bytes);
         if !success {
             log_error("Couldn't write to file %", file_path);
             return;

--- a/src/widgets/open_file_dialog.jai
+++ b/src/widgets/open_file_dialog.jai
@@ -403,7 +403,7 @@ refresh_entries :: (clear_input := true) {
     if mode == .save && input.text && path_chunks {
         array_add(*entries.filtered, Entry.{
             file = File_Info.{ full_path = "", name = "", path = "", icon = .save },
-            entry_name = sprint("Save as '%/%'", get_current_folder_path(), to_string(input.text)),
+            entry_name = sprint("Save as '%/%'", get_current_folder_path(), cast(string) input.text),
             type = .save,
             name_highlights = .[],
             path_highlights = .[],


### PR DESCRIPTION
Removes warnings that `to_string` usage with u8 arrays was deprecated, since we can now use `cast(string)` instead.