### PR TITLE
Comment on empty line

### DIFF
--- a/src/editors.jai
+++ b/src/editors.jai
@@ -3252,13 +3252,14 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer, is_fallback := false) {
     range := Offset_Range.{ start = xx line_starts[0] & LINE_START_MASK, end = xx last_line_end_offset };
     replace_range(buffer, range, new_str);
 
-    for * cursor : editor.cursors { cursor.col_wanted = -1; }
-    
-    if only_empty_lines_selected {
-        first_cursor := *editor.cursors[0];
-        pos := min(first_cursor.pos, first_cursor.sel) + comment.count + 1;
-        first_cursor.pos = xx pos;
-        first_cursor.sel = xx pos;
+    for * cursor : editor.cursors {
+        if only_empty_lines_selected {
+            pos := min(cursor.pos, cursor.sel) + comment.count + 1;
+            cursor.pos = xx pos;
+            cursor.sel = xx pos;
+        }
+        
+        cursor.col_wanted = -1;
     }
     
     editor.cursor_moved = .unimportant;

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -3126,6 +3126,17 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer, is_fallback := false) {
     min_indent  := -1;
     add_comment := false;
     only_empty_lines_selected := true;
+
+    // We probably want to align those 3 selected line comments above the foo() procedure,
+    // so we should check the maximum indent instead of the minimum. It's going to work only if
+    // we selected empty lines.
+    // y
+    // ^ <- minimum indent
+    // ^        
+    // ^^^| <- maximum indent and the cursor here too
+    //    foo(); 
+    max_empty_line_indent := -1;
+    
     for 0..last_line {
         start, end := line_starts[it], line_starts[it+1];
         str := cast(string) array_view(buffer.bytes, start, end-start);
@@ -3158,17 +3169,26 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer, is_fallback := false) {
             }
         }
 
-        if is_empty_line { line_starts[it] |= EMPTY_LINE_BIT; continue; }
+        if is_empty_line { 
+            line_starts[it] |= EMPTY_LINE_BIT;
+            if indent > max_empty_line_indent {
+                max_empty_line_indent = indent;
+            }
+            continue; 
+        }
         if min_indent < 0 || indent < min_indent then min_indent = indent;
         if !add_comment && !begins_with(trimmed_str, comment) then add_comment = true;
+    }
+
+    if only_empty_lines_selected {
+        min_indent  = max_empty_line_indent; 
+        add_comment = true;
     }
 
     if min_indent < 0 then min_indent = 0;
 
     // Build a replacement string
     b: String_Builder;  // not using temp because the string may be too large
-
-    if only_empty_lines_selected then add_comment = true;
    
     if add_comment {
         use_spaces := config.settings.insert_spaces_when_pressing_tab;
@@ -3177,7 +3197,7 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer, is_fallback := false) {
             min_indent = tab_count * TAB_SIZE;  // Update min_indent too. If you use tabs, your comments will align with tab columns.
             get_tmp_tabs(tab_count);
         }
-    
+
         adjustment := 0;
         for 0..last_line {
             start, end := line_starts[it] & LINE_START_MASK, line_starts[it+1] & LINE_START_MASK;
@@ -3189,22 +3209,34 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer, is_fallback := false) {
             
             // Count how many characters are in the minimum indent, then cut off those characters since they will be replaced with new_whitespace
             indent, old_whitespace_count := 0;
-            while indent < min_indent {
-                c := str[old_whitespace_count];
-                if c == {
-                    case #char " ";  indent += 1;
-                    case #char "\t"; indent += TAB_SIZE - (indent % TAB_SIZE);
-                    case;            assert(false, "Unexpected character 0x%, (expected only tabs/spaces)\n", formatInt(c, base=16));
-                }
-                old_whitespace_count += 1;
-            }
-            if indent > min_indent then old_whitespace_count -= 1;
-            trimmed_str := advance(str, old_whitespace_count);
+            trimmed_str := str;
 
-            append(*b, new_whitespace);
-            append(*b, comment);
-            append(*b, " ");
-            append(*b, trimmed_str);
+            if only_empty_lines_selected {
+                max_indent := min_indent;
+                whitespace := ifx use_spaces then get_tmp_spaces(max_indent) else get_tmp_tabs(max_indent/TAB_SIZE);
+                append(*b, whitespace);
+                append(*b, comment);
+                append(*b, " ");
+                append(*b, "\n"); // line end
+
+                old_whitespace_count = max_indent;
+            } else {
+                while indent < min_indent {
+                    c := str[old_whitespace_count];
+                    if c == {
+                        case #char " ";  indent += 1;
+                        case #char "\t"; indent += TAB_SIZE - (indent % TAB_SIZE);
+                        case;            assert(false, "Unexpected character 0x%, (expected only tabs/spaces)\n", formatInt(c, base=16));
+                    }
+                    old_whitespace_count += 1;
+                }
+                if indent > min_indent then old_whitespace_count -= 1;
+                trimmed_str = advance(str, old_whitespace_count);
+                append(*b, new_whitespace);
+                append(*b, comment);
+                append(*b, " ");
+                append(*b, trimmed_str);
+            }
 
             adjusted_start             := start + adjustment;
             adjusted_old_comment_start := start + adjustment + old_whitespace_count;

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -3161,18 +3161,14 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer, is_fallback := false) {
         if !add_comment && !begins_with(trimmed_str, comment) then add_comment = true;
     }
 
