### PR TITLE
fix crash when writing outside config section

### DIFF
--- a/src/config_parser.jai
+++ b/src/config_parser.jai
@@ -87,7 +87,7 @@ parse_config :: (name: string, filename: string, file_data: string, for_highligh
         // Check if we have an active_section
         if active_section == .none {
             add_highlight(*parser, 0, line.count, .error);
-            error_msg := log_parser_error(handler, "Trying to add config outside of config section: '%'. This is an error.", line);
+            error_msg := log_parser_error(handler, "Line outside of any section: '%'. This is an error.", line);
             array_add(*result.warnings, error_msg);
             continue;
         }

--- a/src/config_parser.jai
+++ b/src/config_parser.jai
@@ -84,6 +84,14 @@ parse_config :: (name: string, filename: string, file_data: string, for_highligh
             if handled continue;
         }
 
+        // Check if we have an active_section
+        if active_section == .none {
+            add_highlight(*parser, 0, line.count, .error);
+            error_msg := log_parser_error(handler, "Trying to add config outside of config section: '%'. This is an error.", line);
+            array_add(*result.warnings, error_msg);
+            continue;
+        }
+
         // Check if we allow lines outside of subsection
         if active_subsection == .none && !section_allows_lines_outside_subsection(active_section) {
             add_highlight(*parser, 0, line.count, .error);


### PR DESCRIPTION
This fixes a crash when writing something between version number and [[workspace]] section of the config

The editor crashes with array bounds check error when writing content between the Version number and [[workspace]] section of the config.
This happens both for the global configuration as well as the project configuration.

Let me know if this should be a hard fail. For now it highlights the error and logs a warning.
https://github.com/focus-editor/focus/assets/6022262/e4db552a-796f-4e97-b4fe-86cb4322aa03
