### PR TITLE
Update themes, and add new themes

### DIFF
--- a/config/themes/basic-light.focus-theme
+++ b/config/themes/basic-light.focus-theme
@@ -49,13 +49,13 @@ code_error:                             FF0000FF
 code_warning:                           E4D97DFF
 code_keyword:                           6f0093FF
 
-region_scope_export:                    15212AFF
-region_scope_file:                      131C22FF
-region_scope_module:                    1A2831FF
-region_header:                          51adc2FF
-region_success:                         6DA465FF
-region_warning:                         C25151FF
-region_error:                           772222FF
+region_scope_export:                    FFFFFFFF
+region_scope_file:                      FFFFFFFF
+region_scope_module:                    FFFFFFFF
+region_header:                          FFFFFFFF
+region_success:                         F0FFF0FF
+region_warning:                         EEE8AAFF
+region_error:                           FFC0CBFF
 
 build_panel_background:                 EEEEEEFF
 build_panel_scrollbar:                  33CCCC19

--- a/config/themes/basic-light.focus-theme
+++ b/config/themes/basic-light.focus-theme
@@ -1,0 +1,64 @@
+[2]  # Version number. Do not delete
+
+[colors]
+background0:                            FFFFFFFF
+background1:                            CCCCCCFF
+background2:                            FFFFFFFF
+background3:                            FFFFFFFF
+background4:                            CCCCCCFF
+selection_active:                       B6B6B6FF
+selection_inactive:                     B6B6B67F
+selection_highlight:                    E6FEFE26
+search_result_active:                   D6C280FF
+search_result_inactive:                 FCEDFC26
+scrollbar:                              CCCCCC19
+scrollbar_hover:                        1818184C
+scrollbar_background:                   10191F4C
+cursor:                                 181818FF
+cursor_inactive:                        196666FF
+paste_animation:                        1C4449FF
+splitter:                               CCCCCCFF
+splitter_hover:                         FCFCFCFF
+letter_highlight:                       599999FF
+list_cursor_lite:                       18181819
+list_cursor:                            1818184C
+shadow_dark:                            18181809
+shadow_transparent:                     0E161C00
+text_input_label:                       3B4450FF
+char_under_cursor:                      FFFFFFFF
+
+ui_default:                             181818FF
+ui_dim:                                 383838FF
+ui_neutral:                             181818FF
+ui_warning:                             AC600CFF
+ui_warning_dim:                         FFA500FF
+ui_error:                               772222FF
+ui_error_bright:                        FF0000FF
+ui_success:                             6DA465FF
+
+code_default:                           181818FF
+code_comment:                           416529FF
+code_type:                              0000FFFF
+code_function:                          181818FF
+code_punctuation:                       181818FF
+code_operation:                         181818FF
+code_string:                            008080FF
+code_value:                             0000FFFF
+code_highlight:                         E6FEFEFF
+code_error:                             FF0000FF
+code_warning:                           E4D97DFF
+code_keyword:                           6f0093FF
+
+region_scope_export:                    15212AFF
+region_scope_file:                      131C22FF
+region_scope_module:                    1A2831FF
+region_header:                          51adc2FF
+region_success:                         6DA465FF
+region_warning:                         C25151FF
+region_error:                           772222FF
+
+build_panel_background:                 EEEEEEFF
+build_panel_scrollbar:                  33CCCC19
+build_panel_scrollbar_hover:            33CCCC4C
+build_panel_scrollbar_background:       10191F4C
+build_panel_title_bar:                  CCCCCCFF

--- a/config/themes/gruber-darker.focus-theme
+++ b/config/themes/gruber-darker.focus-theme
@@ -50,12 +50,12 @@ code_error:                             FF0000FF
 code_keyword:                           FFDD33FF
 code_warning:                           E4D97DFF
 
-region_scope_export:                    072626FF
-region_scope_file:                      072626FF
-region_scope_module:                    072626FF
-region_header:                          1A5152FF
-region_success:                         226022FF
-region_warning:                         986032FF
+region_scope_export:                    181818FF
+region_scope_file:                      202020FF
+region_scope_module:                    222222FF
+region_header:                          181818FF
+region_success:                         181818FF
+region_warning:                         226022FF
 region_error:                           772222FF
 
 build_panel_background:                 262624FF