-    if line_starts.count == 2 && (line_starts[0] & EMPTY_LINE_BIT) && editor.cursors.count == 1 && editor.cursors[0].pos == editor.cursors[0].sel {
+    if editor.cursors.count == 1 && !has_selection(editor.cursors[0]) && (line_starts[0] & EMPTY_LINE_BIT) {
         // Inserts a comment at the cursor position if there's only one cursor and the current line is empty.
         
         cursor := *editor.cursors[0];
-        pos := max(cursor.pos, cursor.sel);
-        insert_string_at_offset(buffer, pos, comment);
-        pos += xx comment.count;
-        insert_string_at_offset(buffer, pos, cast(string)" ");
-        pos += 1;
+        insert_string_at_offset(buffer, cursor.pos, tprint("% ", comment));
         
-        cursor.pos = xx pos;
-        cursor.sel = xx pos;
+        cursor.pos += xx (comment.count + 1);
+        cursor.sel = cursor.pos;
         cursor.col_wanted = -1;
         
         editor.cursor_moved = .unimportant;
@@ -3184,6 +3180,8 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer, is_fallback := false) {
     b: String_Builder;  // not using temp because the string may be too large
     
     if add_comment {
+        assert(min_indent > -1);
+        
         use_spaces := config.settings.insert_spaces_when_pressing_tab;
         new_whitespace := ifx use_spaces then get_tmp_spaces(min_indent) else {
             tab_count := min_indent / TAB_SIZE; // Aligns the indentation with tab columns because of integer division.

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -3125,6 +3125,7 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer, is_fallback := false) {
 
     min_indent  := -1;
     add_comment := false;
+    only_empty_lines_selected := true;
     for 0..last_line {
         start, end := line_starts[it], line_starts[it+1];
         str := cast(string) array_view(buffer.bytes, start, end-start);
@@ -3152,6 +3153,7 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer, is_fallback := false) {
                 case;
                     trimmed_str   = slice(str, it_index, str.count - it_index);
                     is_empty_line = false;
+                    only_empty_lines_selected = false;
                     break c;
             }
         }
@@ -3166,6 +3168,8 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer, is_fallback := false) {
     // Build a replacement string
     b: String_Builder;  // not using temp because the string may be too large
 
+    if only_empty_lines_selected then add_comment = true;
+   
     if add_comment {
         use_spaces := config.settings.insert_spaces_when_pressing_tab;
         new_whitespace := ifx use_spaces then get_tmp_spaces(min_indent) else {
@@ -3173,13 +3177,16 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer, is_fallback := false) {
             min_indent = tab_count * TAB_SIZE;  // Update min_indent too. If you use tabs, your comments will align with tab columns.
             get_tmp_tabs(tab_count);
         }
-
+    
         adjustment := 0;
         for 0..last_line {
             start, end := line_starts[it] & LINE_START_MASK, line_starts[it+1] & LINE_START_MASK;
             str        := cast(string) array_view(buffer.bytes, start, end-start);
-            if line_starts[it] & EMPTY_LINE_BIT { append(*b, str); continue; }
-
+            if !only_empty_lines_selected && line_starts[it] & EMPTY_LINE_BIT {
+                append(*b, str); 
+                continue;
+            }
+            
             // Count how many characters are in the minimum indent, then cut off those characters since they will be replaced with new_whitespace
             indent, old_whitespace_count := 0;
             while indent < min_indent {
@@ -3208,6 +3215,7 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer, is_fallback := false) {
             for * cursor : editor.cursors {
                 if      cursor.pos > adjusted_old_comment_start then cursor.pos += xx line_length_difference;
                 else if cursor.pos >= adjusted_start            then cursor.pos  = xx adjusted_new_comment_start;
+    
                 if      cursor.sel > adjusted_old_comment_start then cursor.sel += xx line_length_difference;
                 else if cursor.sel >= adjusted_start            then cursor.sel  = xx adjusted_new_comment_start;
             }
@@ -3245,7 +3253,14 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer, is_fallback := false) {
     replace_range(buffer, range, new_str);
 
     for * cursor : editor.cursors { cursor.col_wanted = -1; }
-
+    
+    if only_empty_lines_selected {
+        first_cursor := *editor.cursors[0];
+        pos := min(first_cursor.pos, first_cursor.sel) + comment.count + 1;
+        first_cursor.pos = xx pos;
+        first_cursor.sel = xx pos;
+    }
+    
     editor.cursor_moved = .unimportant;
 }
 

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -3125,18 +3125,6 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer, is_fallback := false) {
 
     min_indent  := -1;
     add_comment := false;
-    only_empty_lines_selected := true;
-
-    // We probably want to align those 3 selected line comments above the foo() procedure,
-    // so we should check the maximum indent instead of the minimum. It's going to work only if
-    // we selected empty lines.
-    // y
-    // ^ <- minimum indent
-    // ^        
-    // ^^^| <- maximum indent and the cursor here too
-    //    foo(); 
-    max_empty_line_indent := -1;
-    
     for 0..last_line {
         start, end := line_starts[it], line_starts[it+1];
         str := cast(string) array_view(buffer.bytes, start, end-start);
@@ -3164,32 +3152,37 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer, is_fallback := false) {
                 case;
                     trimmed_str   = slice(str, it_index, str.count - it_index);
                     is_empty_line = false;
-                    only_empty_lines_selected = false;
                     break c;
             }
         }
-
-        if is_empty_line { 
-            line_starts[it] |= EMPTY_LINE_BIT;
-            if indent > max_empty_line_indent {
-                max_empty_line_indent = indent;
-            }
-            continue; 
-        }
-        if min_indent < 0 || indent < min_indent then min_indent = indent;
+        
+        if is_empty_line                                      then { line_starts[it] |= EMPTY_LINE_BIT; continue; }
+        if min_indent < 0 || indent < min_indent              then min_indent = indent;
         if !add_comment && !begins_with(trimmed_str, comment) then add_comment = true;
     }
 
-    if only_empty_lines_selected {
-        min_indent  = max_empty_line_indent; 
-        add_comment = true;
+    if line_starts.count == 2 && (line_starts[0] & EMPTY_LINE_BIT) && editor.cursors.count == 1 && editor.cursors[0].pos == editor.cursors[0].sel {
+        // Inserts a comment at the cursor position if there's only one cursor and the current line is empty.
+        
+        cursor := *editor.cursors[0];
+        pos := max(cursor.pos, cursor.sel);
+        insert_string_at_offset(buffer, pos, comment);
+        pos += xx comment.count;
+        insert_string_at_offset(buffer, pos, cast(string)" ");
+        pos += 1;
+        
+        cursor.pos = xx pos;
+        cursor.sel = xx pos;
+        cursor.col_wanted = -1;
+        
+        editor.cursor_moved = .unimportant;
+    
+        return;
     }
-
-    if min_indent < 0 then min_indent = 0;
 
     // Build a replacement string
     b: String_Builder;  // not using temp because the string may be too large
-   
+    
     if add_comment {
         use_spaces := config.settings.insert_spaces_when_pressing_tab;
         new_whitespace := ifx use_spaces then get_tmp_spaces(min_indent) else {
@@ -3202,41 +3195,26 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer, is_fallback := false) {
         for 0..last_line {
             start, end := line_starts[it] & LINE_START_MASK, line_starts[it+1] & LINE_START_MASK;
             str        := cast(string) array_view(buffer.bytes, start, end-start);
-            if !only_empty_lines_selected && line_starts[it] & EMPTY_LINE_BIT {
-                append(*b, str); 
-                continue;
-            }
-            
+            if line_starts[it] & EMPTY_LINE_BIT { append(*b, str); continue; }
+
             // Count how many characters are in the minimum indent, then cut off those characters since they will be replaced with new_whitespace
             indent, old_whitespace_count := 0;
-            trimmed_str := str;
-
-            if only_empty_lines_selected {
-                max_indent := min_indent;
-                whitespace := ifx use_spaces then get_tmp_spaces(max_indent) else get_tmp_tabs(max_indent/TAB_SIZE);
-                append(*b, whitespace);
-                append(*b, comment);
-                append(*b, " ");
-                append(*b, "\n"); // line end
-
-                old_whitespace_count = max_indent;
-            } else {
-                while indent < min_indent {
-                    c := str[old_whitespace_count];
-                    if c == {
-                        case #char " ";  indent += 1;
-                        case #char "\t"; indent += TAB_SIZE - (indent % TAB_SIZE);
-                        case;            assert(false, "Unexpected character 0x%, (expected only tabs/spaces)\n", formatInt(c, base=16));
-                    }
-                    old_whitespace_count += 1;
+            while indent < min_indent {
+                c := str[old_whitespace_count];
+                if c == {
+                    case #char " ";  indent += 1;
+                    case #char "\t"; indent += TAB_SIZE - (indent % TAB_SIZE);
+                    case;            assert(false, "Unexpected character 0x%, (expected only tabs/spaces)\n", formatInt(c, base=16));
                 }
-                if indent > min_indent then old_whitespace_count -= 1;
-                trimmed_str = advance(str, old_whitespace_count);
-                append(*b, new_whitespace);
-                append(*b, comment);
-                append(*b, " ");
-                append(*b, trimmed_str);
+                old_whitespace_count += 1;
             }
+            if indent > min_indent then old_whitespace_count -= 1;
+            trimmed_str := advance(str, old_whitespace_count);
+
+            append(*b, new_whitespace);
+            append(*b, comment);
+            append(*b, " ");
+            append(*b, trimmed_str);
 
             adjusted_start             := start + adjustment;
             adjusted_old_comment_start := start + adjustment + old_whitespace_count;
@@ -3247,7 +3225,6 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer, is_fallback := false) {
             for * cursor : editor.cursors {
                 if      cursor.pos > adjusted_old_comment_start then cursor.pos += xx line_length_difference;
                 else if cursor.pos >= adjusted_start            then cursor.pos  = xx adjusted_new_comment_start;
-    
                 if      cursor.sel > adjusted_old_comment_start then cursor.sel += xx line_length_difference;
                 else if cursor.sel >= adjusted_start            then cursor.sel  = xx adjusted_new_comment_start;
             }
@@ -3284,16 +3261,8 @@ toggle_comment :: (editor: *Editor, buffer: *Buffer, is_fallback := false) {
     range := Offset_Range.{ start = xx line_starts[0] & LINE_START_MASK, end = xx last_line_end_offset };
     replace_range(buffer, range, new_str);
 
-    for * cursor : editor.cursors {
-        if only_empty_lines_selected {
-            pos := min(cursor.pos, cursor.sel) + comment.count + 1;
-            cursor.pos = xx pos;
-            cursor.sel = xx pos;
-        }
-        
-        cursor.col_wanted = -1;
-    }
-    
+    for * cursor : editor.cursors { cursor.col_wanted = -1; }
+
     editor.cursor_moved = .unimportant;
 }
 


### PR DESCRIPTION
This is intended to work almost exactly like in vscode. It doesn't change the existing mechanism; the toggle line comment action only works if empty line or lines are selected, as you can see in the GIF. It's useful if you want to add a line comment for TODO, BUG, etc. I guess I don't need to explain further.

![XXXX](https://github.com/user-attachments/assets/134c731a-cec4-4ba6-8092-6e3ad613d22a)
