### PR TITLE
fix readonly memory access

### DIFF
--- a/modules/Runtime_Support.jai
+++ b/modules/Runtime_Support.jai
@@ -666,7 +666,8 @@ report_failed_assertion_more_visibly :: (loc: Source_Code_Location, msg: string)
 }
 
 report_error_in_yer_face_no_ctx :: (message: string, args: .. Any) #no_context {
-    push_context Context.{} { report_error_in_yer_face(message, ..args, from_no_context = true); }
+    ctx: Context;
+    push_context ctx { report_error_in_yer_face(message, ..args, from_no_context = true); }
 }
 
 report_error_in_yer_face :: (message: string, args: .. Any, from_no_context := false) {

--- a/modules/Runtime_Support.jai
+++ b/modules/Runtime_Support.jai
@@ -671,10 +671,10 @@ report_error_in_yer_face_no_ctx :: (message: string, args: .. Any) #no_context {
 }
 
 report_error_in_yer_face :: (message: string, args: .. Any, from_no_context := false) {
-    using #import "System"; // 'using' ensures the imports stay within this scope. (Raw imports do not respect scopes)
-    using #import "String";
-    using #import "Basic";
-    using #import "File";
+    using _ :: #import "System"; // 'using' ensures the imports stay within this scope. (Raw imports do not respect scopes)
+    using _ :: #import "String";
+    using _ :: #import "Basic";
+    using _ :: #import "File";
 
     formatted_message := tprint(message, ..args);
 


### PR DESCRIPTION
This bug was caused by me in the PR for assertion improvements. I didn't verify that the calls through the #no_context procs still worked properly after I made some final cleanup/simplifications. Turns out it introduced an error.

I used a struct literal in push_context to make it a one-liner `push_context Context.{} { ... }`, but struct literals are placed in read-only memory, so writing to the context immediately crashes the program. Using a local variable again fixed this.

(I also changed some imports from `using #import "Basic"` to `using _ :: #import "Basic"` because it turns out that without the name in between it may still leak the import into the outer scope. Hasn't been an issue here -yet-, but I noticed in another project of mine)