### PR TITLE
Add new super-high-contrast dark theme

### DIFF
--- a/config/themes/steel-breeze.focus-theme
+++ b/config/themes/steel-breeze.focus-theme
@@ -23,7 +23,7 @@ background2:                            ff0000ff
 background3:                            000000aa # Dialog background
 background4:                            ffffff02 # Status bar
 selection_active:                       4000ff80 # Selection and file dialog current directory
-#selection_active:                      3e02b5a0 # 
+#selection_active:                      3e02b5a0
 selection_inactive:                     3e02b580 # Background of selection on other side
 selection_highlight:                    ffffff20 # Background of other occurences of selection
 search_result_active:                   4000ff80 # Background of highlighted occurence
@@ -42,16 +42,6 @@ list_cursor_lite:                       4000ff80 # Mouse cursor in dialog
 shadow_dark:                            ffffff08 # Shadow at the edge of status bar and dialog
 shadow_transparent:                     ffffff00 # Statusbar inverse shadow
 text_input_label:                       ffffff60 # Dialog input prompt
-
-# I don't understand any of these.
-ui_default:                             BFC9DBFF
-ui_dim:                                 87919DFF
-ui_neutral:                             4C4C4CFF
-ui_warning:                             F8AD34FF
-ui_warning_dim:                         986032FF
-ui_error:                               772222FF
-ui_error_bright:                        FF0000FF
-ui_success:                             227722FF
 
 # These are all pretty self-explanatory.
 code_default:                           FFFFFFe0

--- a/config/themes/steel-breeze.focus-theme
+++ b/config/themes/steel-breeze.focus-theme
@@ -1,0 +1,68 @@
+[2]  # Version number. Do not delete
+
+[colors]
+
+region_scope_export                     2C2C2C80
+region_scope_file                       40404080
+region_scope_module                     30303080
+region_header:                          34A2A480 # Debug build header message background
+region_success:                         44C04480 # Debug Panel success message background
+region_warning:                         FFC06480
+region_error:                           EE444480
+
+# Build panel colours (self-explanatory)
+build_panel_title_bar:                  ffffff03
+build_panel_background:                 000000e8
+build_panel_scrollbar:                  ffffff20
+build_panel_scrollbar_hover:            ffffff40
+build_panel_scrollbar_background:       ffffff20
+
+background0:                            ffffff00 # Body area background
+background1:                            000000ff # Bottom layer
+background2:                            ff0000ff
+background3:                            000000aa # Dialog background
+background4:                            ffffff02 # Status bar
+selection_active:                       4000ff80 # Selection and file dialog current directory
+#selection_active:                      3e02b5a0 # 
+selection_inactive:                     3e02b580 # Background of selection on other side
+selection_highlight:                    ffffff20 # Background of other occurences of selection
+search_result_active:                   4000ff80 # Background of highlighted occurence
+search_result_inactive:                 ffffff30 # Background of unhighlighted occurences
+scrollbar:                              ffffff20 # Actual scrollbar
+scrollbar_hover:                        ffffff40 # Whole scrollbar groove when highlighted
+scrollbar_background:                   ffffff20 # Scrollbar curb
+cursor:                                 4020FFFF # Text in body area
+cursor_inactive:                        000000FF # Search dialog text area
+paste_animation:                        1C4449FF # Background colour during paste animation
+splitter:                               ffffff20 # Splitter between right and left body
+splitter_hover:                         ffffff40 # Splitter while hovered
+letter_highlight:                       ffffffff # Highlighted letters in open dialog
+list_cursor:                            4000ffa0 # Cursor in dialog
+list_cursor_lite:                       4000ff80 # Mouse cursor in dialog 
+shadow_dark:                            ffffff08 # Shadow at the edge of status bar and dialog
+shadow_transparent:                     ffffff00 # Statusbar inverse shadow
+text_input_label:                       ffffff60 # Dialog input prompt
+
+# I don't understand any of these.
+ui_default:                             BFC9DBFF
+ui_dim:                                 87919DFF
+ui_neutral:                             4C4C4CFF
+ui_warning:                             F8AD34FF
+ui_warning_dim:                         986032FF
+ui_error:                               772222FF
+ui_error_bright:                        FF0000FF
+ui_success:                             227722FF
+
+# These are all pretty self-explanatory.
+code_default:                           FFFFFFe0
+code_comment:                           ffffff60
+code_type:                              00ff88e0
+code_function:                          0060ffe0
+code_punctuation:                       FFFFFF30
+code_operation:                         FFFFFF38
+code_string:                            ff6000e0
+code_value:                             ff6060e0
+code_highlight:                         D89B75e0
+code_error:                             FF0000e0
+code_keyword:                           8860FFe0
+code_warning:                           FFFF60e0


### PR DESCRIPTION
Add new theme 'Steel Breeze' with very dark background, bright text and vibrant syntax highlighting colours.

Preview screenshot:
![image](https://github.com/focus-editor/focus/assets/63561291/73999281-e40c-4167-a060-3a5f9bc47262)