--- a/config/themes/gruber-darker.focus-theme
+++ b/config/themes/gruber-darker.focus-theme
@@ -1,0 +1,65 @@
+[2]  # Version number. Do not delete
+
+# Based on the gruber darker theme by Jason Blevins
+# https://github.com/rexim/gruber-darker-theme
+[colors]
+background0:                            181818FF
+background1:                            141416FF
+background2:                            453D41FF
+background3:                            282828FF
+background4:                            141416FF
+selection_active:                       484848FF
+selection_inactive:                     48484899
+selection_highlight:                    FCEDFC26
+search_result_active:                   565F73FF
+search_result_inactive:                 95A99F26
+scrollbar:                              484848FF
+scrollbar_hover:                        484848FF
+scrollbar_background:                   4848484C
+cursor:                                 FFDD33FF
+cursor_inactive:                        FFDD3311
+paste_animation:                        484848FF
+splitter:                               1A1A1AFF
+splitter_hover:                         484848FF
+letter_highlight:                       FFDD33FF
+list_cursor_lite:                       FCEDFC19
+list_cursor:                            FCEDFC4C
+shadow_dark:                            0E161C33
+shadow_transparent:                     0E161C00
+text_input_label:                       3B4450FF
+
+ui_default:                             BFC9DBFF
+ui_dim:                                 87919DFF
+ui_neutral:                             4C4C4CFF
+ui_warning:                             CB4B16FF
+ui_warning_dim:                         986032FF
+ui_error:                               772222FF
+ui_error_bright:                        FF0000FF
+ui_success:                             227722FF
+
+code_default:                           E4E4EFFF
+code_comment:                           CC8C3CFF
+code_type:                              95A99fFF
+code_function:                          E4E4EFFF
+code_punctuation:                       E4E4EFFF
+code_operation:                         E4E4EFFF
+code_string:                            73C936FF
+code_value:                             E4E4EFFF
+code_highlight:                         D89B75FF
+code_error:                             FF0000FF
+code_keyword:                           FFDD33FF
+code_warning:                           E4D97DFF
+
+region_scope_export:                    072626FF
+region_scope_file:                      072626FF
+region_scope_module:                    072626FF
+region_header:                          1A5152FF
+region_success:                         226022FF
+region_warning:                         986032FF
+region_error:                           772222FF
+
+build_panel_background:                 262624FF
+build_panel_scrollbar:                  33CCCC19
+build_panel_scrollbar_hover:            33CCCC4C
+build_panel_scrollbar_background:       2626244C
+build_panel_title_bar:                  141416FF

--- a/config/themes/gruvbox-flat.focus-theme
+++ b/config/themes/gruvbox-flat.focus-theme
@@ -2,32 +2,32 @@
 
 [colors]
 
-background0:                            32302f
-background1:                            32302f
-background2:                            5a524c
-background3:                            3c3836
-background4:                            21333FFF
-selection_active:                       1C4449FF
-selection_inactive:                     D5C4A1FF
-selection_highlight:                    D5C4A1FF
+background0:                            32302FFF
+background1:                            32302FFF
+background2:                            5A524CFF
+background3:                            282828FF
+background4:                            282828FF
+selection_active:                       3c3836FF
+selection_inactive:                     3C3836AA
+selection_highlight:                    FCEDFC26
 search_result_active:                   8E772EFF
 search_result_inactive:                 FCEDFC26
-scrollbar:                              33CCCC19
-scrollbar_hover:                        33CCCC4C
+scrollbar:                              D4BE9819
+scrollbar_hover:                        D4BE984C
 scrollbar_background:                   10191F4C
-cursor:                                 45403d
-cursor_inactive:                        196666FF
-paste_animation:                        1C4449FF
-splitter:                               21333FFF
-splitter_hover:                         1C4449FF
+cursor:                                 45403DFF
+cursor_inactive:                        000000FF
+paste_animation:                        D4BE9822
+splitter:                               282828FF
+splitter_hover:                         282828FF
 letter_highlight:                       D79921FF
