### PR TITLE
Fix an indentation issue with Lua `else` keyword

### DIFF
--- a/src/langs/lua.jai
+++ b/src/langs/lua.jai
@@ -41,8 +41,13 @@ tokenize_lua_for_indentation :: (using buffer: Buffer) -> [] Indentation_Token /
                 if src.keyword == {
                     case .kw_do;        token.type = .open; token.kind  = .brace;
                     case .kw_then;      token.type = .open; token.kind  = .brace;
-
                     case .kw_end;       token.type = .close; token.kind = .brace;
+
+                    case .kw_else;
+                        // Intentionally adding 2 tokens to get a `}{` effect when indenting
+                        token.type = .close; token.kind = .brace;
+                        array_add(*tokens, token);
+                        token.type = .open; token.kind = .brace;
 
                     case;               continue;
                 }


### PR DESCRIPTION
Fixed it by getting the `else` token to act as 2 indentation tokens: One to close and another to re-open.