### PR TITLE
save_current_buffer_on_build and save_all_file_backed_buffers_on_build settings

### DIFF
--- a/config/default.focus-config
+++ b/config/default.focus-config
@@ -72,6 +72,8 @@ build_panel_line_wrap_always_on:        true
 build_panel_width_percent:              50
 build_panel_height_percent:             50
 
+save_all_file_backed_buffers_on_build:  false
+save_current_buffer_on_build:           true
 
 # This is an example configuration for build commands
 

--- a/src/config.jai
+++ b/src/config.jai
@@ -495,6 +495,9 @@ Settings :: struct {
     build_panel_height_percent              := 50;
     build_panel_stays_in_one_place          := false;
     build_panel_line_wrap_always_on         := true;
+    
+    save_current_buffer_on_build            := true;
+    save_all_file_backed_buffers_on_build   := false;
 
     // TODO
     // convert_tabs_to_spaces_on_load:     false

--- a/src/main.jai
+++ b/src/main.jai
@@ -388,7 +388,7 @@ maybe_execute_a_build_command :: (event: Input.Event) -> handled: bool {
         }
     } else if config.settings.save_current_buffer_on_build {
         editor, buffer := get_active_editor_and_buffer();
-        if editor save_buffer(buffer, editor.buffer_id);
+        if editor && buffer.has_file save_buffer(buffer, editor.buffer_id);
     }
 
     command := ifx command_id > 0 then *config.build.commands[command_id-1] else *config.build.defaults;

--- a/src/main.jai
+++ b/src/main.jai
@@ -379,6 +379,17 @@ maybe_execute_a_build_command :: (event: Input.Event) -> handled: bool {
 
     command_id := cast(s64) action;
     assert(command_id <= config.build.commands.count, "A keymap was bound to a nonexistent build command %. Number of build commands: %. This is a bug", command_id, config.build.commands.count);
+    
+    if config.settings.save_all_file_backed_buffers_on_build {
+        for * buffer, buffer_id : open_buffers {
+            if buffer.modified && buffer.has_file {
+                save_buffer(buffer, buffer_id);
+            }
+        }
+    } else if config.settings.save_current_buffer_on_build {
+        editor, buffer := get_active_editor_and_buffer();
+        if editor save_buffer(buffer, editor.buffer_id);
+    }
 
     command := ifx command_id > 0 then *config.build.commands[command_id-1] else *config.build.defaults;
     execute_build_command(command);


### PR DESCRIPTION
So you don't forget to save your changes before building.
Save all files is limited to files that already have been saved once, so you don't get a save-as 'popup'.
I disabled save all by default and enabled save current buffer. We might want different defaults?
Settings are now 2 different bools, they should perhaps be set with one enum. Especially if we want to include saving new files as an option making it 3 bools instead of 1 enum. I could implement enum parsing in `parse_settings_line`