### PR TITLE
Add basic yang syntax support

### DIFF
--- a/src/buffer.jai
+++ b/src/buffer.jai
@@ -450,6 +450,7 @@ recalculate_colors :: (buffer: *Buffer) {
         case .Html;         #through;
         case .Xml;          highlight_xml_syntax(buffer);
         case .Worklog;      highlight_worklog(buffer);
+        case .Yang;         highlight_yang_syntax(buffer);
     }
 }
 
@@ -1253,6 +1254,7 @@ Buffer :: struct {
         Xml;
         Html;
         Worklog;
+        Yang;
     } = .Plain_Text;
 
     Edit_Group :: struct {

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -1106,6 +1106,9 @@ set_lang_from_path :: (buffer: *Buffer, path: string) {
             case "vcxproj"; #through;
             case "csproj";
                 buffer.lang = .Xml;
+
+            case "yang";
+                buffer.lang = .Yang;
         }
     }
 
@@ -2864,6 +2867,7 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer) {
         case .Focus_Config; comment = "#";
         case .Python;       comment = "#";
         case .RenPy;        comment = "#";
+        case .Yang;         comment = "//";
         case;               return;
     }
 
@@ -3031,6 +3035,7 @@ toggle_block_comment :: (editor: *Editor, buffer: *Buffer) {
         case .Odin;         comment_start = "/*"; comment_end = "*/";
         case .Html;         comment_start = "<!--"; comment_end = "-->";
         case .Xml;          comment_start = "<!--"; comment_end = "-->";
+        case .Yang;         comment_start = "/*"; comment_end = "*/";
         case;               toggle_comment(editor, buffer); return;  // fallback to toggle_comment for the rest.
     }
 