-list_cursor_lite:                       33CCCC19
-list_cursor:                            33CCCC4C
-shadow_dark:                            0E161C7F
-shadow_transparent:                     0E161C00
-text_input_label:                       3B4450FF
+list_cursor_lite:                       D4BE9819
+list_cursor:                            D4BE984C
+shadow_dark:                            1818182F
+shadow_transparent:                     18181800
+text_input_label:                       D4BE98FF
 
-ui_default:                             BFC9DBFF
+ui_default:                             D4BE98FF
 ui_dim:                                 87919DFF
 ui_neutral:                             4C4C4CFF
 ui_warning:                             F8AD34FF
@@ -36,28 +36,29 @@ ui_error:                               772222FF
 ui_error_bright:                        FF0000FF
 ui_success:                             227722FF
 
-code_default:                           d4be98
-code_comment:                           504945FF
-code_type:                              D65D0E
-code_function:                          fb4934FF
+code_default:                           D4BE98FF
+code_comment:                           7C6f64FF
+code_type:                              D65D0EFF
+code_function:                          FB4934FF
 code_punctuation:                       928374FF
-code_operation:                         d79221
-code_string:                            a9b665
-code_value:                             d3869bFF
+code_operation:                         D79221FF
+code_string:                            A9B665FF
+code_value:                             D3869BFF
 code_highlight:                         458588FF
 code_error:                             FF0000FF
-code_keyword:                           d79921
+code_keyword:                           D79921FF
 code_warning:                           E4D97DFF
 
-region_scope_export:                    32302f
-region_scope_file:                      32302f
-region_scope_module:                    32302f
+region_scope_export:                    32302FFF
+region_scope_file:                      32302FFF
+region_scope_module:                    32302FFF
 region_header:                          1A5152FF
 region_success:                         226022FF
 region_warning:                         986032FF
 region_error:                           772222FF
-build_panel_background:                 3c3836
+
+build_panel_background:                 3C3836FF
 build_panel_scrollbar:                  33CCCC19
 build_panel_scrollbar_hover:            33CCCC4C
 build_panel_scrollbar_background:       10191F4C
-build_panel_title_bar:                  1C303AFF
+build_panel_title_bar:                  282828FF

--- a/config/themes/halogen.focus-theme
+++ b/config/themes/halogen.focus-theme
@@ -56,9 +56,9 @@ region_success:                         227722FF
 region_warning:                         227722FF
 region_error:                           227722FF
 
-build_panel_background:                 1A2831FF
+build_panel_background:                 202020FF
 build_panel_scrollbar:                  33CCCC19
 build_panel_scrollbar_hover:            33CCCC4C
 build_panel_scrollbar_background:       10191F4C
-build_panel_title_bar:                  1C303AFF
+build_panel_title_bar:                  383838FF
 

--- a/config/themes/jblow-nostalgia.focus-theme
+++ b/config/themes/jblow-nostalgia.focus-theme
@@ -2,6 +2,53 @@
 
 [colors]
 
