### PR TITLE
Parse private identifiers in JS

### DIFF
--- a/src/langs/js.jai
+++ b/src/langs/js.jai
@@ -64,6 +64,7 @@ get_next_token :: (using tokenizer: *Tokenizer) -> Token {
         case #char "|";  parse_pipe                        (tokenizer, *token);
         case #char "%";  parse_percent                     (tokenizer, *token);
         case #char "^";  parse_caret                       (tokenizer, *token);
+        case #char "#";  parse_private_identifier          (tokenizer, *token);
 
         case #char ";";  token.type = .punctuation; token.punctuation = .semicolon; t += 1;
         case #char "\\"; token.type = .punctuation; token.punctuation = .backslash; t += 1;
@@ -402,6 +403,15 @@ parse_caret :: (using tokenizer: *Tokenizer, token: *Token) {
             token.operation = .caret_equal;
             t += 1;
     }
+}
+
+parse_private_identifier :: (using tokenizer: *Tokenizer, token: *Token) {
+    token.type = .identifier;
+
+    t += 1;
+    if t < max_t && !is_alpha(<<t) return;
+
+    identifier_str := read_utf8_identifier_string(tokenizer);
 }
 
 Token :: struct {


### PR DESCRIPTION
Private properties and methods start with # in JavaScript. Previously the leading hash was parsed as an error but the identifier after the hash was parsed as an identifier. This made the syntax highlighting a bit weird.