### PR TITLE
Add `Show troubleshooting info` command

### DIFF
--- a/modules/Linux_Display/linux_display.jai
+++ b/modules/Linux_Display/linux_display.jai
@@ -87,6 +87,11 @@ active_backend :: (display: *Display) -> ACTIVE_BACKEND {
     }
 }
 
+active_gl_backend :: (display: *Display) -> GL_BACKEND {
+    bd: *Base_Display = display;
+    return bd.gl.type;
+}
+
 /*
  * Window functions
  */

--- a/modules/Linux_Display/stdlib_interop.jai
+++ b/modules/Linux_Display/stdlib_interop.jai
@@ -8,6 +8,10 @@ active_backend :: inline () -> ACTIVE_BACKEND {
     return active_backend(global_display);
 }
 
+active_gl_backend :: inline () -> GL_BACKEND {
+    return active_gl_backend(global_display);
+}
+
 create_window :: inline (width: int, height: int, window_name: string, window_x := 0, window_y := 0,
     parent: *Window = INVALID_WINDOW, background_color_rgb: [3]float) -> *Window
 {

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -1427,7 +1427,7 @@ draw_file_info :: (buffer: Buffer, width: float, padding: float, _pen: Vector2, 
         label: string;
         if platform_path_equals(buffer.file.full_path, global_config_path) {
             label = "[current global config]";
-        } else if platform_path_equals(buffer.file.full_path, project_config_path) {
+        } else if project_config_path && platform_path_equals(buffer.file.full_path, project_config_path) {
             label = "[current project config]";
         }
         if label {

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -468,9 +468,7 @@ editors_show_troubleshooting_info :: (placement: Editor_Placement) {
     }
 
     buffer := *open_buffers[global_troubleshooting_buffer_id];
-    info := platform_get_troubleshooting_info();
-    replace_range_raw(buffer, 0, xx buffer.bytes.count, info);
-    free(info);
+    replace_range_raw(buffer, 0, xx buffer.bytes.count, platform_get_troubleshooting_info());
     buffer.meow_hash = calculate_hash(buffer.bytes);
     rescan_for_lines(buffer);
 

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -456,6 +456,27 @@ editors_show_default_config :: (placement: Editor_Placement) {
     editors_open_buffer(global_config_buffer_id, placement);
 }
 
+editors_show_troubleshooting_info :: (placement: Editor_Placement) {
+    if global_troubleshooting_buffer_id < 0 {
+        global_troubleshooting_buffer_id = find_or_create_an_empty_buffer();
+        buffer := *open_buffers[global_troubleshooting_buffer_id];
+        buffer.readonly = true;
+        buffer.lang = .Plain_Text;
+        buffer.file.name = "Troubleshooting info";
+        buffer.file.icon = .debug;
+        buffer.has_file = true;
+    }
+
+    buffer := *open_buffers[global_troubleshooting_buffer_id];
+    info := platform_get_troubleshooting_info();
+    replace_range_raw(buffer, 0, xx buffer.bytes.count, info);
+    free(info);
+    buffer.meow_hash = calculate_hash(buffer.bytes);
+    rescan_for_lines(buffer);
+
+    editors_open_buffer(global_troubleshooting_buffer_id, placement);
+}
+
 editors_create_new_file :: (placement: Editor_Placement = .in_place) {
     buffer_id := find_or_create_an_empty_buffer();
 
@@ -3514,6 +3535,7 @@ cursor_blink_start: Time;
 cursors_blinking := false;
 
 global_config_buffer_id := -1;
+global_troubleshooting_buffer_id := -1;
 
 CURSOR_BLINK_SPEED_MS   :: 500;
 

--- a/src/files.jai
+++ b/src/files.jai
@@ -224,4 +224,6 @@ File_Icon :: enum u16 {
 
     save    :: 0xf019;
     dots    :: 0xf141;
+
+    debug   :: 0xf7d9;
 }

--- a/src/keymap.jai
+++ b/src/keymap.jai
@@ -271,6 +271,7 @@ ACTIONS_COMMON :: string.[
     "show_default_config",
     // "open_error_log",  // todo
     "toggle_fullscreen",
+    "show_troubleshooting_info",
 
     "show_commands",
     "search_in_buffer",

--- a/src/main.jai
+++ b/src/main.jai
@@ -330,6 +330,7 @@ handle_common_editor_action :: (action: Action_Editors, placement: Editor_Placem
         case .open_global_config;                               editors_open_global_config(placement);              return true;
         case .open_project_config;                              editors_open_project_config(placement);             return true;
         case .show_default_config;                              editors_show_default_config(placement);             return true;
+        case .show_troubleshooting_info;                        editors_show_troubleshooting_info(placement);       return true;
 
         case .go_to_line;                                       show_go_to_line_dialog();                           return true;
         case .create_new_file;                                  editors_create_new_file(placement);                 return true;

--- a/src/platform/linux.jai
+++ b/src/platform/linux.jai
@@ -90,6 +90,11 @@ DONE;
     assert(active_backend != .UNINITIALIZED);
 
     timer = LD.timer_create();
+
+    system_info.ld_backend_choice = backend;
+    system_info.ld_backend = LD.active_backend();
+    system_info.ld_gl_backend_choice = gl_backend;
+    system_info.ld_gl_backend = LD.active_gl_backend();
 }
 
 platform_data_dir :: () -> string {
@@ -228,11 +233,162 @@ platform_path_contains :: inline (path: string, subpath: string) -> bool {
 }
 
 platform_set_border_color :: inline () {
-
 }
 
 platform_show_cursor :: (show: bool) {
+}
 
+platform_get_troubleshooting_info :: () -> string {
+    using LD.GL.gl_procs;
+
+    system_info.ld_gl_backend = LD.active_gl_backend();
+
+    env_check :: (sb: *String_Builder, name: *u8) {
+        val := getenv(name);
+        print_to_builder(sb, "  % : %\n", to_string(name), ifx val then to_string(val) else "<not set>");
+    }
+
+    gl_string :: (id: GLenum) -> string {
+        using LD.GL.gl_procs;
+        str_raw := glGetString(id);
+        return ifx str_raw then to_string(str_raw) else tprint("<GL error %>", glGetError());
+    }
+
+    gl_get_extensions :: (sb: *String_Builder) {
+        using LD.GL.gl_procs;
+        extension_count: u32;
+        extension: u32;
+        glGetIntegerv(GL_NUM_EXTENSIONS, xx *extension_count);
+
+        print_to_builder(sb, "  extensions (%):\n", extension_count);
+        width := 0;
+        while extension < extension_count {
+            ext_raw := glGetStringi(GL_EXTENSIONS, extension);
+            if !ext_raw {
+                print_to_builder(sb, "    >>> glGetStringi(GL_EXTENSIONS, %): %\n", extension, glGetError());
+                break;
+            }
+            ext := to_string(ext_raw);
+            if !width print_to_builder(sb, "    ");
+            if extension && width {
+                print_to_builder(sb, ", ");
+                width += 2;
+            }
+            if width + ext.count < 100 {
+                print_to_builder(sb, "%", ext);
+                width += ext.count;
+            } else {
+                print_to_builder(sb, "\n");
+                width = 0;
+            }
+
+            extension += 1;
+            if extension >= extension_count print_to_builder(sb, "\n");
+        }
+    }
+
+    get_loaded_libs :: (sb: *String_Builder) {
+        #import "String";
+
+        fd := open("/proc/self/maps", O_RDONLY);
+        if fd < 0 {
+            print_to_builder(sb, "Failed to open '/proc/self/maps': %\n", errno());
+            return;
+        }
+        defer close(fd);
+
+        data: [..] u8;
+        buff: [4096] u8;
+        defer array_reset(*data);
+
+        while true {
+            rs := read(fd, buff.data, buff.count);
+            if rs < 0 {
+                print_to_builder(sb, "Failed to read data from '/proc/self/maps': %\n", errno());
+                return;
+            }
+            if !rs break;
+            array_reserve(*data, data.count + rs);
+            memcpy(data.data + data.count, buff.data, rs);
+            data.count += rs;
+        }
+
+        libs: [..] string;
+        lines := split(to_string(data.data, data.count), "\n");
+        for line : lines {
+            parts := split(line, " ", 6);
+            if parts.count != 6 continue;
+            if parts[1].count != 4 continue;
+            if parts[1][2] != #char "x" continue;
+
+            lib := trim(parts[5]);
+            if !starts_with(lib, "/") continue;
+
+            found := false;
+            for l : libs {
+                if l == lib {
+                    found := true;
+                    break;
+                }
+            }
+            if !found array_add(*libs, lib);
+        }
+
+        for libs  print_to_builder(sb, "  %\n", it);
+        array_reset(*libs);
+    }
+
+    sb: String_Builder;
+
+    print_to_builder(*sb, "Kernel:\n");
+    result, output := run_command("uname", "-a", capture_and_return_output = true);
+    print_to_builder(*sb, "  %\n", ifx result.exit_code == 0 then trim(output) else tprint(">> failed to run `uname -a`: %", result));
+    free(output);
+
+    print_to_builder(*sb, "OS information:\n");
+    os_data, ok := read_entire_file("/etc/os-release");
+    if !ok {
+        print_to_builder(*sb, "  >> failed to read '/etc/os-release'\n");
+    } else {
+        lines := split(os_data, "\n");
+        for lines {
+            line := trim(it);
+            if line print_to_builder(*sb, "  %\n", line);
+        }
+        free(os_data);
+    }
+    print_to_builder(*sb, "\n");
+
+    print_to_builder(*sb, "Interesting things in the environment:\n");
+    env_check(*sb, "FOCUS_LD_BACKEND");
+    env_check(*sb, "FOCUS_LD_GL_BACKEND");
+    env_check(*sb, "LD_LIBRARY_PATH");
+    env_check(*sb, "LD_PRELOAD");
+    env_check(*sb, "PATH");
+    print_to_builder(*sb, "\n");
+
+    print_to_builder(*sb, "Loaded libraries:\n");
+    get_loaded_libs(*sb);
+    print_to_builder(*sb, "\n");
+
+    print_to_builder(*sb, "Linux_Display information:\n");
+    print_to_builder(*sb, "  desired backend    : %\n", system_info.ld_backend_choice);
+    print_to_builder(*sb, "  active backend     : %\n", system_info.ld_backend);
+    print_to_builder(*sb, "  desired GL backend : %\n", system_info.ld_gl_backend_choice);
+    print_to_builder(*sb, "  active GL backend  : %\n", system_info.ld_gl_backend);
+    print_to_builder(*sb, "\n");
+
+    print_to_builder(*sb, "OpenGL Information:\n");
+    print_to_builder(*sb, "  vendor       : %\n", gl_string(GL_VENDOR));
+    print_to_builder(*sb, "  renderer     : %\n", gl_string(GL_RENDERER));
+    print_to_builder(*sb, "  version      : %\n", gl_string(GL_VERSION));
+    print_to_builder(*sb, "  GLSL version : %\n", gl_string(GL_SHADING_LANGUAGE_VERSION));
+    gl_get_extensions(*sb);
+    print_to_builder(*sb, "\n");
+
+    ret := builder_to_string(*sb);
+    log("Troubleshooting data: % bytes", ret.count);
+    return ret;
 }
 
 #scope_file
@@ -271,3 +427,11 @@ Linux_Icon :: struct {
 }
 
 timer: LD.Timer;
+
+Linux_System_Info :: struct {
+    ld_backend_choice: LD.BACKEND_CHOICE;
+    ld_backend: LD.ACTIVE_BACKEND;
+    ld_gl_backend_choice: LD.GL_BACKEND_CHOICE;
+    ld_gl_backend: LD.GL_BACKEND;
+}
+system_info: Linux_System_Info;

--- a/src/platform/linux.jai
+++ b/src/platform/linux.jai
@@ -238,10 +238,12 @@ platform_set_border_color :: inline () {
 platform_show_cursor :: (show: bool) {
 }
 
-platform_get_troubleshooting_info :: () -> string {
+platform_get_troubleshooting_info :: () -> string /* temp */ {
     using LD.GL.gl_procs;
 
     system_info.ld_gl_backend = LD.active_gl_backend();
+
+    push_allocator(temp);
 
     env_check :: (sb: *String_Builder, name: *u8) {
         val := getenv(name);
@@ -299,8 +301,6 @@ platform_get_troubleshooting_info :: () -> string {
 
         data: [..] u8;
         buff: [4096] u8;
-        defer array_reset(*data);
-
         while true {
             rs := read(fd, buff.data, buff.count);
             if rs < 0 {
@@ -335,7 +335,6 @@ platform_get_troubleshooting_info :: () -> string {
         }
 
         for libs  print_to_builder(sb, "  %\n", it);
-        array_reset(*libs);
     }
 
     sb: String_Builder;
@@ -343,7 +342,6 @@ platform_get_troubleshooting_info :: () -> string {
     print_to_builder(*sb, "Kernel:\n");
     result, output := run_command("uname", "-a", capture_and_return_output = true);
     print_to_builder(*sb, "  %\n", ifx result.exit_code == 0 then trim(output) else tprint(">> failed to run `uname -a`: %", result));
-    free(output);
 
     print_to_builder(*sb, "OS information:\n");
     os_data, ok := read_entire_file("/etc/os-release");
@@ -355,7 +353,6 @@ platform_get_troubleshooting_info :: () -> string {
             line := trim(it);
             if line print_to_builder(*sb, "  %\n", line);
         }
-        free(os_data);
     }
     print_to_builder(*sb, "\n");
 

--- a/src/platform/macos.jai
+++ b/src/platform/macos.jai
@@ -102,7 +102,7 @@ platform_show_cursor :: (show: bool) {
 }
 
 platform_get_troubleshooting_info :: () -> string {
-    return copy_string("<not implemented>");
+    return "<not implemented>";
 }
 
 #scope_file

--- a/src/platform/macos.jai
+++ b/src/platform/macos.jai
@@ -92,7 +92,6 @@ platform_path_contains :: inline (path: string, subpath: string) -> bool {
 }
 
 platform_set_border_color :: inline () {
-
 }
 
 platform_show_cursor :: (show: bool) {
@@ -100,6 +99,10 @@ platform_show_cursor :: (show: bool) {
         NSCursor.unhide();
     else
         NSCursor.hide();
+}
+
+platform_get_troubleshooting_info :: () -> string {
+    return copy_string("<not implemented>");
 }
 
 #scope_file

--- a/src/platform/windows.jai
+++ b/src/platform/windows.jai
@@ -252,7 +252,7 @@ platform_show_cursor :: (show: bool) {
 }
 
 platform_get_troubleshooting_info :: () -> string {
-    return copy_string("<not implemented>");
+    return "<not implemented>";
 }
 
 #scope_file

--- a/src/platform/windows.jai
+++ b/src/platform/windows.jai
@@ -251,6 +251,10 @@ platform_show_cursor :: (show: bool) {
     }
 }
 
+platform_get_troubleshooting_info :: () -> string {
+    return copy_string("<not implemented>");
+}
+
 #scope_file
 
 cursor_shown : s32 = 1;

--- a/src/utils.jai
+++ b/src/utils.jai
@@ -418,6 +418,39 @@ ends_with :: inline (s: string, ch: u8) -> bool {
     return (s.count >= 1) && (s[s.count - 1] == ch);
 }
 
+// a version of `split()` from the `String` module that returns an array with a maximum
+// number of elements
+split :: (s: string, separator: $T, max_splits: int, allocator := temp) -> [] string {
+    #assert (T == u8) || (T == string);
+
+    results: [..] string;
+    results.allocator = allocator;
+
+    if max_splits < 1 return results;
+
+    remainder := s;
+    while remainder {
+        if results.count >= max_splits - 1 {
+            array_add(*results, remainder);
+            break;
+        }
+
+        found, left, right := split_from_left(remainder, separator);
+        if found {
+            array_add(*results, left);
+        } else {
+            array_add(*results, remainder);
+            break;
+        }
+
+        remainder = right;
+    }
+
+    if !remainder && results.count < max_splits array_add(*results, "");
+
+    return results;
+}
+
 Tween_Animation :: struct(T: Type) {
     start, target: T;
     started_at: Time;

--- a/src/widgets/commands.jai
+++ b/src/widgets/commands.jai
@@ -142,6 +142,7 @@ commands := #run Command.[
     .{ .open_project_config,                                "Open Project Config",                0, .None },
     .{ .open_global_config,                                 "Open Global Config",                 0, .None },
     .{ .show_default_config,                                "Show Default Config (readonly)",     0, .None },
+    .{ .show_troubleshooting_info,                          "Show troubleshooting information",   0, .None },
 
     .{ .create_new_file,                                    "Create New File",                    0, .None },
     .{ .create_new_file_on_the_side,                        "Create New File On The Side",        0, .Single },


### PR DESCRIPTION
Add a command that generates a (read-only) buffer containing information that can help when troubleshooting issues that users report (the intent is that the users can attach this information to bug reports to help developers with initial assessment of the issue).

Currently only implemented on Linux where it generates a report that looks something like this:

```
Kernel:
  Linux ltkcentral 6.6.1-gentoo-dist #1 SMP PREEMPT_DYNAMIC Fri Nov 10 16:04:08 -00 2023 x86_64 AMD Ryzen 9 7950X 16-Core Processor AuthenticAMD GNU/Linux
OS information:
  NAME=Gentoo
  ID=gentoo
  PRETTY_NAME="Gentoo Linux"
  ANSI_COLOR="1;32"
  HOME_URL="https://www.gentoo.org/"
  SUPPORT_URL="https://www.gentoo.org/support/"
  BUG_REPORT_URL="https://bugs.gentoo.org/"
  VERSION_ID="2.14"

Interesting things in the environment:
  FOCUS_LD_BACKEND : <not set>
  FOCUS_LD_GL_BACKEND : <not set>
  LD_LIBRARY_PATH : <not set>
  LD_PRELOAD : <not set>
  PATH : /home/ileonte/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/opt/bin:/usr/lib/llvm/17/bin:/usr/lib/llvm/16/bin:/etc/eselect/wine/bin:/home/ileonte/.cargo/bin:/home/ileonte/.cargo/bin

Loaded libraries:
  /home/ileonte/Work/projects/jai/focus/editor/build_debug/focus
  /memfd:/.glXXXXXX (deleted)
  /usr/lib64/libnvidia-gpucomp.so.545.29.02
  /usr/lib64/libnvidia-eglcore.so.545.29.02
  /usr/lib64/libxshmfence.so.1.0.0
  /usr/lib64/libxcb-sync.so.1.0.0
  /usr/lib64/libxcb-present.so.0.0.0
  /usr/lib64/libxcb-dri3.so.0.1.0
  /usr/lib64/libxcb-xfixes.so.0.0.0
  /usr/lib64/libxcb-dri2.so.0.0.0
  /usr/lib64/libX11-xcb.so.1.0.0
  /usr/lib64/libglapi.so.0.0.0
  /usr/lib64/libEGL_mesa.so.0.0.0
  /usr/lib64/libXdmcp.so.6.0.0
  /usr/lib64/libXau.so.6.0.0
  /usr/lib64/libxcb.so.1.1.0
  /usr/lib64/libxcb-randr.so.0.1.0
  /usr/lib64/libgbm.so.1.0.0
  /usr/lib64/libnvidia-egl-gbm.so.1.1.0
  /usr/lib64/libdrm.so.2.4.0
  /usr/lib64/libwayland-server.so.0.22.0
  /usr/lib64/libEGL_nvidia.so.545.29.02
  /usr/lib64/libnvidia-egl-wayland.so.1.1.13
  /usr/lib64/libnvidia-glsi.so.545.29.02
  /usr/lib64/libGLdispatch.so.0.0.0
  /usr/lib64/libEGL.so.1.1.0
  /usr/lib64/libpng16.so.16.40.0
  /usr/lib64/libbz2.so.1.0.8
  /usr/lib64/libz.so.1.3
  /usr/lib64/libexpat.so.1.8.10
  /usr/lib64/libfreetype.so.6.20.1
  /usr/lib64/libfontconfig.so.1.13.0
  /usr/lib64/libwayland-cursor.so.0.22.0
  /usr/lib64/libwayland-egl.so.1.22.0
  /usr/lib64/libxkbcommon.so.0.0.0
  /usr/lib64/librt.so.1
  /usr/lib64/libdl.so.2
  /usr/lib64/libm.so.6
  /usr/lib64/libpthread.so.0
  /usr/lib64/libc.so.6
  /usr/lib64/libffi.so.8.1.2
  /usr/lib64/libwayland-client.so.0.22.0
  /usr/lib64/ld-linux-x86-64.so.2

Linux_Display information:
  desired backend    : PREFER_BEST_USER_EXPERIENCE
  active backend     : WAYLAND
  desired GL backend : AUTOSELECT
  active GL backend  : EGL

OpenGL Information:
  vendor       : NVIDIA Corporation
  renderer     : NVIDIA GeForce RTX 4090/PCIe/SSE2
  version      : 3.3.0 NVIDIA 545.29.02
  GLSL version : 3.30 NVIDIA via Cg compiler
  extensions (395):
    GL_AMD_multi_draw_indirect, GL_AMD_seamless_cubemap_per_texture, 
    GL_AMD_vertex_shader_layer, GL_ARB_arrays_of_arrays, GL_ARB_base_instance, GL_ARB_bindless_texture, 
[...]
```