### PR TITLE
switch_to_project no longer prematurely loads config

### DIFF
--- a/src/buffer.jai
+++ b/src/buffer.jai
@@ -1132,6 +1132,7 @@ process_buffer_save_queue :: () {
             case .do_nothing;           // yay, do nothing
             case .exit_program;         should_quit = true;
             case .reload_workspace;     should_reload_workspace = true;
+            case .switch_project;       should_switch_project = true;
         }
     }
 }
@@ -1403,6 +1404,13 @@ Indentation_Token :: struct {
 }
 
 
+After_Save_Action :: enum {
+    do_nothing;
+    exit_program;
+    reload_workspace;
+    switch_project;
+}
+
 #scope_file
 
 // A queue to allow us to use the in-editor save dialog for multiple buffers.
@@ -1413,8 +1421,3 @@ buffer_save_queue: struct {
     after_save: After_Save_Action = .do_nothing;
 };
 
-After_Save_Action :: enum {
-    do_nothing;
-    exit_program;
-    reload_workspace;
-}

--- a/src/buffer.jai
+++ b/src/buffer.jai
@@ -1132,7 +1132,7 @@ process_buffer_save_queue :: () {
             case .do_nothing;           // yay, do nothing
             case .exit_program;         should_quit = true;
             case .reload_workspace;     should_reload_workspace = true;
-            case .switch_project;       should_switch_project = true;
+            case .switch_project;       switch_project();
         }
     }
 }

--- a/src/main.jai
+++ b/src/main.jai
@@ -283,19 +283,6 @@ main :: () {
         }
 
         process_buffer_save_queue();
-
-        if should_switch_project {
-            success := load_project_config(project_to_switch_to, force = true);
-            if success {
-                should_reload_workspace = true;
-            } else {
-                add_user_error("Couldn't load project config for %", project_to_switch_to, dismiss_in_seconds = 10);
-            }
-
-            should_switch_project   = false;
-            project_to_switch_to    = "";
-        }
-
         build_system_update();
         refresh_open_buffers();
 
@@ -650,8 +637,6 @@ should_quit             := false;
 force_quit              := false;
 should_reload_workspace := false;
 automatic_workspace_reload := false;
-should_switch_project   := false;
-project_to_switch_to    := "";
 
 frame_time: Time;                 // ever-increasing time since start in seconds
 frame_dt:   Time = MAX_FRAME_DT;  // time delta since the last frame

--- a/src/main.jai
+++ b/src/main.jai
@@ -283,6 +283,19 @@ main :: () {
         }
 
         process_buffer_save_queue();
+
+        if should_switch_project {
+            success := load_project_config(project_to_switch_to, force = true);
+            if success {
+                should_reload_workspace = true;
+            } else {
+                add_user_error("Couldn't load project config for %", project_to_switch_to, dismiss_in_seconds = 10);
+            }
+
+            should_switch_project   = false;
+            project_to_switch_to    = "";
+        }
+
         build_system_update();
         refresh_open_buffers();
 
@@ -637,6 +650,8 @@ should_quit             := false;
 force_quit              := false;
 should_reload_workspace := false;
 automatic_workspace_reload := false;
+should_switch_project   := false;
+project_to_switch_to    := "";
 
 frame_time: Time;                 // ever-increasing time since start in seconds
 frame_dt:   Time = MAX_FRAME_DT;  // time delta since the last frame