+background0:                            292929FF
+background1:                            1A1A1AFF
+background2:                            1A1A1AFF
+background3:                            1A1A1AFF
+background4:                            1A1A1AFF
+selection_active:                       0000FFFF
+selection_inactive:                     0000FF00
+selection_highlight:                    FCEDFC26
+search_result_active:                   CD6889FF
+search_result_inactive:                 FCEDFC26
+scrollbar:                              D0C5A94C
+scrollbar_hover:                        D0C5A9A8
+scrollbar_background:                   10191F4C
+cursor:                                 89E2A1FF
+cursor_inactive:                        161616FF
+paste_animation:                        D3B58D19
+splitter:                               D0C5A94C
+splitter_hover:                         D0C5A9A8
+letter_highlight:                       FFFFFFFF
+list_cursor_lite:                       D3B58D19
+list_cursor:                            D3B58D4C
+shadow_dark:                            0E161C33
+shadow_transparent:                     0E161C00
+text_input_label:                       3B4450FF
+
+ui_default:                             BFC9DBFF
+ui_dim:                                 87919DFF
+ui_neutral:                             4C4C4CFF
+ui_warning:                             F8AD34FF
+ui_warning_dim:                         986032FF
+ui_error:                               772222FF
+ui_error_bright:                        FF0000FF
+ui_success:                             227722FF
+
+code_default:                           D3B58DFF
+code_comment:                           FFFF00FF
+code_type:                              98FB98FF
+code_function:                          D3B58DFF
+code_punctuation:                       D3B58DFF
+code_operation:                         D3B58DFF
+code_string:                            BEBEBEFF
+code_value:                             7FFFD4FF
+code_highlight:                         D89B75FF
+code_error:                             FF0000FF
+code_keyword:                           FFFFFFFF
+code_warning:                           E4D97DFF
+
 region_scope_export                     161616FF
 region_scope_file                       202020FF
 region_scope_module                     18181BFF
@@ -10,55 +57,8 @@ region_success:                         226022FF
 region_warning:                         986032FF
 region_error:                           772222FF
 
-build_panel_title_bar:                  202020FF
-build_panel_background:                 161616FF
+build_panel_title_bar:                  1A1A1AFF
+build_panel_background:                 000000FF
 build_panel_scrollbar:                  D0C5A94C
 build_panel_scrollbar_hover:            D0C5A9A8
-build_panel_scrollbar_background:       1212124C
-
-background0:                            191919FF
-background1:                            161616FF
-background2:                            18262FFF
-background3:                            202020FF
-background4:                            202020FF
-selection_active:                       0000FFCF
-selection_inactive:                     1C44497F
-selection_highlight:                    FCEDFC26
-search_result_active:                   8E772EFF
-search_result_inactive:                 FCEDFC26
-scrollbar:                              D0C5A94C
-scrollbar_hover:                        D0C5A9A8
-scrollbar_background:                   1212124C
-cursor:                                 89E2A1FF
-cursor_inactive:                        161616FF
-paste_animation:                        1C4449FF
-splitter:                               D0C5A94C
-splitter_hover:                         D0C5A9A8
-letter_highlight:                       89E2A1FF
-list_cursor_lite:                       1616167F
-list_cursor:                            161616FF
-shadow_dark:                            1616167F
-shadow_transparent:                     16161600
-text_input_label:                       D0C5A966
-
-ui_default:                             D0C5A9FF
-ui_dim:                                 D0C5A966
-ui_neutral:                             4C4C4CFF
-ui_warning:                             F8AD34FF
-ui_warning_dim:                         986032FF
-ui_error:                               772222FF
-ui_error_bright:                        FF0000FF
-ui_success:                             227722FF
-
-code_default:                           D0C5A9FF
-code_comment:                           F7F06FFF
-code_type:                              89E2A1FF
-code_function:                          D0C5A9FF
-code_punctuation:                       BFC9DBFF
-code_operation:                         B6A997FF
-code_string:                            CCE8D3FF
-code_value:                             89E2A1FF
-code_highlight:                         D89B75FF
-code_error:                             FF0000FF
-code_keyword:                           FFFBD9FF
-code_warning:                           E4D97DFF
+build_panel_scrollbar_background:       10191F4C

--- a/config/themes/jblow-nostalgia.focus-theme
+++ b/config/themes/jblow-nostalgia.focus-theme
@@ -49,16 +49,16 @@ code_error:                             FF0000FF
 code_keyword:                           FFFFFFFF
 code_warning:                           E4D97DFF
 
-region_scope_export                     161616FF
-region_scope_file                       202020FF
-region_scope_module                     18181BFF
+region_scope_export                     292929FF
+region_scope_file                       292929FF
+region_scope_module                     292929FF
 region_header:                          1A5152FF
 region_success:                         226022FF
 region_warning:                         986032FF
 region_error:                           772222FF
 
 build_panel_title_bar:                  1A1A1AFF
