### PR TITLE
fix a crash when trying to access none available buffers after worksp…

### DIFF
--- a/src/editors.jai
+++ b/src/editors.jai
@@ -1085,6 +1085,9 @@ init_buffers :: () {
     init(*buffers_table, slots_to_allocate = 3000);
 
     init(*open_buffers_lock);
+
+    global_config_buffer_id = -1;
+    global_troubleshooting_buffer_id = -1;
 }
 
 set_lang_from_path :: (buffer: *Buffer, path: string) {


### PR DESCRIPTION
…ace reload

Initially reported here: https://discord.com/channels/1106007785193345104/1106007786418090088/1191384024938197093

After reloading a workspace by i.e. switching to a project the global buffer ids need to be reset so we do not try to access invalid buffer id