--- a/src/langs/yang.jai
+++ b/src/langs/yang.jai
@@ -1,0 +1,283 @@
+highlight_yang_syntax :: (using buffer: *Buffer) {
+    tokenizer := get_tokenizer(buffer);
+
+    while true {
+        token := get_next_token(*tokenizer);
+        if token.type == .eof break;
+
+        using tokenizer;
+
+        color := COLOR_MAP[token.type];
+        memset(colors.data + token.start, xx color, token.len);
+    }
+}
+
+#scope_file
+
+get_tokenizer :: (using buffer: Buffer) -> Tokenizer {
+    tokenizer : Tokenizer;
+
+    tokenizer.buf = cast(string) bytes;
+    tokenizer.max_t = bytes.data + bytes.count;
+    tokenizer.t     = bytes.data;
+
+    return tokenizer;
+}
+
+get_next_token :: (using tokenizer: *Tokenizer) -> Token {
+    t = eat_white_space(t, max_t);
+
+    token : Token;
+    token.start = cast(s32) (t - buf.data);
+    token.type  = .eof;
+    if t >= max_t return token;
+
+    start_t = t;
+
+    char := << t;
+
+    if is_alpha(char) {
+        parse_identifier(tokenizer, *token);
+    } else if is_digit(char) {
+        parse_number(tokenizer, *token);
+    } else if char == {
+        case #char "\"";        parse_string_literal(tokenizer, *token, char);
+        case #char "'";         parse_string_literal(tokenizer,*token, char);
+        case #char "/";         parse_slash_or_comment(tokenizer, *token);
+
+        case #char ";";         token.type = .punctuation; token.punctuation = .semicolon; t += 1;
+        case #char "{";         token.type = .punctuation; token.punctuation = .l_brace;   t += 1;
+        case #char "}";         token.type = .punctuation; token.punctuation = .r_brace;   t += 1;
+        case #char "(";         token.type = .punctuation; token.punctuation = .l_paren;   t += 1;
+        case #char ")";         token.type = .punctuation; token.punctuation = .r_paren;   t += 1;
+        case #char "[";         token.type = .punctuation; token.punctuation = .l_bracket; t += 1;
+        case #char "]";         token.type = .punctuation; token.punctuation = .r_bracket; t += 1;
+
+        case;                   token.type = .invalid; t += 1;
+    }
+
+    if t >= max_t then t = max_t;
+    token.len = cast(s32) (t - start_t);
+    return token;
+}
+
+parse_identifier :: (using tokenizer: *Tokenizer, token: *Token) {
+    token.type = .identifier;
+
+    identifier_str := read_identifier_string(tokenizer);
+    
+    // need to do this if we want to use the same enum logic as in other parsers, not pretty but get's the job done.
+    sanitized_string := replace(identifier_str, "-", "_");
+
+    if sanitized_string.count <= MAX_KEYWORD_LENGTH {
+        kw_token, ok := table_find(*KEYWORD_MAP, sanitized_string);
+        if ok {
+            token.type = kw_token.type;
+            token.keyword = kw_token.keyword;
+            return;
+        }
+    }
+}
+
+parse_number :: (using tokenizer: *Tokenizer, token: *Token) {
+    token.type = .number;
+
+    t += 1;
+    if t >= max_t return;
+
+    if is_digit(<< t) || << t == #char "_" {
+        // Decimal
+        t += 1;
+        seen_decimal_point := false;
+        while t < max_t && (is_digit(<< t) || << t == #char "_" || << t == #char ".") {
+            if << t == #char "." {
+                if seen_decimal_point break;
+                seen_decimal_point = true;
+            }
+            t += 1;
+        }
+    }
+}
+
+parse_slash_or_comment :: (using tokenizer: *Tokenizer, token: *Token) {
+    token.type = .identifier;
+
+    t += 1;
+    if t >= max_t return;
+
+    if << t == {
+        case #char "/";
+            token.type = .comment;
+            t += 1;
+            while t < max_t && << t != #char "\n" t += 1;
+        case #char "*";
+            token.type = .comment;
+            t += 1;
+            while t + 1 < max_t {
+                if << t == #char "*" && << (t + 1) == #char "/" {
+                  t += 2;
+                  break;
+                }
+                t += 1;
+            }
+    }
+}
+
+parse_string_literal :: (using tokenizer: *Tokenizer, token: *Token, quote := #char "\"") {
+     token.type = .string_literal;
+     
+     escape_seen := false;
+     t += 1;
+
+     while t < max_t {
+        char := << t;
+        if char == quote && !escape_seen break;
+        escape_seen = !escape_seen && <<t == #char "\\";
+        t += 1;
+        if t >= max_t return;
+     }
+     t += 1;
+}
+
+read_identifier_string :: (using tokenizer: *Tokenizer) -> string {
+    ret: string;
+    ret.data = t;
+
+    while t < max_t {
+        c := <<t;
+        if is_alnum(c) || c == #char "-"  { t += 1; continue; }
+        break;
+    }
+    if t >= max_t then t = max_t;
+    ret.count = xx (t - ret.data);
+
+    return ret;
+}
+
+
+Tokenizer :: struct {
+    buf: string;
+    max_t:   *u8;
+    start_t: *u8;  // cursor when starting parsing new token
+    t:       *u8;  // cursor
+
+    last_tokens: [2] Token;  // to retroactively highlight functions
+}
+
+Token :: struct {
+    start, len: s32;
+    type: Type;
+
+    // Additional info to distinguish between keywords/punctuation
+    union {
+        keyword:            Keyword;
+        punctuation:        Punctuation;
+    }
+
+    Type :: enum u16 {
+        eof;            // End of file
+        identifier;     // Variable names, etc.
+        string_literal; // String values
+        multiline_string; // Multiline string values
+        number;         // Numeric values
+        comment;        // Comments
+        punctuation;    // Punctuation characters
+        keyword;        // Key language constructs
+        type_keyword;   // Types
+        invalid;        // invalid / anything else
+    }
+}
+
+// Must match the order of the types in the enum
+COLOR_MAP :: Code_Color.[
+    .COMMENT,       // eof - obviously not used
+    .DEFAULT,       // identifier
+    .STRING,        // string_literal
+    .STRING,        // multiline_string
+    .VALUE,         // number
+    .COMMENT,       // comment
+    .PUNCTUATION,   // punctuation
+    .KEYWORD,       // keyword
+    .DEFAULT,       // type_keyword
+    .DEFAULT        // invalid / anything else
+];
+
+// https://datatracker.ietf.org/doc/html/rfc7950
+KEYWORDS :: string.[
+    "module", "submodule", "anydata", "anyxml", "augment", "choice", "case", "contact", "container", "description",
+    "deviation", "extension", "feature", "grouping", "identity", "import", "include", "leaf", "list", "namespace",
+    "notification", "organization", "prefix", "reference", "revision", "rpc", "typedef", "uses", "default",
+    "status", "type", "units", "base", "bit", "enum", "length", "path", "pattern", "range", "action", "must",
+    "presence", "when", "mandatory", "unique", "refine", "input", "output", "value", "position", "key", "config",
+    // These have '-' in the original language definition, but we cannot use those inside the enum,
+    // so we define them with underscore here and replace with '-' in parse_identifier
+    "leaf_list", "yang_version", "revision_date", "belongs_to", "fraction_digits", "require_instance", "if_feature",
+    "error_app_tag", "error_message", "max_elements", "min_elements", "ordered_by", "yin_element",
+];
+
+TYPE_KEYWORDS :: string.[
+    "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64", "decimal64", "string", "boolean",
+    "enumeration", "bits", "binary", "leafref", "identityref", "empty", "union",
+];
+
+PUNCTUATION :: string.[
+    "semicolon", "l_paren", "r_paren", "l_brace", "r_brace", "l_bracket", "r_bracket", "comma",
+    "quotes" // not sure if quotes is correct here
+];
+
+// magic macro to define all the enums we just now defined :)
+#insert -> string {
+    b: String_Builder;
+    init_string_builder(*b);
+
+    define_enum :: (b: *String_Builder, enum_name: string, prefix: string, value_lists: [][] string) {
+        print_to_builder(b, "% :: enum u16 {\n", enum_name);
+        for values : value_lists {
+            for v : values print_to_builder(b, "    %0%;\n", prefix, v);
+        }
+        print_to_builder(b, "}\n");
+    }
+
+    define_enum(*b, "Punctuation", "",    .[PUNCTUATION]);
+    define_enum(*b, "Keyword",     "kw_", .[KEYWORDS, TYPE_KEYWORDS]);
+
+    return builder_to_string(*b);
+}
+
+Keyword_Token :: struct {
+    type: Token.Type;
+    keyword: Keyword;
+}
+
+KEYWORD_MAP :: #run -> Table(string, Keyword_Token) {
+    table: Table(string, Keyword_Token);
+    size := 10 * (KEYWORDS.count + TYPE_KEYWORDS.count);
+    init(*table, size);
+
+    #insert -> string {
+        b: String_Builder;
+        for KEYWORDS       append(*b, sprint("table_add(*table, \"%\", Keyword_Token.{ type = .keyword,           keyword = .kw_% });\n", it, it));
+        for TYPE_KEYWORDS  append(*b, sprint("table_add(*table, \"%\", Keyword_Token.{ type = .type_keyword,           keyword = .kw_% });\n", it, it));
+        return builder_to_string(*b);
+    }
+
+    return table;
+}
+
+MAX_KEYWORD_LENGTH :: #run -> s32 {
+    result: s64;
+    for KEYWORDS       { if it.count > result then result = it.count; }
+    for TYPE_KEYWORDS  { if it.count > result then result = it.count; }
+    return xx result;
+}
+
+eat_white_space :: inline (start: *u8, max_t: *u8) -> *u8 {
+    t := start;
+    while t < max_t && is_white_space(<<t) {
+        t += 1;
+    }
+    return t;
+}
+
+
+#import "Hash_Table";

