### PR TITLE
C# nested string interpolation highlighting

### DIFF
--- a/src/buffer.jai
+++ b/src/buffer.jai
@@ -454,7 +454,7 @@ tokenize_for_indentation :: (buffer: *Buffer) -> [] Indentation_Token /* temp */
     if buffer.lang == {
         case .Jai;          return tokenize_jai_for_indentation(buffer);
         case .C;            return tokenize_c_like_lang_for_indentation(buffer, get_next_c_token);
-        case .CSharp;       return tokenize_c_like_lang_for_indentation(buffer, get_next_csharp_token);
+        case .CSharp;       return tokenize_csharp_for_indentation(buffer);
         case .Glsl;         return tokenize_c_like_lang_for_indentation(buffer, get_next_glsl_token);
         case .Zig;          return tokenize_c_like_lang_for_indentation(buffer, get_next_zig_token);
         case .Html;         #through;

--- a/src/langs/csharp.jai
+++ b/src/langs/csharp.jai
@@ -34,7 +34,7 @@ get_next_token :: (using tokenizer: *Tokenizer) -> Token {
     start_t = t;
 
     // Look at the first char as if it's ASCII (if it isn't, this is just a text line)
-    char := <<t;
+    char := t.*;
 
     if is_alpha(char) || char == #char "_" {
         parse_identifier(tokenizer, *token, true);
@@ -106,81 +106,81 @@ parse_number :: (using tokenizer: *Tokenizer, token: *Token) {
     // Consecutive underscores are allowed in numbers but they can't end in one.
     is_valid_underscore :: (t: *u8, max_t: *u8, allowed: (u8) -> bool) -> bool {
         next := t + 1;
-        return <<t == #char "_" && (next < max_t && (allowed(<<next) || <<next == #char "_"));
+        return t.* == #char "_" && (next < max_t && (allowed(next.*) || next.* == #char "_"));
     }
 
     t += 1;
     if t >= max_t return;
 
-    if <<t == #char "x" || <<t == #char "X" {
+    if t.* == #char "x" || t.* == #char "X" {
         // Hex
         t += 1;
-        while t < max_t && (is_hex(<<t) || is_valid_underscore(t, max_t, is_hex)) t += 1;
+        while t < max_t && (is_hex(t.*) || is_valid_underscore(t, max_t, is_hex)) t += 1;
         return;
-    } else if <<t == #char "b" || <<t == #char "B" {
+    } else if t.* == #char "b" || t.* == #char "B" {
         // Binary
         t += 1;
         is_binary :: inline (c: u8) -> bool { return c == #char "1" || c == #char "0"; }
-        while t < max_t && (is_binary(<<t) || is_valid_underscore(t, max_t, is_binary)) t += 1;
+        while t < max_t && (is_binary(t.*) || is_valid_underscore(t, max_t, is_binary)) t += 1;
         return;
     }
 
     // Eat initial digits/underscores
-    while t < max_t && (is_digit(<<t) || is_valid_underscore(t, max_t, is_digit)) {
+    while t < max_t && (is_digit(t.*) || is_valid_underscore(t, max_t, is_digit)) {
         t += 1;
     }
     if t >= max_t return;
 
-    if <<t == #char "." {
+    if t.* == #char "." {
         // Float, double or decimal
         // First char after a decimal point must be a digit(cannot be an underscore).
         t += 1;
-        if t >= max_t || !is_digit(<<t) { token.type = .invalid; return; }
+        if t >= max_t || !is_digit(t.*) { token.type = .invalid; return; }
 
         // Eat digits/underscores after the decimal point
         t += 1;
-        while t < max_t && (is_digit(<<t) || is_valid_underscore(t, max_t, is_digit)) {
+        while t < max_t && (is_digit(t.*) || is_valid_underscore(t, max_t, is_digit)) {
             t += 1;
         }
 
         if t >= max_t return;
 
         // Exponent
-        if <<t == #char "e" || <<t == #char "E" {
+        if t.* == #char "e" || t.* == #char "E" {
             t += 1;
             if t >= max_t return;
 
-            if <<t == #char "+" || <<t == #char "-" {
+            if t.* == #char "+" || t.* == #char "-" {
               t += 1;
               if t >= max_t return;
             }
 
-            while t < max_t && (is_digit(<<t) || is_valid_underscore(t, max_t, is_digit)) {
+            while t < max_t && (is_digit(t.*) || is_valid_underscore(t, max_t, is_digit)) {
                 t += 1;
             }
             if t >= max_t return;
         }
 
         // Floating point suffixes
-        if is_floating_point_suffix(<<t) t += 1;
+        if is_floating_point_suffix(t.*) t += 1;
     } else {
-        if is_floating_point_suffix(<<t) {
+        if is_floating_point_suffix(t.*) {
             // Floating point suffixes (can occur without a decimal point)
             t += 1;
         } else {
             // Integer suffixes
-            if <<t == #char "l" || <<t == #char "L" { // l, L
+            if t.* == #char "l" || t.* == #char "L" { // l, L
                 t += 1;
                 if t >= max_t return;
 
-                if <<t == #char "u" || <<t == #char "U" {  // lu, lU, Lu, LU
+                if t.* == #char "u" || t.* == #char "U" {  // lu, lU, Lu, LU
                     t += 1;
                 }
-            } else if <<t == #char "u" || <<t == #char "U" { // u, U
+            } else if t.* == #char "u" || t.* == #char "U" { // u, U
                 t += 1;
                 if t >= max_t return;
 
-                if <<t == #char "l" || <<t == #char "L" {  // ul, uL, Ul, UL
+                if t.* == #char "l" || t.* == #char "L" {  // ul, uL, Ul, UL
                     t += 1;
                 }
             }
