### PR TITLE
Go to next build error

### DIFF
--- a/config/default.focus-config
+++ b/config/default.focus-config
@@ -79,6 +79,8 @@ build_panel_height_percent:             50
 # build_working_dir:      <build working dir for all commands>
 # open_panel_on_build:    true  #  <- any settings specified here will apply to all commands unless overridden
 # close_panel_on_success: false
+# error_regex:            ^(?P<file>.*):(?P<line>\d+),(?P<col>\d+): (?P<type>Error|Warning|Info): (?P<msg>.*)|^(?P<msg>.*error LNK.*)
+# auto_jump_to_error:     true
 
 # [Debug Build And Run]   # <- command name. Can be arbitrary
 # build_command:          jai main.jai  # should be an executable or a script

--- a/modules/uniform/match.jai
+++ b/modules/uniform/match.jai
@@ -79,6 +79,36 @@ match :: (text: string, re: Regexp, re_anchor_in: Anchor = .UNANCHORED) -> match
 	return matched, submatches;
 }
 
+
+map_named_captures :: (captures: []string, re: Regexp) -> Table(string, string) {
+    result: Table(string, string);
+    
+    Named_Capture :: struct {
+        name: string;
+        index: s32;
+    }
+    
+    get_all_named_captures :: (list: *[..]Named_Capture, re: *Regexp_Node, v: *void) -> *void, bool {
+        if re.op == .Capture && re.name {
+            array_add(list, .{re.name, re.cap});
+        }
+        
+        return null, false;
+    }
+    
+    named_captures: [..]Named_Capture;
+    w := Walk(*[..]Named_Capture, *void).{pre_visit = get_all_named_captures};
+	walk(*named_captures, re.suffix_regexp, null, w);
+    
+    for named_captures {
+        if captures[it.index] {
+            table_set(*result, it.name, captures[it.index]);
+        }
+    }
+    
+    return result;
+}
+
 // Avoid possible locale nonsense in standard strcasecmp.
 // The string a is known to be all lowercase.
 ascii_strcasecmp :: (a: string, b: string) -> int {

--- a/src/build_system.jai
+++ b/src/build_system.jai
@@ -106,6 +106,8 @@ build_kill_running_command :: () {
     unlock(*build_mutex);
 }
 
+DEBUG_BUILD_ERRORS :: true;
+
 Build_Error_Location :: struct {
     message: string;
     type: enum {
@@ -127,12 +129,11 @@ go_to_next_build_error :: () {
     
     build_error_index += 1;
     
-    if build_error_index >= build_errors.count
-        build_error_index = 0;
+    if build_error_index >= build_errors.count then build_error_index = 0;
     
     error := build_errors[build_error_index];
     
-    log("Trying to go to error: %", error);
+    #if DEBUG_BUILD_ERRORS log("Trying to go to error: %", error);
     
     if error.file {
         //TODO: remember last error and info place so we don't switch each time
@@ -169,13 +170,14 @@ clear_build_errors :: () {
         free(it.file);
         free(it.message);
     }
+    
     array_reset(*build_errors);
+    
+    build_error_index = -1;
 }
 
 parse_build_errors :: (command: Build_Command) {
     if !command.error_regex return;
-    
-    build_error_index = -1;
     
     editor, buffer := get_build_editor_and_buffer();
     
@@ -189,7 +191,7 @@ parse_build_errors :: (command: Build_Command) {
     
     contents := slice(cast(string)buffer.bytes, start, buffer.bytes.count);
     
-    log("Parsing build_errors: %\n%", start, contents);
+    #if DEBUG_BUILD_ERRORS log("Parsing build_errors: %\n%", start, contents);
     
     regex, valid := re.compile(command.error_regex, .LikePerl & ~.OneLine);
     if !valid return;
@@ -206,7 +208,7 @@ parse_build_errors :: (command: Build_Command) {
             break;//TODO: skip one char/line
         }
         
-        log("Found regex error match: %", c);
+        #if DEBUG_BUILD_ERRORS log("Found regex error match: %", c);
         
         local_offset := c.data - contents.data;
         count  := c.count;
@@ -218,7 +220,7 @@ parse_build_errors :: (command: Build_Command) {
         named_captures := re.map_named_captures(captures, regex);
         defer deinit(*named_captures);
         for value, name: named_captures {
-            log("Captured name: %=%", name, value);
+            #if DEBUG_BUILD_ERRORS log("Captured name: %=%", name, value);
         }
         
         msg, found := table_find(*named_captures, "msg");
@@ -248,21 +250,20 @@ parse_build_errors :: (command: Build_Command) {
         }
         
         line := table_find_or_default(*named_captures, "line");
-        col := table_find_or_default(*named_captures, "col");
+        col  := table_find_or_default(*named_captures, "col");
         
         val, parsed := string_to_int(line, T=s32);
-        if parsed error.line = val;
+        if parsed then error.line = val;
         
         val, parsed  = string_to_int(col, T=s32);
-        if parsed error.col = val - 1;//TODO: config based? other compilers could be 0 based
+        if parsed then error.col = val - 1;//TODO: config based? other compilers could be 0 based
         
         array_add(*build_errors, error);
     }
     
-    log("FOUND: %", build_errors);
+    #if DEBUG_BUILD_ERRORS log("FOUND: %", build_errors);
     
-    if command.auto_jump_to_error
-        go_to_next_build_error();
+    if command.auto_jump_to_error then go_to_next_build_error();
 }
 
 build_system_update :: () {

--- a/src/build_system.jai
+++ b/src/build_system.jai
@@ -59,6 +59,9 @@ execute_build_command :: (command: *Build_Command) {
     }
 
     log("Executing build command [%]\n", command.name);
+    
+    clear_build_errors();
+    //array_reset(*build_errors);//if we move this to other place, remember to copy_string the file and message
 
     // Add an empty line between commands
     if last_command_result.finished then print_to_output_panel_from_main_thread("\n");
@@ -101,6 +104,129 @@ build_kill_running_command :: () {
     lock(*build_mutex);
     kill_process(*running_process);
     unlock(*build_mutex);
+}
+
+Build_Error_Location :: struct {
+    file: string;
+    line: s32;
+    col: s32;
+    message: string;
+}
+
+build_error_index := -1;
+go_to_next_build_error :: () {
+    if !build_errors.count {
+        //TODO: show message that there are no errors?
+        return;
+    }
+    
+    build_error_index += 1;
+    
+    if build_error_index >= build_errors.count
+        build_error_index = 0;
+    
+    error := build_errors[build_error_index];
+    
+    beditor, bbuffer := get_build_editor_and_buffer();
+    log("Build editor: %, %", bbuffer.bytes.data, bbuffer.bytes.count);
+    
+    log("Trying to go to error: %", error);
+    
+    editors_open_file(error.file, .in_place);//TODO: test ctrl-modifier for .on_the_side
+    // found := -1;
+    // for buffer, buffer_id : open_buffers {
+    //     if buffer.file.full_path == error.file {
+    //         found = buffer_id;
+    //         break;
+    //     }
+    // }
+    
+    // if found == -1 {
+    //     add_user_error("File with name '%' is not found.", error.file);
+    //     return;
+    // }
+    
+    // activate_buffer(open_buffers[found], found);
+    
+    editor, buffer := get_active_editor_and_buffer();
+    go_to_line(editor, buffer, error.line, error.col);
+    
+    clear_user_messages(.build_error);
+    add_user_error(error.message, dismiss_in_seconds = -1, .build_error);//TODO: -1 to dismiss manually or on next
+}
+
+build_errors: [..]Build_Error_Location;
+clear_build_errors :: () {
+    clear_user_messages(.build_error);
+    
+    for build_errors {
+        free(it.file);
+        free(it.message);
+    }
+    array_reset(*build_errors);
+}
+
+parse_build_errors :: (command: Build_Command) {
+    if !command.error_regex return;
+    
+    build_error_index = -1;
+    
+    editor, buffer := get_build_editor_and_buffer();
+    
+    start := 0;
+    for < * region : buffer.regions {
+        if region.kind == .header {
+            start = region.end;
+            break;
+        }
+    }
+    
+    contents := slice(cast(string)buffer.bytes, start, buffer.bytes.count);
+    
+    log("Parsing build_errors: %\n%", start, contents);
+    
+    regex, valid := re.compile(command.error_regex, .LikePerl);
+    if !valid return;
+    
+    while true {
+        matched, captures := re.match(contents, regex);
+        
+        if !matched break;
+        defer free(captures.data);
+        
+        c := captures[0];
+        if !c {
+            log_error("build regex matched an empty line");
+            break;//TODO: skip one char/line
+        }
+        
+        local_offset := c.data - contents.data;
+        count  := c.count;
+        //offset := contents_advance + local_offset;
+        //contents_advance := offset + count;
+
+        advance(*contents, local_offset + count);
+        
+        log("Found: %", c);
+        
+        //TODO: copy_string, because build editor gets modified? But we reset build_errors before that
+        error := Build_Error_Location.{ file = copy_string(captures[1]), message = copy_string(captures[4]) };
+        
+        val, parsed := string_to_int(captures[2], T=s32);
+        if !parsed continue;
+        error.line = val;
+        
+        val, parsed  = string_to_int(captures[3], T=s32);
+        if !parsed continue;
+        error.col = val - 1;//TODO: config based? other compilers could be 0 based
+        
+        array_add(*build_errors, error);
+    }
+    
+    log("FOUND: %", build_errors);
+    log("Build editor: %, %", buffer.bytes.data, buffer.bytes.count);
+    
+    //TODO: run regex on build_buffer from X to end
 }
 
 build_system_update :: () {
@@ -161,7 +287,12 @@ build_system_update :: () {
                         kind = .success;
                     }
             }
+            
+            if last_command_result.build.process_result.exit_code != 0 {
+                parse_build_errors(running_command);
+            }
         }
+        
 
         print_to_output_panel_from_main_thread(tprint("%\n", message), mark_as = kind, add_newline_if_missing = true);
 

--- a/src/build_system.jai
+++ b/src/build_system.jai
@@ -132,9 +132,6 @@ go_to_next_build_error :: () {
     
     error := build_errors[build_error_index];
     
-    beditor, bbuffer := get_build_editor_and_buffer();
-    log("Build editor: %, %", bbuffer.bytes.data, bbuffer.bytes.count);
-    
     log("Trying to go to error: %", error);
     
     if error.file {
@@ -150,7 +147,8 @@ go_to_next_build_error :: () {
     
     //TODO: open info first or switch back to error site?
     if error.type == .error && build_error_index < build_errors.count - 1 && build_errors[build_error_index+1].type == .info {
-        next_error := build_errors[build_error_index+1];
+        build_error_index += 1;
+        next_error := build_errors[build_error_index];
         
         if next_error.file {
             editors_open_file(next_error.file, .on_the_side);//TODO: test ctrl-modifier for .on_the_side
@@ -218,6 +216,7 @@ parse_build_errors :: (command: Build_Command) {
         advance(*contents, local_offset + count);
         
         named_captures := re.map_named_captures(captures, regex);
+        defer deinit(*named_captures);
         for value, name: named_captures {
             log("Captured name: %=%", name, value);
         }

--- a/src/build_system.jai
+++ b/src/build_system.jai
@@ -107,10 +107,15 @@ build_kill_running_command :: () {
 }
 
 Build_Error_Location :: struct {
+    message: string;
+    type: enum {
+        error;
+        warning;
+        info;
+    };
     file: string;
     line: s32;
     col: s32;
-    message: string;
 }
 
 build_error_index := -1;
@@ -132,27 +137,30 @@ go_to_next_build_error :: () {
     
     log("Trying to go to error: %", error);
     
-    editors_open_file(error.file, .in_place);//TODO: test ctrl-modifier for .on_the_side
-    // found := -1;
-    // for buffer, buffer_id : open_buffers {
-    //     if buffer.file.full_path == error.file {
-    //         found = buffer_id;
-    //         break;
-    //     }
-    // }
-    
-    // if found == -1 {
-    //     add_user_error("File with name '%' is not found.", error.file);
-    //     return;
-    // }
-    
-    // activate_buffer(open_buffers[found], found);
-    
-    editor, buffer := get_active_editor_and_buffer();
-    go_to_line(editor, buffer, error.line, error.col);
+    if error.file {
+        //TODO: remember last error and info place so we don't switch each time
+        editors_open_file(error.file, .in_place);//TODO: test ctrl-modifier for .on_the_side
+        
+        editor, buffer := get_active_editor_and_buffer();
+        go_to_line(editor, buffer, error.line, error.col);
+    }
     
     clear_user_messages(.build_error);
-    add_user_error(error.message, dismiss_in_seconds = -1, .build_error);//TODO: -1 to dismiss manually or on next
+    add_user_error(error.message, dismiss_in_seconds = -1, .build_error);
+    
+    //TODO: open info first or switch back to error site?
+    if error.type == .error && build_error_index < build_errors.count - 1 && build_errors[build_error_index+1].type == .info {
+        next_error := build_errors[build_error_index+1];
+        
+        if next_error.file {
+            editors_open_file(next_error.file, .on_the_side);//TODO: test ctrl-modifier for .on_the_side
+            
+            editor, buffer := get_active_editor_and_buffer();
+            go_to_line(editor, buffer, next_error.line, next_error.col);
+        }
+        
+        add_user_warning(next_error.message, dismiss_in_seconds = -1, .build_error);
+    }
 }
 
 build_errors: [..]Build_Error_Location;
@@ -185,7 +193,7 @@ parse_build_errors :: (command: Build_Command) {
     
     log("Parsing build_errors: %\n%", start, contents);
     
-    regex, valid := re.compile(command.error_regex, .LikePerl);
+    regex, valid := re.compile(command.error_regex, .LikePerl & ~.OneLine);
     if !valid return;
     
     while true {
@@ -200,6 +208,8 @@ parse_build_errors :: (command: Build_Command) {
             break;//TODO: skip one char/line
         }
         
+        log("Found regex error match: %", c);
+        
         local_offset := c.data - contents.data;
         count  := c.count;
         //offset := contents_advance + local_offset;
@@ -207,26 +217,53 @@ parse_build_errors :: (command: Build_Command) {
 
         advance(*contents, local_offset + count);
         
-        log("Found: %", c);
+        named_captures := re.map_named_captures(captures, regex);
+        for value, name: named_captures {
+            log("Captured name: %=%", name, value);
+        }
+        
+        msg, found := table_find(*named_captures, "msg");
+        if !found return;
+        
+        table_find_or_default :: (table: *Table, key: table.Key_Type) -> table.Value_Type {
+            pointer := inline table_find_pointer(table, key);
+            if pointer  return << pointer;
+            
+            default: table.Value_Type; 
+            return default;
+        }
+        
+        file := table_find_or_default(*named_captures, "file");
         
         //TODO: copy_string, because build editor gets modified? But we reset build_errors before that
-        error := Build_Error_Location.{ file = copy_string(captures[1]), message = copy_string(captures[4]) };
+        error := Build_Error_Location.{ file = copy_string(file), message = copy_string(msg) };
         
-        val, parsed := string_to_int(captures[2], T=s32);
-        if !parsed continue;
-        error.line = val;
+        type := table_find_or_default(*named_captures, "type");
+        if type {
+            //TODO: enum_from_string_nocase
+            if equal_nocase(type, "warning") {
+                error.type = .warning;
+            } else if equal_nocase(type, "info") {
+                error.type = .info;
+            }
+        }
         
-        val, parsed  = string_to_int(captures[3], T=s32);
-        if !parsed continue;
-        error.col = val - 1;//TODO: config based? other compilers could be 0 based
+        line := table_find_or_default(*named_captures, "line");
+        col := table_find_or_default(*named_captures, "col");
+        
+        val, parsed := string_to_int(line, T=s32);
+        if parsed error.line = val;
+        
+        val, parsed  = string_to_int(col, T=s32);
+        if parsed error.col = val - 1;//TODO: config based? other compilers could be 0 based
         
         array_add(*build_errors, error);
     }
     
     log("FOUND: %", build_errors);
-    log("Build editor: %, %", buffer.bytes.data, buffer.bytes.count);
     
-    //TODO: run regex on build_buffer from X to end
+    if command.auto_jump_to_error
+        go_to_next_build_error();
 }
 
 build_system_update :: () {

--- a/src/config_parser.jai
+++ b/src/config_parser.jai
@@ -758,7 +758,7 @@ parse_build_line :: (using parser: *Config_Parser, line: string) -> success: boo
     }
 
     if setting_name == "error_regex" {
-        _, regex_is_valid := re.compile(setting_value, BASE_REGEX_FLAGS);
+        _, regex_is_valid := re.compile(setting_value, BASE_REGEX_FLAGS&~.NeverCapture);
         if !regex_is_valid {
             add_highlight(parser, setting_value.data - line.data, setting_value.count, .error);
             return true, tprint("Error regex is invalid: '%'", setting_value);

--- a/src/keymap.jai
+++ b/src/keymap.jai
@@ -280,6 +280,7 @@ ACTIONS_COMMON :: string.[
     "search_in_buffer_dropdown_mode",
     "search_in_project",
     "go_to_line",
+    "go_to_next_build_error",
 
     "open_file_by_name",
     "navigate_to_file",

--- a/src/main.jai
+++ b/src/main.jai
@@ -347,7 +347,8 @@ handle_common_editor_action :: (action: Action_Editors, placement: Editor_Placem
         case .go_to_line;                                       show_go_to_line_dialog();                           return true;
         case .create_new_file;                                  editors_create_new_file(placement);                 return true;
         case .create_new_file_on_the_side;                      editors_create_new_file(.on_the_side);              return true;
-
+        case .go_to_next_build_error;                           go_to_next_build_error();
+        
         case .open_file_by_name;                                show_open_file_dialog(.search);                     return true;
         case .navigate_to_file;                                 show_open_file_dialog(.navigate);                   return true;
         case .navigate_to_file_from_root;                       show_open_file_dialog(.navigate, from_root = true); return true;

--- a/src/user_messages.jai
+++ b/src/user_messages.jai
@@ -70,6 +70,7 @@ Tag :: enum_flags {
     none;
     config;
     build;
+    build_error;
 }
 
 MAX_MESSAGES_ON_SCREEN :: 20;

--- a/src/widgets/go_to_line_dialog.jai
+++ b/src/widgets/go_to_line_dialog.jai
@@ -103,14 +103,27 @@ jump_to_line :: () {
         line_num += digit * n;
         n *= 10;
     }
+    
+    go_to_line(editor, buffer, line_num);
+}
 
+go_to_line :: (editor: *Editor, buffer: *Buffer, line_num: s64, col : s32 = -1) {
     line_num = clamp(line_num - 1, 0, get_max_real_line_num(buffer));
     line_start := get_real_line_start_offset(buffer, cast(s32)line_num);
     line_end   := get_real_line_end_offset  (buffer, cast(s32)line_num);
 
     cursor := leave_only_original_cursor(editor);
-    cursor.pos = line_start + count_whitespace(buffer.bytes, line_start, line_end);
-    cursor.sel = line_end;  // to make the line visible
+    
+    if col < 0 {
+        cursor.pos = line_start + count_whitespace(buffer.bytes, line_start, line_end);
+        cursor.sel = line_end;  // to make the line visible
+    } else {
+        cursor.pos = line_start + col;
+        if cursor.pos > line_end
+            cursor.pos = line_end;
+        
+        cursor.sel = cursor.pos;
+    }
     add_paste_animation(editor, get_selection(cursor));
     editor.cursor_moved = .jumped;
     editor.scroll_to_cursor = .yes;


### PR DESCRIPTION
Simple build error parser. Uses `error_regex` and `auto_jump_to_error` in Build_Command.

To support different compilers that might give different order for message, error type and/or line/column I added support for named captures in the `uniform` module. `map_named_captures` returns a Table that maps names to captures.

I use the regex `^(?P<file>.*):(?P<line>\d+),(?P<col>\d+): (?P<type>Error|Warning|Info): (?P<msg>.*)|^(?P<msg>.*error LNK.*)` in my own jai project.

There is a new action `go_to_next_build_error` that I mapped to `Ctrl-E` for myself. For the default we should probably poll Discord.

The action opens the next error in the active editor. If the next error in the queue is an info message (as is often the case in jai) it is opened on the side.