### PR TITLE
Parse .jsx and .tsx files as JavaScript

### DIFF
--- a/config/default.focus-config
+++ b/config/default.focus-config
@@ -18,7 +18,7 @@ __pycache__
 # These files are explicitly allowed so that the editor doesn't waste time figuring out
 # whether it should ignore these or not (if a file is not explicitly allowed or ignored,
 # it will be read to determine if it's binary or not).
-.jai .c .cpp .h .hpp .cc .cs .txt .md .focus-* .ini .csv .log .sql .py .m .html .xml .plist .js .ts .yml .yaml .toml .zig
+.jai .c .cpp .h .hpp .cc .cs .txt .md .focus-* .ini .csv .log .sql .py .m .html .xml .plist .js .jsx .ts .tsx .yml .yaml .toml .zig
 
 [ignore file extensions]
 # Files with the following extensions will not appear in the file open dialog and won't be loaded into memory.

--- a/config/default_macos.focus-config
+++ b/config/default_macos.focus-config
@@ -18,7 +18,7 @@ __pycache__
 # These files are explicitly allowed so that the editor doesn't waste time figuring out
 # whether it should ignore these or not (if a file is not explicitly allowed or ignored,
 # it will be read to determine if it's binary or not).
-.jai .c .cpp .h .hpp .cc .cs .txt .md .focus-* .ini .csv .log .sql .py .m .html .xml .plist .js .ts .yml .yaml .toml .zig
+.jai .c .cpp .h .hpp .cc .cs .txt .md .focus-* .ini .csv .log .sql .py .m .html .xml .plist .js .jsx .ts .tsx .yml .yaml .toml .zig
 
 [ignore file extensions]
 # Files with the following extensions will not appear in the file open dialog and won't be indexed.

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -1145,6 +1145,8 @@ get_lang_from_path :: (path: string) -> Buffer.Lang {
             case "go";             lang = .Golang;
 
             case "ts";             #through;
+            case "tsx";            #through;
+            case "jsx";            #through;
             case "js";             lang = .Js;
 
             case "lua";            lang = .Lua;

--- a/src/langs/common.jai
+++ b/src/langs/common.jai
@@ -166,7 +166,9 @@ get_lang_from_name :: (lang_name: string) -> Buffer.Lang {
     if ends_with_nocase(lang_name, "hlsl")         return .Hlsl;
     if ends_with_nocase(lang_name, "golang")       return .Golang;
     if ends_with_nocase(lang_name, "js")           return .Js;
+    if ends_with_nocase(lang_name, "jsx")          return .Js;
     if ends_with_nocase(lang_name, "ts")           return .Js;
+    if ends_with_nocase(lang_name, "tsx")          return .Js;
     if ends_with_nocase(lang_name, "lua")          return .Lua;
     if ends_with_nocase(lang_name, "odin")         return .Odin;
     if ends_with_nocase(lang_name, "python")       return .Python;


### PR DESCRIPTION
Eventually we might want some better syntax highlighting for JSX but it currently looks ok.