### PR TITLE
Separate data/config directories for Debug mode

### DIFF
--- a/src/platform/linux.jai
+++ b/src/platform/linux.jai
@@ -112,12 +112,24 @@ DONE;
 platform_data_dir :: () -> string {
     data_dir := sprint("%/focus-editor", XDG.get_path(.DATA_HOME));
     make_directory_if_it_does_not_exist(data_dir);
+    
+    #if DEBUG {
+        data_dir = sprint("%/debug", data_dir);
+        make_directory_if_it_does_not_exist(data_dir);
+    }
+    
     return data_dir;
 }
 
 platform_config_dir :: () -> string {
     config_dir := sprint("%/focus-editor", XDG.get_path(.CONFIG_HOME));
     make_directory_if_it_does_not_exist(config_dir);
+    
+    #if DEBUG {
+        config_dir = sprint("%/debug", config_dir);
+        make_directory_if_it_does_not_exist(config_dir);
+    }
+    
     return config_dir;
 }
 

--- a/src/platform/macos.jai
+++ b/src/platform/macos.jai
@@ -6,8 +6,15 @@ platform_setup :: inline () {
 }
 
 platform_data_dir :: () -> string {
-    application_support := NSFileManager.URLForDirectory(NSFileManager.defaultManager(), NSApplicationSupportDirectory, NSUserDomainMask, null, YES, null);
-    config_dir := sprint("%/dev.focus-editor", to_string(NSURL.path(application_support)));
+    application_support := to_string(NSURL.path(NSFileManager.URLForDirectory(NSFileManager.defaultManager(), NSApplicationSupportDirectory, NSUserDomainMask, null, YES, null)));
+    
+    #if DEBUG {
+        make_directory_if_it_does_not_exist(tprint("%/dev.focus-editor", application_support));
+        config_dir := sprint("%/dev.focus-editor/debug", application_support);
+    } else {
+        config_dir := sprint("%/dev.focus-editor", application_support);
+    }
+    
     make_directory_if_it_does_not_exist(config_dir);
     return config_dir;
 }

--- a/src/platform/windows.jai
+++ b/src/platform/windows.jai
@@ -6,7 +6,13 @@ platform_setup :: () {
 }
 
 platform_data_dir :: () -> string {
-    dir := trim_right(path_strip_filename(get_path_of_running_executable()), "/");
+    #if DEBUG {
+        dir := tprint("%/debug", trim_right(path_strip_filename(get_path_of_running_executable()), "/"));
+        make_directory_if_it_does_not_exist(dir);
+    } else {
+        dir := trim_right(path_strip_filename(get_path_of_running_executable()), "/");
+    }
+    
     return copy_string(dir);
 }
 


### PR DESCRIPTION
When developing Focus, local config files (global, project, & themes) may be adjusted by test runs, potentially making them incompatible with the release version.

Now when DEBUG == true, Focus will create/use a "debug" subfolder *within* its usual data/config directories. Now, there is a separate set of data/configs for instances of Focus when compiled in Debug mode.

I made this change (and tested it successfully) on macOS, but I cannot test the Windows/Linux code paths. Please test this PR on those platforms before merging.