-build_panel_background:                 000000FF
+build_panel_background:                 131313FF
 build_panel_scrollbar:                  D0C5A94C
 build_panel_scrollbar_hover:            D0C5A9A8
 build_panel_scrollbar_background:       10191F4C

--- a/config/themes/jblowtorch.focus-theme
+++ b/config/themes/jblowtorch.focus-theme
@@ -1,29 +1,28 @@
 [2]  # Version number. Do not delete
 
 [colors]
-
 background0:                            072626FF
-background1:                            10191FFF
+background1:                            1A1A1AFF
 background2:                            18262FFF
-background3:                            1A2831FF
-background4:                            21333FFF
-selection_active:                       1C4449FF
-selection_inactive:                     1C44497F
+background3:                            072626FF
+background4:                            1A1A1AFF
+selection_active:                       0000FFFF
+selection_inactive:                     0000FF00
 selection_highlight:                    FCEDFC26
-search_result_active:                   8E772EFF
+search_result_active:                   CD6889FF
 search_result_inactive:                 FCEDFC26
 scrollbar:                              33CCCC19
 scrollbar_hover:                        33CCCC4C
-scrollbar_background:                   10191F4C
-cursor:                                 26B2B2FF
+scrollbar_background:                   0726264C
+cursor:                                 90EE90FF
 cursor_inactive:                        196666FF
-paste_animation:                        1C4449FF
-splitter:                               21333FFF
+paste_animation:                        0FDFAF4C
+splitter:                               1A1A1AFF
 splitter_hover:                         1C4449FF
-letter_highlight:                       599999FF
-list_cursor_lite:                       33CCCC19
-list_cursor:                            33CCCC4C
-shadow_dark:                            0E161C7F
+letter_highlight:                       FFFFFFFF
+list_cursor_lite:                       0FDFAF19
+list_cursor:                            0FDFAF4C
+shadow_dark:                            0E161C33
 shadow_transparent:                     0E161C00
 text_input_label:                       3B4450FF
 
@@ -38,15 +37,15 @@ ui_success:                             227722FF
 
 code_default:                           D3B58DFF
 code_comment:                           3DDF23FF
-code_type:                              E1E1E1FF
-code_function:                          D0C5A9FF
-code_punctuation:                       BFC9DBFF
+code_type:                              98FB98FF
+code_function:                          D3B58DFF
+code_punctuation:                       D3B58DFF
 code_operation:                         E0AD82FF
-code_string:                            D4BC7DFF
-code_value:                             6BE1CDFF
+code_string:                            0FDFAFFF
+code_value:                             7FFFD4FF
 code_highlight:                         D89B75FF
 code_error:                             FF0000FF
-code_keyword:                           E1E1E1FF
+code_keyword:                           FFFFFFFF
 code_warning:                           E4D97DFF
 
 region_scope_export:                    072626FF
@@ -57,8 +56,8 @@ region_success:                         226022FF
 region_warning:                         986032FF
 region_error:                           772222FF
 
-build_panel_background:                 1A2831FF
+build_panel_background:                 262624FF
 build_panel_scrollbar:                  33CCCC19
 build_panel_scrollbar_hover:            33CCCC4C
-build_panel_scrollbar_background:       10191F4C
-build_panel_title_bar:                  1C303AFF
+build_panel_scrollbar_background:       2626244C
+build_panel_title_bar:                  1A1A1AFF

--- a/config/themes/nord-midnight.focus-theme
+++ b/config/themes/nord-midnight.focus-theme
@@ -1,21 +1,6 @@
 [2]  # Version number. Do not delete
 
 [colors]
-
-region_scope_export:                    1D2129FF
-region_scope_file:                      3B425270
-region_scope_module:                    434C5E30
-region_header:                          1A5152FF
-region_success:                         226022FF
-region_warning:                         986032FF
-region_error:                           772222FF
-
-build_panel_title_bar:                  1C303AFF
-build_panel_background:                 1D2129FF
-build_panel_scrollbar:                  292D38AF
-build_panel_scrollbar_hover:            292D38FF
-build_panel_scrollbar_background:       1d212990
-
 background0:                            1D2129FF
 background1:                            3B4252FF
 background2:                            434C5EFF