--- a/src/langs/yang.jai
+++ b/src/langs/yang.jai
@@ -14,18 +14,8 @@ highlight_yang_syntax :: (using buffer: *Buffer) {
 
 #scope_file
 
-get_tokenizer :: (using buffer: Buffer) -> Tokenizer {
-    tokenizer : Tokenizer;
-
-    tokenizer.buf = cast(string) bytes;
-    tokenizer.max_t = bytes.data + bytes.count;
-    tokenizer.t     = bytes.data;
-
-    return tokenizer;
-}
-
 get_next_token :: (using tokenizer: *Tokenizer) -> Token {
-    t = eat_white_space(t, max_t);
+    eat_white_space(tokenizer);
 
     token : Token;
     token.start = cast(s32) (t - buf.data);
@@ -62,10 +52,11 @@ get_next_token :: (using tokenizer: *Tokenizer) -> Token {
 }
 
 parse_identifier :: (using tokenizer: *Tokenizer, token: *Token) {
+    push_allocator(temp);
     token.type = .identifier;
 
     identifier_str := read_identifier_string(tokenizer);
-    
+
     // need to do this if we want to use the same enum logic as in other parsers, not pretty but get's the job done.
     sanitized_string := replace(identifier_str, "-", "_");
 
@@ -125,7 +116,7 @@ parse_slash_or_comment :: (using tokenizer: *Tokenizer, token: *Token) {
 
 parse_string_literal :: (using tokenizer: *Tokenizer, token: *Token, quote := #char "\"") {
      token.type = .string_literal;
-     
+
      escape_seen := false;
      t += 1;
 
@@ -152,16 +143,6 @@ read_identifier_string :: (using tokenizer: *Tokenizer) -> string {
     ret.count = xx (t - ret.data);
 
     return ret;
-}
-
-
-Tokenizer :: struct {
-    buf: string;
-    max_t:   *u8;
-    start_t: *u8;  // cursor when starting parsing new token
-    t:       *u8;  // cursor
-
-    last_tokens: [2] Token;  // to retroactively highlight functions
 }
 
 Token :: struct {
@@ -270,14 +251,5 @@ MAX_KEYWORD_LENGTH :: #run -> s32 {
     for TYPE_KEYWORDS  { if it.count > result then result = it.count; }
     return xx result;
 }
-
-eat_white_space :: inline (start: *u8, max_t: *u8) -> *u8 {
-    t := start;
-    while t < max_t && is_white_space(<<t) {
-        t += 1;
-    }
-    return t;
-}
-
 
 #import "Hash_Table";

--- a/src/main.jai
+++ b/src/main.jai
@@ -796,6 +796,7 @@ dont_ignore_next_window_resize := false;
 #load "langs/renpy.jai";
 #load "langs/xml.jai";
 #load "langs/worklog.jai";
+#load "langs/yang.jai";
 
 #if OS == .WINDOWS {
     #load "platform/windows.jai";


### PR DESCRIPTION
As hinted at in the discord, this PR adds basic syntax highlighting support for the YANG Modeling lanuage (https://datatracker.ietf.org/doc/html/rfc7950) as well as support for the commands `toggle_comment` and `toggle_block_comment` for the language.

This version of the parser is not context aware of the statements so does not support highlighting of custom types defined in the model but does a good job of syntax highlighting. Statement awareness would need to be added for more advanced language support like linting.

This is an example of how it looks: ![image](https://github.com/focus-editor/focus/assets/6022262/4f018bc1-0f85-42cd-b288-269dc43834a5)
By default `TYPE_KEYWORDS` are highlighted with default code color to avoid angry fruit salad as jon would put it.