### PR TITLE
Implemented command to open a new focus window

### DIFF
--- a/config/default.focus-config
+++ b/config/default.focus-config
@@ -196,7 +196,7 @@ Alt-A                       align_cursors
 Alt-Z                       toggle_line_wrap
 Alt-Shift-L                 toggle_line_numbers
 
-Ctrl-Shift-Alt-N            open_another_window
+Ctrl-Shift-Alt-N            duplicate_session
 
 [open file dialog]
 

--- a/config/default.focus-config
+++ b/config/default.focus-config
@@ -196,6 +196,7 @@ Alt-A                       align_cursors
 Alt-Z                       toggle_line_wrap
 Alt-Shift-L                 toggle_line_numbers
 
+Ctrl-Shift-Alt-N            open_another_window
 
 [open file dialog]
 

--- a/src/keymap.jai
+++ b/src/keymap.jai
@@ -268,7 +268,7 @@ ACTIONS_COMMON :: string.[
 
     "quit",
 
-    "open_another_window",
+    "duplicate_session",
 
     "open_project",
     "switch_to_project",  // alias of open_project

--- a/src/keymap.jai
+++ b/src/keymap.jai
@@ -268,6 +268,8 @@ ACTIONS_COMMON :: string.[
 
     "quit",
 
+    "open_another_window",
+
     "open_project",
     "switch_to_project",  // alias of open_project
     "close_project",

--- a/src/main.jai
+++ b/src/main.jai
@@ -57,7 +57,7 @@ main :: () {
         }
     }
 
-    args := get_command_line_arguments();
+    args = get_command_line_arguments();
 
     if args.count >= 2 {
         session_initialized := false;
@@ -309,6 +309,8 @@ handle_common_editor_action :: (action: Action_Editors, placement: Editor_Placem
     if action == {
         case .quit;                                             should_quit = true;                                 return true;
 
+        case .open_another_window;                              open_another_window();                              return true;
+
         case .increase_font_size;                               increase_font_size();                               return true;
         case .decrease_font_size;                               decrease_font_size();                               return true;
         case .reset_font_size_to_default;                       reset_font_size_to_default();                       return true;
@@ -517,6 +519,12 @@ editor_toggle_fullscreen :: () {
     toggle_fullscreen(window, fullscreen, *fullscreen_state);  // platform-specific
 }
 
+open_another_window :: () {
+    new_window_process := Process.{};
+    print("opening another window: %\n", args);
+    create_process(*new_window_process, .. args, "", capture_and_return_output = false, arg_quoting = Process_Argument_Quoting.QUOTE_IF_NEEDED);
+}
+
 increase_font_size :: () {
     if (font_size + 1) <= MAX_FONT_SIZE {
         font_size += 1;
@@ -618,6 +626,8 @@ data_dir:     string;
 temp_dir:     string;
 projects_dir: string;
 themes_dir:   string;
+
+args: []string;
 
 window: Window_Type;
 window_generic_title: string = ---;

--- a/src/main.jai
+++ b/src/main.jai
@@ -309,7 +309,7 @@ handle_common_editor_action :: (action: Action_Editors, placement: Editor_Placem
     if action == {
         case .quit;                                             should_quit = true;                                 return true;
 
-        case .open_another_window;                              open_another_window();                              return true;
+        case .duplicate_session;                                duplicate_session();                                return true;
 
         case .increase_font_size;                               increase_font_size();                               return true;
         case .decrease_font_size;                               decrease_font_size();                               return true;
@@ -519,9 +519,8 @@ editor_toggle_fullscreen :: () {
     toggle_fullscreen(window, fullscreen, *fullscreen_state);  // platform-specific
 }
 
-open_another_window :: () {
+duplicate_session :: () {
     new_window_process := Process.{};
-    print("opening another window: %\n", args);
     create_process(*new_window_process, .. args, "", capture_and_return_output = false, arg_quoting = Process_Argument_Quoting.QUOTE_IF_NEEDED);
 }
 

--- a/src/widgets/commands.jai
+++ b/src/widgets/commands.jai
@@ -142,6 +142,8 @@ commands := #run -> [] Command {
         .{ .build_kill_running_command,            "Build: Kill Running Command",        .None,    0 },
 
         .{ .autoindent_region,                     "Autoindent Region",                  .Single,  0 },
+
+        .{ .open_another_window,                   "Open Anohter Window",                .None,    0 },
     ];
 
     linux_commands := Command.[

--- a/src/widgets/commands.jai
+++ b/src/widgets/commands.jai
@@ -143,7 +143,7 @@ commands := #run -> [] Command {
 
         .{ .autoindent_region,                     "Autoindent Region",                  .Single,  0 },
 
-        .{ .open_another_window,                   "Open Anohter Window",                .None,    0 },
+        .{ .duplicate_session,                     "Duplicate Session",                  .None,    0 },
     ];
 
     linux_commands := Command.[


### PR DESCRIPTION
The command duplicates the same command-line arguments used to launch focus the first time. It starts a new process independent of the first one.

https://github.com/focus-editor/focus/assets/10339438/56d64d75-3dba-44b7-8166-c7417097f2b7


