### PR TITLE
Fix + Cleanup of allocator changes in 083 update

### DIFF
--- a/src/platform/linux.jai
+++ b/src/platform/linux.jai
@@ -79,7 +79,7 @@ DONE;
     flags : LD.Init_Flags = 0;
     cstr = getenv("FOCUS_LD_FLAGS");
     flags_s := ifx cstr then to_lower_copy_new(to_string(cstr),, allocator = temp) else "";
-    flags_a := split(flags_s, ",");
+    flags_a := split(flags_s, ",",, allocator = temp);
     for flag : flags_a {
         if flag == {
             case "xcb-pure"; flags |= .XCB_Pure;

--- a/src/platform/windows.jai
+++ b/src/platform/windows.jai
@@ -199,7 +199,7 @@ platform_get_fonts_dir :: () -> string {
         ret := SHGetKnownFolderPath(*FOLDERID_Fonts, KF_FLAG_CREATE, null, *path_utf16);
         defer CoTaskMemFree(path_utf16);
         if SUCCEEDED(ret) {
-            fonts_dir = copy_string(wide_to_utf8_new(path_utf16,, allocator = temp));
+            fonts_dir = wide_to_utf8_new(path_utf16);
             path_overwrite_separators(fonts_dir, #char "/");
         } else {
             fonts_dir = "C:/Windows/Fonts";

--- a/src/utils.jai
+++ b/src/utils.jai
@@ -477,7 +477,6 @@ split :: (s: string, separator: $T, max_splits: int) -> [] string {
     #assert (T == u8) || (T == string);
 
     results: [..] string;
-    results.allocator = context.allocator;
 
     if max_splits < 1 return results;
 

--- a/src/workspace.jai
+++ b/src/workspace.jai
@@ -452,7 +452,7 @@ file_change_callback :: (watcher: *File_Watcher(void), change: *File_Change, use
         print_to_builder(*b, "%", <<change);
         change_kind := "Project file";
         if watcher == *watchers.external_watcher change_kind = "External file";
-        defer log("% change: %\n", change_kind, builder_to_string(*b, allocator = temp));
+        defer log("% change: %\n", change_kind, builder_to_string(*b,, allocator = temp));
     }
 
     maybe_add_to_queue :: (dir: string) {


### PR DESCRIPTION
### Fixes
* Updated a call to `split` that didn't explicitly use `temp` yet.
* Updated content of a static if to also use `,,` syntax, it went unnoticed due to being in a static if.
### Cleanup
* Removed unnecessary string copy of a temp-allocated string by just not temp-allocating it in the first place.
* Removed unnecessary assignment `allocator = context.allocator` (the assignment was only there because it used to assign `temp` before)