### PR TITLE
Selection length now factors in text length of additional cursors. Fix for the off-screen text overlap.

### DIFF
--- a/src/draw.jai
+++ b/src/draw.jai
@@ -1530,11 +1530,19 @@ draw_editor :: (editor_id: s64, main_area: Rect, footer_height: float, ui_id: Ui
             Simp.draw_prepared_text(font_ui_bold, xx line_col_start_x, xx pen.y, color = xx Color.UI_DIM);
 
             // Draw length of selected text if any text is currently selected
-            if config.settings.show_selected_text_length && editor.selected_text_length > 0 {
-                
-                width += xx Simp.prepare_text(font_ui_bold, tprint("Length: %  ", editor.selected_text_length));
-                line_col_start_x := footer_rect.x + footer_rect.w - width;
-                Simp.draw_prepared_text(font_ui_bold, xx line_col_start_x, xx pen.y, color = xx Color.UI_DIM);
+            if config.settings.show_selected_text_length {
+            
+                selection_length:= 0;
+                for cursor : cursors {
+                    text := get_selected_string(cursor, buffer);
+                    selection_length += text.count;
+                }
+
+                if selection_length > 0 {
+                    width += xx Simp.prepare_text(font_ui_bold, tprint("Length: %  ", selection_length));
+                    line_col_start_x = footer_rect.x + footer_rect.w - width;
+                    Simp.draw_prepared_text(font_ui_bold, xx line_col_start_x, xx pen.y, color = xx Color.UI_DIM);
+                }
             }
             
             // Maybe draw the number of cursors off screen


### PR DESCRIPTION
![Screenshot 2024-03-09 230109](https://github.com/focus-editor/focus/assets/126894359/903bbc2b-d696-4451-bb87-cb44d2e663a3)
It fixes this overlap as well.

Testing required. 