### PR TITLE
Strip whitespace command

### DIFF
--- a/src/editors.jai
+++ b/src/editors.jai
@@ -208,11 +208,11 @@ active_editor_handle_event :: (editor: *Editor, buffer: *Buffer, event: Input.Ev
         case .remove_additional_cursors;        remove_additional_cursors           (editor);
         case .add_cursors_to_line_ends;         add_cursors_to_line_ends            (editor, buffer);
         case .add_cursors_to_line_starts;       add_cursors_to_line_starts          (editor, buffer);
-        case .swap_selections;                  swap_selections                     (editor, buffer);         keep_selection = true;
-        case .select_all;                       select_all                          (editor, buffer);         keep_selection = true;
-        case .create_cursor_above;              create_cursor                       (editor, buffer, .above); keep_selection = true;
-        case .create_cursor_below;              create_cursor                       (editor, buffer, .below); keep_selection = true;
-        case .strip_trailing_whitespace;        strip_trailing_whitespace           (buffer, editor.buffer_id);
+        case .swap_selections;                  swap_selections                     (editor, buffer);           keep_selection = true;
+        case .select_all;                       select_all                          (editor, buffer);           keep_selection = true;
+        case .create_cursor_above;              create_cursor                       (editor, buffer, .above);   keep_selection = true;
+        case .create_cursor_below;              create_cursor                       (editor, buffer, .below);   keep_selection = true;
+        case .strip_trailing_whitespace;        strip_trailing_whitespace           (buffer, editor.buffer_id); keep_selection = true;
 
         // Actions that do something per cursor
         case .move_left;                        move_cursors_left                   (editor, buffer, by = .char,      shift_pressed);

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -212,6 +212,7 @@ active_editor_handle_event :: (editor: *Editor, buffer: *Buffer, event: Input.Ev
         case .select_all;                       select_all                          (editor, buffer);         keep_selection = true;
         case .create_cursor_above;              create_cursor                       (editor, buffer, .above); keep_selection = true;
         case .create_cursor_below;              create_cursor                       (editor, buffer, .below); keep_selection = true;
+        case .strip_trailing_whitespace;        strip_trailing_whitespace           (buffer, editor.buffer_id);
 
         // Actions that do something per cursor
         case .move_left;                        move_cursors_left                   (editor, buffer, by = .char,      shift_pressed);

--- a/src/keymap.jai
+++ b/src/keymap.jai
@@ -334,6 +334,7 @@ ACTIONS_COMMON :: string.[
     "increase_font_size",
     "decrease_font_size",
     "reset_font_size_to_default",
+    "strip_trailing_whitespace",
     "close_all_editors",
     "close_current_editor",
     "close_other_editors",

--- a/src/widgets/commands.jai
+++ b/src/widgets/commands.jai
@@ -159,6 +159,8 @@ base_commands := #run -> [] Command {
         cmd( "New Line Below Without Breaking",   .new_line_below_without_breaking,  .Single ),
         cmd( "New Line Above Without Breaking",   .new_line_above_without_breaking,  .Single ),
 
+        cmd( "Strip Trailing Whitespace",         .strip_trailing_whitespace,        .Single ),
+
         cmd( "Switch To Left Pane",               .switch_to_left_editor,            .Double ),
         cmd( "Switch To Right Pane",              .switch_to_right_editor,           .Double ),
         cmd( "Switch To Other Pane",              .switch_to_other_editor,           .Double ),


### PR DESCRIPTION
Addresses #359 

Adds an editor command `strip_trailing_whitespace` to remove whitespace from the command menu. I didn't always want to strip whitespace on save, so making this an explicit command makes sense.