### PR TITLE
Parse private identifiers with an underscore as one token

### DIFF
--- a/src/langs/js.jai
+++ b/src/langs/js.jai
@@ -409,7 +409,7 @@ parse_private_identifier :: (using tokenizer: *Tokenizer, token: *Token) {
     token.type = .identifier;
 
     t += 1;
-    if t < max_t && !is_alpha(<<t) return;
+    if t < max_t && !is_alpha(<<t) && <<t != #char "_" return;
 
     identifier_str := read_utf8_identifier_string(tokenizer);
 }


### PR DESCRIPTION
I think previously this: `#_something` was parsed as two tokens instead of one. I think this change makes it one token.