### PR TITLE
Fix crash in show_open_file_dialog_in_open_editors_mode

### DIFF
--- a/src/buffer.jai
+++ b/src/buffer.jai
@@ -1081,6 +1081,7 @@ unsaved_buffers_exist :: () -> bool {
 }
 
 remove_all_buffers :: () {
+    array_reset_keeping_memory(*most_recent_buffers);
     deinit(*buffers_table);
     for * open_buffers free_buffer(it);
     bucket_array_reset(*open_buffers);


### PR DESCRIPTION
## Repro
1. Open Focus
2. Open any file. May be a new file with Ctrl-N `create_new_file`
3. Switch to any project. It doesn't matter if you save modified files.
5. Ctrl-Tab `show_open_file_dialog_in_open_editors_mode`
6. Crash.

## Fix
`remove_all_buffers` now resets `most_recent_buffers`