### PR TITLE
Auto skip closing brackets

### DIFF
--- a/src/config.jai
+++ b/src/config.jai
@@ -543,6 +543,7 @@ Settings :: struct {
     draw_indent_guides                            := false;
     auto_surround_with_brackets_and_quotes        := false;
     auto_close_brackets                           := false;
+    auto_skip_closing_brackets                    := false;
     prefer_system_file_dialogs                    := false;
     show_cursors_off_screen                       := true;
     persist_local_search_results                  := false;

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -346,6 +346,7 @@ active_editor_type_char :: (char: u32) {
 
     should_surround_selection     := config.settings.auto_surround_with_brackets_and_quotes && all_cursors_have_selection(editor) && is_balanceable_char(char);
     should_insert_closing_bracket := config.settings.auto_close_brackets && all_cursors_can_auto_insert_closing_bracket(editor, buffer) && is_auto_closeable_char(char);
+    should_skip_closing_bracket   := config.settings.auto_skip_closing_brackets && all_cursors_can_auto_skip_closing_bracket(editor, buffer) && is_auto_skippable_char(char);
 
     for * cursor : editor.cursors {
         new_len := cast(s32) buffer.bytes.count;
@@ -367,6 +368,9 @@ active_editor_type_char :: (char: u32) {
             insert_char_at_offset(buffer, cursor.pos, convert_utf32_to_utf8(get_balancing_char(char)));
             insert_char_at_offset(buffer, cursor.pos, utf8_char);
 
+            cursor.pos = next_char_offset(buffer.bytes, cursor.pos);
+            cursor.sel = cursor.pos;
+        } else if should_skip_closing_bracket {
             cursor.pos = next_char_offset(buffer.bytes, cursor.pos);
             cursor.sel = cursor.pos;
         } else {
@@ -754,6 +758,18 @@ all_cursors_can_auto_insert_closing_bracket :: (using editor: Editor, buffer: Bu
         ch := get_char_at_offset(buffer, it.pos);
 
         if !is_whitespace_char(xx ch) && !(is_non_word_char(ch) && !is_auto_closeable_char(ch)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+all_cursors_can_auto_skip_closing_bracket :: (using editor: Editor, buffer: Buffer) -> bool {
+    for editor.cursors {
+        if has_selection(it)  return false;
+        ch := get_char_at_offset(buffer, it.pos);
+
+        if !is_auto_skippable_char(ch) {
             return false;
         }
     }

--- a/src/utils.jai
+++ b/src/utils.jai
@@ -321,7 +321,11 @@ is_balanceable_char :: (ch: u32) -> bool {
 }
 
 is_auto_closeable_char :: (ch: u32) -> bool {
-    return ch == #char "{" || ch == #char "(" || ch == #char "[";
+    return ch == #char "{" || ch == #char "(" || ch == #char "[" || ch == #char "\"";;
+}
+
+is_auto_skippable_char :: (ch: u32) -> bool {
+    return ch == #char "}" || ch == #char ")" || ch == #char "]" || ch == #char "\"";;
 }
 
 get_balancing_char :: (ch: u32) -> u32 {


### PR DESCRIPTION
Similar to "auto_closing_brackets", were the closing bracket gets written when you type an open bracket.

Added "auto_skip_closing_brackets" to the settings config.
With this option enabled the closing bracket won't be written again if there already is one beneath the cursor.
The cursor will just be moved over by one position.
