### PR TITLE
Chossing theme should change window border-color when previewing

### DIFF
--- a/src/config.jai
+++ b/src/config.jai
@@ -74,8 +74,6 @@ load_project_config :: (project: string = "", force := false) -> success: bool, 
 }
 
 apply_config :: () {
-    platform_set_border_color();
-
     // Make sure the values are within the acceptable range
     old_tab_size := TAB_SIZE;
     TAB_SIZE = clamp(cast(s32) config.settings.tab_size, 1, 100);  // be reasonable mkay (though even 100 is unreasonable)
@@ -277,6 +275,8 @@ apply_style :: (parsed: Parsed_Config) {
             log_error("Couldn't map color name '%' to color enum value. This is a bug", it.color_name);
         }
     }
+
+    platform_set_border_color();
 }
 
 #scope_file

--- a/src/widgets/theme_dialog.jai
+++ b/src/widgets/theme_dialog.jai
@@ -93,6 +93,7 @@ preview_selected_theme :: () {
 
     if theme.config_name == "default" {
         reset_color_map_to_default();
+        platform_set_border_color();
         return;
     }
 


### PR DESCRIPTION
When browsing themes with `Choose Theme` the color titlebar of the window is not changed in the preview.

Moved `platform_set_border_color()` to `apply_style()` to make that happen. To also properly reset it gets set again when switching back to the default theme.

The `platform_set_border_color()` call in `apply_config()` seemed now redundant, as `apply_style()` is also called in `merge_configs`.
I tested different scenarios of changing theme in the files, on disk and with theme picker and these changes seem to catch them. Changing the `colored_titlebar` setting also still works properly.

Is there a scenario I might have missed?

Also feel free to close if this is not the intended behavior.