@@ -195,7 +195,7 @@ parse_equal :: (using tokenizer: *Tokenizer, token: *Token) {
     t += 1;
     if t >= max_t return;
 
-    if <<t == #char "=" {
+    if t.* == #char "=" {
         token.operation = .equal_equal;
         t += 1;
     }
@@ -208,7 +208,7 @@ parse_minus :: (using tokenizer: *Tokenizer, token: *Token) {
     t += 1;
     if t >= max_t return;
 
-    if <<t == {
+    if t.* == {
         case #char "=";
             token.operation = .minus_equal;
             t += 1;
@@ -229,7 +229,7 @@ parse_plus :: (using tokenizer: *Tokenizer, token: *Token) {
     t += 1;
     if t >= max_t return;
 
-    if <<t == {
+    if t.* == {
         case #char "=";
             token.operation = .plus_equal;
             t += 1;
@@ -246,7 +246,7 @@ parse_asterisk :: (using tokenizer: *Tokenizer, token: *Token) {
     t += 1;
     if t >= max_t return;
 
-    if <<t == #char "=" {
+    if t.* == #char "=" {
         token.operation = .asterisk_equal;
         t += 1;
     }
@@ -259,7 +259,7 @@ parse_less_than :: (using tokenizer: *Tokenizer, token: *Token) {
     t += 1;
     if t >= max_t return;
 
-    if <<t == {
+    if t.* == {
         case #char "=";
             token.operation = .less_than_equal;
             t += 1;
@@ -276,7 +276,7 @@ parse_greater_than :: (using tokenizer: *Tokenizer, token: *Token) {
     t += 1;
     if t >= max_t return;
 
-    if <<t == {
+    if t.* == {
         case #char "=";
             token.operation = .greater_than_equal;
             t += 1;
@@ -290,7 +290,7 @@ parse_bang :: (using tokenizer: *Tokenizer, token: *Token) {
     t += 1;
     if t >= max_t return;
 
-    if <<t == {
+    if t.* == {
         case #char "=";
             token.operation = .bang_equal;
             t += 1;
@@ -302,11 +302,11 @@ parse_preprocessor_directive :: (using tokenizer: *Tokenizer, token: *Token) {
 
     t += 1;
     eat_white_space(tokenizer);  // There may be spaces between the # and the name
-    if !is_alpha(<<t) return;
+    if !is_alpha(t.*) return;
 
     directive := read_identifier_string(tokenizer);
 
-    while t < max_t && is_alnum(<<t) t += 1;
+    while t < max_t && is_alnum(t.*) t += 1;
     if t >= max_t return;
 
     // Check if it's one of the existing directives
@@ -324,9 +324,10 @@ parse_string_literal :: (using tokenizer: *Tokenizer, token: *Token) {
     escape_seen := false;
 
     t += 1;
-    while t < max_t && <<t != #char "\n" {
-        if <<t == #char "\"" && !escape_seen break;
-        escape_seen = !escape_seen && <<t == #char "\\";
+    while t < max_t && t.* != #char "\n" {
+        //Escape for " in literal is \"
+        if t.* == #char "\"" && !escape_seen break;
+        escape_seen = !escape_seen && t.* == #char "\\";
         t += 1;
     }
     if t >= max_t return;
@@ -361,35 +362,35 @@ parse_char_literal :: (using tokenizer: *Tokenizer, token: *Token) {
     escape_seen := false;
 
     t += 1;
-    if t >= max_t || <<t == #char "\n" return;
+    if t >= max_t || t.* == #char "\n" return;
 
-    if <<t == #char "\\" {
+    if t.* == #char "\\" {
         escape_seen = true;
         t += 1;
-        if t >= max_t || <<t == #char "\n" return;
-    } else if <<t == #char "'" {
+        if t >= max_t || t.* == #char "\n" return;
+    } else if t.* == #char "'" {
         // Unescaped single quote without a character
         t += 1; // Invalid '
         return;
     }
 
     if escape_seen {
-        if !is_valid_character_escape_character(<<t) {
+        if !is_valid_character_escape_character(t.*) {
             return;
-        } else if <<t == #char "u" {
+        } else if t.* == #char "u" {
             // u must be followed by 4 hex characters
             t += 1; count := 0;
             while t < max_t && count < 4 {
-                if !is_hex(<<t) { t += 1; return; }
+                if !is_hex(t.*) { t += 1; return; }
                 count += 1;
                 t += 1;
             }
-            if t >= max_t || <<t == #char "\n" return;
-        } else if <<t ==#char "x" {
+            if t >= max_t || t.* == #char "\n" return;
+        } else if t.* ==#char "x" {
             t += 1;
             // x must be followed by at least one hex character
-            if t >= max_t || !is_hex(<<t) return;
-            while t < max_t && is_hex(<<t) t += 1;
+            if t >= max_t || !is_hex(t.*) return;
+            while t < max_t && is_hex(t.*) t += 1;
         } else {
             // A single valid character after the escape like '\n'
             t += 1;
@@ -398,7 +399,7 @@ parse_char_literal :: (using tokenizer: *Tokenizer, token: *Token) {
         t += 1; // Unescaped single character
     }
 
-    if t >= max_t || <<t == #char "\n" || <<t != #char "'" return;
+    if t >= max_t || t.* == #char "\n" || t.* != #char "'" return;
 
     token.type = .char_literal;
     t += 1; // Ending '
@@ -411,19 +412,19 @@ parse_slash_or_comment :: (using tokenizer: *Tokenizer, token: *Token) {
     t += 1;
     if t >= max_t return;
 
-    if <<t == {
+    if t.* == {
         case #char "=";
             token.operation = .slash_equal;
             t += 1;
         case #char "/";
             token.type = .comment;
             t += 1;
-            while t < max_t && <<t != #char "\n" t += 1;
+            while t < max_t && t.* != #char "\n" t += 1;
         case #char "*";
             token.type = .multiline_comment;
             t += 1;
             while t + 1 < max_t {
-                if <<t == #char "*" && <<(t + 1) == #char "/" {
+                if t.* == #char "*" && (t + 1).* == #char "/" {
                   t += 2;
                   break;
                 }
@@ -439,7 +440,7 @@ parse_ampersand :: (using tokenizer: *Tokenizer, token: *Token) {
     t += 1;
     if t >= max_t return;
 
-    if <<t == {
+    if t.* == {
         case #char "=";
             token.operation = .ampersand_equal;
             t += 1;
@@ -456,7 +457,7 @@ parse_pipe :: (using tokenizer: *Tokenizer, token: *Token) {
     t += 1;
     if t >= max_t return;
 
-    if <<t == {
+    if t.* == {
         case #char "=";
             token.operation = .pipe_equal;
             t += 1;
@@ -473,7 +474,7 @@ parse_percent :: (using tokenizer: *Tokenizer, token: *Token) {
     t += 1;
     if t >= max_t return;
 
-    if <<t == {
+    if t.* == {
         case #char "=";
             token.operation = .percent_equal;
             t += 1;
@@ -486,9 +487,10 @@ parse_verbatim_string_literal :: (using tokenizer: *Tokenizer, token: *Token) {
     escape_seen := false;
 
     t += 1;
-    while t < max_t && <<t != #char "\n" {
-        if escape_seen && <<t != #char "\"" { t -= 1; break; }
-        escape_seen = !escape_seen && <<t == #char "\"";
+    while t < max_t && t.* != #char "\n" {
+        //Escape for " in verbatim is ""
+        if escape_seen && t.* != #char "\"" { t -= 1; break; }
+        escape_seen = !escape_seen && t.* == #char "\"";
         t += 1;
     }
     if t >= max_t return;
@@ -504,13 +506,13 @@ parse_at :: (using tokenizer: *Tokenizer, token: *Token) {
     t += 1;
     if t >= max_t return;
 
-    if <<t == #char "$" {
+    if t.* == #char "$" {
         // Verbatim interpolated string
         parse_dollar(tokenizer, token, true);
-    } else if <<t == #char "\"" {
+    } else if t.* == #char "\"" {
         // Verbatim string
         parse_verbatim_string_literal(tokenizer, token);
-    } else if is_alpha(<<t) || <<t == #char "_" {
+    } else if is_alpha(t.*) || t.* == #char "_" {
         // Identifier or disambiguate attribute
         parse_identifier(tokenizer, token, check_for_keyword = false);
     }
@@ -524,10 +526,10 @@ parse_dollar :: (using tokenizer: *Tokenizer, token: *Token, verbatim := false) 
     t += 1;
     if t >= max_t return;
 
-    if <<t == #char "@" {
+    if t.* == #char "@" {
         // Interpolated verbatim string
         parse_at(tokenizer, token);
-    } else if <<t == #char "\"" {
+    } else if t.* == #char "\"" {
         if verbatim {
             // Verbatim interpolated string
             parse_verbatim_string_literal(tokenizer, token);
@@ -545,7 +547,7 @@ parse_caret :: (using tokenizer: *Tokenizer, token: *Token) {
     t += 1;
     if t >= max_t return;
 
-    if <<t == {
+    if t.* == {
         case #char "=";
             token.operation = .caret_equal;
             t += 1;

--- a/src/langs/csharp.jai
+++ b/src/langs/csharp.jai
@@ -59,13 +59,11 @@ tokenize_csharp_for_indentation :: (using buffer: Buffer) -> [] Indentation_Toke
 #scope_file
 
 get_csharp_tokenizer :: (using buffer: Buffer) -> CSharp_Tokenizer {
-    tokenizer := CSharp_Tokenizer.{
+    return CSharp_Tokenizer.{
         buf = cast(string) bytes,
         max_t = bytes.data + bytes.count,
         t = bytes.data
     };
-    tokenizer.interpolated_string_is_verbatim.allocator = temp;
-    return tokenizer;
 }
 
 get_next_token :: (using tokenizer: *CSharp_Tokenizer) -> Token {
@@ -590,8 +588,7 @@ parse_interpolated_string_literal :: (using tokenizer: *CSharp_Tokenizer, token:
     }
 
     // Unescaped left brace
-    if left_brace_seen
-        array_add(*interpolated_string_is_verbatim, is_verbatim,);
+    if left_brace_seen then array_add(*interpolated_string_is_verbatim, is_verbatim,);
 
     if t >= max_t return;
 
@@ -657,6 +654,7 @@ CSharp_Tokenizer :: struct {
     // Records if the interpolated string is also a verbatim string at
     // the current nested interpolated expression level(array index).
     interpolated_string_is_verbatim: [..] bool;
+    interpolated_string_is_verbatim.allocator = temp;
 }
 
 Token :: struct {

--- a/src/langs/csharp.jai
+++ b/src/langs/csharp.jai
@@ -1,29 +1,74 @@
 highlight_csharp_syntax :: (using buffer: *Buffer) {
-    using tokenizer := get_tokenizer(buffer);
-
-    last_token := Token.{0, 0, .eof};
+    tokenizer := get_csharp_tokenizer(buffer);
 
     while true {
         token := get_next_token(*tokenizer);
         if token.type == .eof break;
 
         // Maybe retroactively highlight a "method("
-        if token.type == .punctuation && token.punctuation == .l_paren && last_token.type == .identifier {
-            memset(colors.data + last_token.start, xx Color.CODE_FUNCTION, last_token.len);
+        last := tokenizer.last_token;
+        if token.type == .punctuation && token.punctuation == .l_paren && last.type == .identifier {
+            memset(colors.data + last.start, xx Color.CODE_FUNCTION, last.len);
         }
 
-        last_token = token;
+        tokenizer.last_token = token;
 
         color := COLOR_MAP[token.type];
         memset(colors.data + token.start, xx color, token.len);
     }
 }
 
-get_next_csharp_token :: get_next_token;  // export for indent tokenization
+tokenize_csharp_for_indentation :: (using buffer: Buffer) -> [] Indentation_Token /* temp */ {
+    tokens: [..] Indentation_Token;
+    tokens.allocator = temp;
+
+    tokenizer := get_csharp_tokenizer(buffer);
+
+    while true {
+        src := get_next_token(*tokenizer);
+
+        token: Indentation_Token = ---;
+        token.start = src.start;
+        token.len   = src.len;
+
+        if src.type == {
+            case .punctuation;
+                if src.punctuation == {
+                    case .l_paren;      token.type = .open;  token.kind = .paren;
+                    case .l_bracket;    token.type = .open;  token.kind = .bracket;
+                    case .l_brace;      token.type = .open;  token.kind = .brace;
+                    case .r_paren;      token.type = .close; token.kind = .paren;
+                    case .r_bracket;    token.type = .close; token.kind = .bracket;
+                    case .r_brace;      token.type = .close; token.kind = .brace;
+                    case;               continue;
+                }
+
+            case .multiline_comment;    token.type = .maybe_multiline;
+            case .eof;                  token.type = .eof;  // to guarantee we always have indentation tokens
+            case;                       token.type = .unimportant;
+        }
+
+        array_add(*tokens, token);
+
+        if src.type == .eof break;
+    }
+
+    return tokens;
+}
 
 #scope_file
 
-get_next_token :: (using tokenizer: *Tokenizer) -> Token {
+get_csharp_tokenizer :: (using buffer: Buffer) -> CSharp_Tokenizer {
+    tokenizer := CSharp_Tokenizer.{
+        buf = cast(string) bytes,
+        max_t = bytes.data + bytes.count,
+        t = bytes.data
+    };
+    tokenizer.interpolated_string_is_verbatim.allocator = temp;
+    return tokenizer;
+}
+
+get_next_token :: (using tokenizer: *CSharp_Tokenizer) -> Token {
     eat_white_space(tokenizer);
 
     token: Token;
@@ -36,7 +81,11 @@ get_next_token :: (using tokenizer: *Tokenizer) -> Token {
     // Look at the first char as if it's ASCII (if it isn't, this is just a text line)
     char := t.*;
 
-    if is_alpha(char) || char == #char "_" {
+    if interpolated_string_is_verbatim.count > 0 && last_token.type == .punctuation && last_token.punctuation == .r_brace {
+        is_verbatim := interpolated_string_is_verbatim[interpolated_string_is_verbatim.count - 1];
+        parse_interpolated_string_literal(tokenizer, *token, is_verbatim , is_start = false);
+        array_ordered_remove_by_index(*interpolated_string_is_verbatim, interpolated_string_is_verbatim.count - 1);
+    } else if is_alpha(char) || char == #char "_" {
         parse_identifier(tokenizer, *token, true);
     } else if is_digit(char) {
         parse_number(tokenizer, *token);
@@ -498,20 +547,75 @@ parse_verbatim_string_literal :: (using tokenizer: *Tokenizer, token: *Token) {
     t += 1;
 }
 
+// https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/interpolated
+// Interpolated strings are parsed in sections.
+// - From start to the first interpolated expression section in {} (or the end)
+// - Between the interpolated expression sections in {}
+// - From the end of an interpolated expression section to the end
+// After the start of an interpolated expression section interpolated_string_is_verbatim
+// will have data that tells get_next_token() to come back and start parsing the interpolated
+// string again after a right brace is encountered.
+parse_interpolated_string_literal :: (using tokenizer: *CSharp_Tokenizer, token: *Token, is_verbatim: bool, is_start: bool) {
+    token.type = .string_literal;
+
+    // Parse until an unescaped { (interpolated expression section start)
+    // or unescaped " (end of interpolated string)
+    quote_seen, left_slash_seen, left_brace_seen := false;
+
+    // If it's not the start of the interpolated string we keep the " as it could be the end
+    if is_start t += 1;
+
+    if is_verbatim {
+        while t < max_t && t.* != #char "\n" {
+            // Escape for " in verbatim is ""
+            // Escape for { in interpolated is {{
+            if quote_seen && t.* != #char "\"" { t -= 1; break; }
+            if left_brace_seen && t.* != #char "{" { t -= 2; break; }
+
+            quote_seen = !quote_seen && t.* == #char "\"";
+            left_brace_seen = !left_brace_seen && t.* == #char "{";
+            t += 1;
+        }
+    } else {
+        while t < max_t && t.* != #char "\n" {
+            // Escape for " in literal is \"
+            // Escape for { in interpolated is {{
+            if !left_slash_seen && t.* == #char "\"" { quote_seen = true; break; }
+            if left_brace_seen && t.* != #char "{" { t -= 2; break; }
+
+            left_slash_seen = !left_slash_seen && t.* == #char "\\";
+            left_brace_seen = !left_brace_seen && t.* == #char "{";
+            t += 1;
+        }
+    }
+
+    // Unescaped left brace
+    if left_brace_seen
+        array_add(*interpolated_string_is_verbatim, is_verbatim,);
+
+    if t >= max_t return;
+
+    t += 1;
+}
+
 // https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/verbatim
 // https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/attributes
-parse_at :: (using tokenizer: *Tokenizer, token: *Token) {
+parse_at :: (using tokenizer: *CSharp_Tokenizer, token: *Token, is_interpolated := false) {
     token.type = .invalid;
 
     t += 1;
     if t >= max_t return;
 
     if t.* == #char "$" {
-        // Verbatim interpolated string
-        parse_dollar(tokenizer, token, true);
+        parse_dollar(tokenizer, token, is_verbatim = true);
     } else if t.* == #char "\"" {
-        // Verbatim string
-        parse_verbatim_string_literal(tokenizer, token);
+        if is_interpolated {
+            // Interpolated verbatim  string
+            parse_interpolated_string_literal(tokenizer, token, is_verbatim = true, is_start = true);
+        } else {
+            // Verbatim string
+            parse_verbatim_string_literal(tokenizer, token);
+        }
     } else if is_alpha(t.*) || t.* == #char "_" {
         // Identifier or disambiguate attribute
         parse_identifier(tokenizer, token, check_for_keyword = false);
@@ -519,24 +623,17 @@ parse_at :: (using tokenizer: *Tokenizer, token: *Token) {
 }
 
 // Interpolated string
-// The enclosed identifiers and braces are not parsed
-parse_dollar :: (using tokenizer: *Tokenizer, token: *Token, verbatim := false) {
+parse_dollar :: (using tokenizer: *CSharp_Tokenizer, token: *Token, is_verbatim := false) {
     token.type = .invalid;
 
     t += 1;
     if t >= max_t return;
 
     if t.* == #char "@" {
-        // Interpolated verbatim string
-        parse_at(tokenizer, token);
+        parse_at(tokenizer, token, is_interpolated = true);
     } else if t.* == #char "\"" {
-        if verbatim {
-            // Verbatim interpolated string
-            parse_verbatim_string_literal(tokenizer, token);
-        } else {
-            // Interpolated string
-            parse_string_literal(tokenizer, token);
-        }
+        // Interpolated or verbatim interpolated string
+        parse_interpolated_string_literal(tokenizer, token, is_verbatim, is_start = true);
     }
 }
 
@@ -552,6 +649,14 @@ parse_caret :: (using tokenizer: *Tokenizer, token: *Token) {
             token.operation = .caret_equal;
             t += 1;
     }
+}
+
+CSharp_Tokenizer :: struct {
+    using #as base: Tokenizer;
+    last_token: Token;
+    // Records if the interpolated string is also a verbatim string at
+    // the current nested interpolated expression level(array index).
+    interpolated_string_is_verbatim: [..] bool;
 }
 
 Token :: struct {


### PR DESCRIPTION
Added C# nested string interpolation highlighting by parsing interpolated string in sections broken up by the interpolated expression sections in {} (further details in code comments).

This required remembering if the parser was inside an interpolated string expression section and if the string was also a verbatim string. This was done by creating CSharp_Tokenizer (similar to other tokenizers) with the extra info to keep things thread safe.

Also updated the dereference operators (separate commit).

Tested on the following C# (built with Jai 0.1.086)
```
var
test = "thing";            //standard
test = "thi\"ng";          //standard " escaped
test = @"thing";           //verbatim
test = @"thi""ng";         //verbatim " escaped
            
test = $"thin{1}g";        //interpolated
test = $"thin{1 + Single.MinValue + (0x2A66__F__a * 10)}g"; //interpolated longer expression
test = $"thi\"n{1}g";      //interpolated " escaped
test = $"thi\"n{{{1}}}g";  //interpolated " escaped, bracket escaped
test = $"thi{1}n{2}g";     //interpolated multiple
            
test = @$"th""in{1}g";     //verbatim interpolated escaped
test = $@"th""in{1}g";     //interpolated verbatim escaped
            
test = $"thin{$"thin{1-1}g"}g";                          //interpolated nested
test = $"thin{$"th{1-1}in{1-2}g"}g";                     //interpolated multiple in nested
test = $"thin{$"thin{$"thin{3}g"}g"}g";                  //interpolated triple nested
test = $"thin{$"thin{1-1}g"}g_thin{$"thin{2-1}g"}g";     //interpolated nested multiple same levels
test = $"thin{$"thin{1-1}g"}g_thin{2}g";                 //interpolated nested multiple different levels
            
test = $"thin{$"th\"in{1-1}g"}g";                        //interpolated nested, nested " escape
test = $"thin{$"th{{in{1-1}g}}"}g";                      //interpolated nested, nested bracket escape
test = $"thin{$"th\"in{1-1}g"}g_thin{$"thin{2-1}g"}g";   //interpolated nested multiple same levels, nested " escape
test = $"thin{$"th\"in{1-1}g"}g_thin{2}g";               //interpolated nested multiple different levels, nested " escape
            
test = @$"thin{$"thin{1-1}g"}g";                         //verbatim interpolated nested
test = @$"thin{$"thin{1-1}g"}g_thin{$"thin{2-1}g"}g";    //verbatim interpolated nested multiple same levels
test = @$"thin{$"thin{1-1}g"}g_thin{2}g";                //verbatim interpolated nested multiple different levels

test = @$"thin{@$"th""in{1-1}g"}g";                      //verbatim interpolated nested, nested " escape
test = @$"thin{@$"th{{in{1-1}g}}"}g";                    //verbatim interpolated nested, nested bracket escape
test = @$"thin{@$"th""in{1-1}g"}g_thin{$"thin{2-1}g"}g"; //verbatim interpolated nested multiple same levels, nested " escape
test = @$"thin{@$"th""in{1-1}g"}g_thin{2}g";             //verbatim interpolated nested multiple different levels, nested " escape
            
test = @$"thin{$@"th""in{1-1}g"}g";                      //verbatim interpolated, interpolated verbatim nested, nested " escape
```
Comparison vs VS 2022
![image](https://github.com/focus-editor/focus/assets/77188323/a2f530fb-669c-46fc-b66e-17b2708b6e6d)