@@ -63,3 +48,16 @@ code_error:                             BF616AFF
 code_keyword:                           81A1C1FF
 code_warning:                           E4D97DFF
 
+region_scope_export:                    1D2129FF
+region_scope_file:                      3B425270
+region_scope_module:                    434C5E30
+region_header:                          1A5152FF
+region_success:                         226022FF
+region_warning:                         986032FF
+region_error:                           772222FF
+
+build_panel_background:                 1D2129FF
+build_panel_scrollbar:                  292D38AF
+build_panel_scrollbar_hover:            292D38FF
+build_panel_scrollbar_background:       1d212990
+build_panel_title_bar:                  292D38FF

--- a/config/themes/nord.focus-theme
+++ b/config/themes/nord.focus-theme
@@ -1,21 +1,6 @@
 [2]  # Version number. Do not delete
 
 [colors]
-
-region_scope_export:              2E3440FF
-region_scope_file:                3B4252AF
-region_scope_module:              434C5E9F
-region_header:                    1A5152FF
-region_success:                   226022FF
-region_warning:                   986032FF
-region_error:                     772222FF
-
-build_panel_background:           2E3440FF
-build_panel_scrollbar:            292D38AF
-build_panel_scrollbar_hover:      292D38FF
-build_panel_scrollbar_background: 1d212990
-build_panel_title_bar:            1C303AFF
-
 background0:                      2E3440FF
 background1:                      3B4252FF
 background2:                      434C5EFF
@@ -63,3 +48,16 @@ code_error:                       BF616AFF
 code_keyword:                     81A1C1FF
 code_warning:                     E4D97DFF
 
+region_scope_export:              2E3440FF
+region_scope_file:                3B4252AF
+region_scope_module:              434C5E9F
+region_header:                    1A5152FF
+region_success:                   226022FF
+region_warning:                   986032FF
+region_error:                     772222FF
+
+build_panel_background:           2E3440FF
+build_panel_scrollbar:            292D38AF
+build_panel_scrollbar_hover:      292D38FF
+build_panel_scrollbar_background: 1D212990
+build_panel_title_bar:            434C5EFF

--- a/config/themes/solarized-dark.focus-theme
+++ b/config/themes/solarized-dark.focus-theme
@@ -6,13 +6,11 @@ background1:                            002B36FF
 background2:                            073642FF
 background3:                            073642FF
 background4:                            073642FF
-
 selection_active:                       073642FF
 selection_inactive:                     073642FF
 selection_highlight:                    93A1A1FF
 search_result_active:                   B58900FF
 search_result_inactive:                 FCEDFC26
-
 scrollbar:                              33CCCC19
 scrollbar_hover:                        33CCCC4C
 scrollbar_background:                   10191F4C
@@ -22,8 +20,8 @@ paste_animation:                        1C4449FF
 splitter:                               21333FFF
 splitter_hover:                         1C4449FF
 letter_highlight:                       599999FF
-list_cursor_lite:                       93A1A1FF
-list_cursor:                            93A1A1FF
+list_cursor_lite:                       93A1A122
+list_cursor:                            93A1A144
 shadow_dark:                            0E161C7F
 shadow_transparent:                     0E161C00
 text_input_label:                       3B4450FF

--- a/config/themes/spacemacs-light.focus-theme
+++ b/config/themes/spacemacs-light.focus-theme
@@ -60,4 +60,4 @@ build_panel_background:                 efeae9FF
 build_panel_scrollbar:                  33CCCC19
 build_panel_scrollbar_hover:            33CCCC4C
 build_panel_scrollbar_background:       10191F4C
-build_panel_title_bar:                  1C303AFF
+build_panel_title_bar:                  d2cedaFF

--- a/config/themes/zenburn.focus-theme
+++ b/config/themes/zenburn.focus-theme
@@ -50,9 +50,9 @@ code_error:                             FF0000FF
 code_keyword:                           F0DFAFFF
 code_warning:                           E4D97DFF
 
