### PR TITLE
Added .comp as GLSL file type

### DIFF
--- a/src/editors.jai
+++ b/src/editors.jai
@@ -1204,6 +1204,7 @@ get_lang_from_path :: (full_path: string) -> Buffer.Lang {
         case "tese";            lang = .Glsl;
         case "tesc";            lang = .Glsl;
         case "glsl";            lang = .Glsl;
+        case "comp";            lang = .Glsl;
 
         case "hlsl";            lang = .Hlsl;
         case "hlsli";           lang = .Hlsl;


### PR DESCRIPTION
`.comp` is often used for compute shaders in Vulkan, but right now it's not counted as GLSL.
This fixes that, I'm not sure if this could "collide" with HLSL (never used it, I don't know the conventions) but if not, would be a nice feature to have.