--- a/src/widgets/open_project.jai
+++ b/src/widgets/open_project.jai
@@ -8,18 +8,11 @@ open_selected_project :: () {
     using open_project_dialog;
     if selected >= filtered.count return;
 
-    entry := filtered[selected];
-
-    success := load_project_config(entry.name, force = true);
-    if success {
-        should_reload_workspace = true;
-        automatic_workspace_reload = false;
-        if unsaved_buffers_exist() {
-            show_unsaved_buffers_dialog(.reload_workspace);
-            should_reload_workspace = false;
-        }
+    project_to_switch_to  = filtered[selected].name;
+    if unsaved_buffers_exist() {
+        show_unsaved_buffers_dialog(After_Save_Action.switch_project);
     } else {
-        add_user_error("Couldn't load project config for %", entry.name, dismiss_in_seconds = 10);
+        should_switch_project = true;
     }
 }
 

--- a/src/widgets/open_project.jai
+++ b/src/widgets/open_project.jai
@@ -12,7 +12,7 @@ open_selected_project :: () {
     if unsaved_buffers_exist() {
         show_unsaved_buffers_dialog(After_Save_Action.switch_project);
     } else {
-        should_switch_project = true;
+        switch_project();
     }
 }
 
@@ -23,7 +23,22 @@ Open_Project_Dialog :: struct {
     generic_dialog.global_widget_id    = .open_project_dialog;
     generic_dialog.refresh_entries     = open_project_refresh_entries;
     generic_dialog.open_entry_in_place = open_selected_project;
+
+    project_to_switch_to := "";
 };
+
+switch_project :: () {
+    using open_project_dialog;
+    assert(project_to_switch_to != "");
+
+    success := load_project_config(project_to_switch_to, force = true);
+    if success {
+        should_reload_workspace = true;
+    } else {
+        add_user_error("Couldn't load project config for %", project_to_switch_to, dismiss_in_seconds = 10);
+    }
+    project_to_switch_to = "";
+}
 
 #scope_file
 

--- a/src/widgets/unsaved_buffers.jai
+++ b/src/widgets/unsaved_buffers.jai
@@ -55,7 +55,7 @@ unsaved_buffers_dialog_proceed :: () {
             should_quit = true;
 
         case .reload_workspace;  should_reload_workspace = true;
-        case .switch_project;    should_switch_project   = true;
+        case .switch_project;    switch_project();
         case .do_nothing;
     }
 

--- a/src/widgets/unsaved_buffers.jai
+++ b/src/widgets/unsaved_buffers.jai
@@ -11,7 +11,7 @@ unsaved_buffers_dialog_handle_event :: (event: Input.Event) -> bool {
     return false;
 }
 
-show_unsaved_buffers_dialog :: (requested_mode: Mode = .exit_program) {
+show_unsaved_buffers_dialog :: (requested_mode: After_Save_Action = .exit_program) {
     using unsaved_buffers_dialog;
 
     active_global_widget = .unsaved_buffers_dialog;
@@ -40,10 +40,7 @@ unsaved_buffers_save_all :: () {
             save_buffer(buffer, buffer_id);
             if buffer.error_when_saving then should_proceed = false;
         } else {
-            if #complete unsaved_buffers_dialog.mode == {
-                case .exit_program;         add_buffer_to_save_queue(buffer_id, after_save = .exit_program);
-                case .reload_workspace;     add_buffer_to_save_queue(buffer_id, after_save = .reload_workspace);
-            }
+            add_buffer_to_save_queue(buffer_id, after_save = unsaved_buffers_dialog.mode);
             should_proceed = false;
         }
     }
@@ -56,8 +53,10 @@ unsaved_buffers_dialog_proceed :: () {
         case .exit_program;
             force_quit  = true;
             should_quit = true;
-        case .reload_workspace;
-            should_reload_workspace = true;
+
+        case .reload_workspace;  should_reload_workspace = true;
+        case .switch_project;    should_switch_project   = true;
+        case .do_nothing;
     }
 
     close_unsaved_buffers_dialog();
@@ -67,12 +66,5 @@ unsaved_buffers_dialog_proceed :: () {
 
 unsaved_buffers_dialog: struct {
     modified_buffers: [..] s64;
-    mode: Mode;
+    mode: After_Save_Action;
 };
-
-#scope_file
-
-Mode :: enum {
-    exit_program;
-    reload_workspace;
-}


### PR DESCRIPTION
# Issue repro
- Create New File
  - type some stuff in there
- Switch To Project
  - Save
    - hit Escape
- Open Project Config
  - note the config is that of the selected project, but the workspace has not been reloaded because you canceled the save.

# Fix
`open_selected_project` no longer instantly loads the new project config, but does so after the save dialog completes. To do that, `show_unsaved_buffers_dialog` and `add_buffer_to_save_queue` have gotten a new mode/action: `.switch_project` to call on once all files are saved.

### Sidenote
I'm not a fan of the way dialogs work right now. `open_selected_project` has the potential to call a chain of 3-4 different kinds of dialogs, but they feel a little too loosely connected. Preferably a change down the line makes it so that dialogs are saved in some kind of stack so that when the save dialog closes it knows to return control to the open_project_dialog that initially called forth the save dialog. Then the open_project_dialog could decide to reload or not, but such a change would affect other dialogs too, I'd rather discuss something like that before implementing it.