-region_scope_export:                    072626FF
-region_scope_file:                      072626FF
-region_scope_module:                    072626FF
+region_scope_export:                    3F3F3FFF
+region_scope_file:                      484848FF
+region_scope_module:                    292929FF
 region_header:                          1A5152FF
 region_success:                         226022FF
 region_warning:                         986032FF

--- a/config/themes/zenburn.focus-theme
+++ b/config/themes/zenburn.focus-theme
@@ -1,0 +1,65 @@
+[2]  # Version number. Do not delete
+
+# Based on the original Zenburn Vim theme:
+# https://github.com/jnurmine/Zenburn/blob/master/colors/zenburn.vim
+[colors]
+background0:                            3F3F3FFF
+background1:                            282828FF
+background2:                            2E3330FF
+background3:                            2E3330FF
+background4:                            2E3330FF
+selection_active:                       304A3DFF
+selection_inactive:                     484848FF
+selection_highlight:                    FCEDFC26
+search_result_active:                   385f38FF
+search_result_inactive:                 95A99F55
+scrollbar:                              28282819
+scrollbar_hover:                        484848FF
+scrollbar_background:                   4848484C
+cursor:                                 8FAF9FFF
+cursor_inactive:                        8FAF9FFF
+paste_animation:                        304A3DFF
+splitter:                               2E3330FF
+splitter_hover:                         2E3330FF
+letter_highlight:                       DFDFBFFF
+list_cursor_lite:                       2E33304C
+list_cursor:                            304A3DFF
+shadow_dark:                            0E161C33
+shadow_transparent:                     0E161C00
+text_input_label:                       BFC9DBFF
+
+ui_default:                             BFC9DBFF
+ui_dim:                                 87919DFF
+ui_neutral:                             4C4C4CFF
+ui_warning:                             F8AD34FF
+ui_warning_dim:                         986032FF
+ui_error:                               772222FF
+ui_error_bright:                        FF0000FF
+ui_success:                             227722FF
+
+code_default:                           DCDCCCFF
+code_comment:                           7F9F7FFF
+code_type:                              DFDFBFFF
+code_function:                          EFEF8FFF
+code_punctuation:                       DCDCCCFF
+code_operation:                         F0EFD0FF
+code_string:                            CC9393FF
+code_value:                             8CD0D3FF
+code_highlight:                         D89B75FF
+code_error:                             FF0000FF
+code_keyword:                           F0DFAFFF
+code_warning:                           E4D97DFF
+
+region_scope_export:                    072626FF
+region_scope_file:                      072626FF
+region_scope_module:                    072626FF
+region_header:                          1A5152FF
+region_success:                         226022FF
+region_warning:                         986032FF
+region_error:                           772222FF
+
+build_panel_background:                 1F1F1FFF
+build_panel_scrollbar:                  33CCCC19
+build_panel_scrollbar_hover:            33CCCC4C
+build_panel_scrollbar_background:       2626244C
+build_panel_title_bar:                  2E3330FF


### PR DESCRIPTION
I know themes aren't super important but I felt like the non-default themes needed a little work. I also added a few new ones that would be nice to have. I also made sure that the jblow themes are 100% accurate ~~if~~ when Jon decides to switch to Focus.

**Updated the following themes:**

- Gruvbox Flat: Fixed UI elements to fit theme instead of using the default colors
- Nord Midnight: Make ui more consistent / readable
- Nord: Same as above
- Solarized Dark: Same as above
- Halogen: Same as above
- Jblowtorch: Colors updated to the _exact_ colors in Jon's stream (a screenshot of his .emacs colors was posted on github). Colors that are not specified in his config are emacs defaults, which I had to dig through emacs to find their hex codes.
- Jblow Nostalgia: Same as above.

**Added the following new themes:**
- Gruber Darker: Theme by youtuber/streamer Tsoding, high contrast dark theme
- Zenburn: Very popular low contrast dark theme originally for vim
- Basic Light: 'Generic' high contrast light theme.