### PR TITLE
Configure build panel for spacemacs-light theme to have better title success and error backgrounds

### DIFF
--- a/config/themes/spacemacs-light.focus-theme
+++ b/config/themes/spacemacs-light.focus-theme
@@ -51,13 +51,13 @@ code_warning:                           E4D97DFF
 region_scope_export:                    fbf8efFF
 region_scope_file:                      fbf8efFF
 region_scope_module:                    fbf8efFF
-region_header:                          1A5152FF
-region_success:                         226022FF
+region_header:                          d2cedaFF
+region_success:                         42ae2cFF
 region_warning:                         986032FF
-region_error:                           772222FF
+region_error:                           e0211dFF
 region_heredoc:                         f0eee0FF
 
-build_panel_background:                 efeae9FF
+build_panel_background:                 fbf8efFF
 build_panel_scrollbar:                  33CCCC19
 build_panel_scrollbar_hover:            33CCCC4C
 build_panel_scrollbar_background:       10191F4C


### PR DESCRIPTION
This still isn't ideal because we can't (to my knowledge) change text color for build panel individually, but this is way better than it used to be
![image](https://github.com/focus-editor/focus/assets/7038954/5a184d00-50cb-488b-9230-f2c7447d7321)

![image](https://github.com/focus-editor/focus/assets/7038954/afdc0a16-44cf-4fab-a3c4-f4833fe325fc)
