### PR TITLE
Persistent search highlights

### DIFF
--- a/src/draw.jai
+++ b/src/draw.jai
@@ -960,7 +960,7 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
         }
 
         // Draw search results
-        if search_bar_is_open(editor) {
+        if search_bar.results {
             for search_bar.results {
                 start, end := it.offset, it.offset + it.count;
                 if end   < visible_offset_range.start continue;
@@ -1105,7 +1105,7 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
 
             total_scrollable_lines := content_height / line_height;
 
-            if search_bar_is_open(editor) && search_bar.results {
+            if search_bar.results {
                 // Search results
                 for search_bar.results {
                     pos_from_top := rect.h * cast(float) it.line / total_scrollable_lines;

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -288,9 +288,7 @@ active_editor_handle_event :: (editor: *Editor, buffer: *Buffer, event: Input.Ev
     if buffer.dirty {
         rescan_for_lines(buffer);
         if line_wrap_is_active(editor) then rescan_for_wrapped_lines(editor, buffer);
-        if editor.search_bar.results {
-            search_and_update_results(editor, buffer, jump = false);
-        }
+        if editor.search_bar.results then search_and_update_results(editor, buffer, jump = false);
     }
     for * editor.cursors put_cursor_in_valid_spot(it, buffer);
     if editor.cursors.count > 1 then organise_cursors(editor);  // sort and maybe merge overlapping cursors
@@ -382,9 +380,7 @@ active_editor_type_char :: (char: u32) {
     buffer.last_edit_time = frame_time;
     editor.cursor_moved = .unimportant;
     cursors_start_blinking();
-    if editor.search_bar.results {
-        search_and_update_results(editor, buffer, jump = false);
-    }
+    if editor.search_bar.results then search_and_update_results(editor, buffer, jump = false);
 }
 
 get_active_editor_and_buffer :: () -> *Editor, *Buffer {
@@ -403,7 +399,7 @@ refresh_all_editors_for_buffer :: (buffer_id: s64) {
 
         adjust_cursors_and_viewport(editor, buffer, editor_id);
         editor.refresh_highlights = true;
-        if search_bar_is_open(editor) search_and_update_results(editor, buffer);
+        if editor.search_bar.results then search_and_update_results(editor, buffer);
     }
     array_reset_keeping_memory(*buffer.edit_notifications);
 }

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -159,7 +159,10 @@ active_editor_handle_event :: (editor: *Editor, buffer: *Buffer, event: Input.Ev
         case .close_right_editor;               close_editor(.right);
 
         case .close_dialog;                     hide_build_panel();
-        case .escape;                           hide_build_panel(); remove_additional_cursors(editor);
+        case .escape;                           hide_build_panel();
+                                                remove_additional_cursors(editor);
+                                                reset_search_results(*editor.search_bar);
+                                                editor.refresh_highlights = true;
 
         case .save;                             save    (editor.buffer_id);
         case .save_as;                          save_as (editor.buffer_id);
@@ -857,9 +860,6 @@ close_search_bar :: inline (editor: *Editor, jump_to_original_cursor := false, j
         cursor.pos = xx (cursor.sel + results[selected_result].count);
         editor.scroll_to_cursor = .yes;
     }
-
-    reset_search_results(*editor.search_bar);
-    editor.refresh_highlights = true;
 }
 
 search_bar_toggle_expand :: (using editor: *Editor) {

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -288,6 +288,9 @@ active_editor_handle_event :: (editor: *Editor, buffer: *Buffer, event: Input.Ev
     if buffer.dirty {
         rescan_for_lines(buffer);
         if line_wrap_is_active(editor) then rescan_for_wrapped_lines(editor, buffer);
+        if editor.search_bar.results {
+            search_and_update_results(editor, buffer, jump = false);
+        }
     }
     for * editor.cursors put_cursor_in_valid_spot(it, buffer);
     if editor.cursors.count > 1 then organise_cursors(editor);  // sort and maybe merge overlapping cursors

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -379,6 +379,9 @@ active_editor_type_char :: (char: u32) {
     buffer.last_edit_time = frame_time;
     editor.cursor_moved = .unimportant;
     cursors_start_blinking();
+    if editor.search_bar.results {
+        search_and_update_results(editor, buffer, jump = false);
+    }
 }
 
 get_active_editor_and_buffer :: () -> *Editor, *Buffer {


### PR DESCRIPTION
Makes search highlighting stay visible after closing the search bar. This is similar to vim's `hlsearch` option.

Relevant discord msg: https://discord.com/channels/1106007785193345104/1126291418202251368/1153893543820140646

Question: should this be default behaviour or behind a config option?