### PR TITLE
Fix a bug that caused a crash on Linux

### DIFF
--- a/src/main.jai
+++ b/src/main.jai
@@ -41,6 +41,16 @@ main :: () {
     init_buffers();
     load_global_config(fallback_to_default_on_failure = true);
 
+    window_x, window_y, window_width, window_height = platform_get_centered_window_dimensions(config.settings.open_on_the_biggest_monitor);
+
+    if config.settings.window_width  > 0 then window_width  = xx config.settings.window_width;
+    if config.settings.window_height > 0 then window_height = xx config.settings.window_height;
+    if config.settings.window_x != -1000 then window_x      = xx config.settings.window_x;
+    if config.settings.window_y != -1000 then window_y      = xx config.settings.window_y;
+
+    window_generic_title = ifx DEBUG then "Focus (debug mode)" else "Focus";
+    platform_create_window();
+
     // Process command line parameters
     focus_executable_args = get_command_line_arguments();
 
@@ -109,16 +119,6 @@ main :: () {
     } else {
         session = start_fresh_session();
     }
-
-    window_x, window_y, window_width, window_height = platform_get_centered_window_dimensions(config.settings.open_on_the_biggest_monitor);
-
-    if config.settings.window_width  > 0 then window_width  = xx config.settings.window_width;
-    if config.settings.window_height > 0 then window_height = xx config.settings.window_height;
-    if config.settings.window_x != -1000 then window_x      = xx config.settings.window_x;
-    if config.settings.window_y != -1000 then window_y      = xx config.settings.window_y;
-
-    window_generic_title = ifx DEBUG then "Focus (debug mode)" else "Focus";
-    platform_create_window();
 
     if project_config.loaded then update_window_title();
 


### PR DESCRIPTION
This change fixes a bug that made the editor crash on Linux when a file was passed as an argument. `editors_open_file` tried to set the title bar text before a window was created which resulted in a null dereference.

The bug was introduced in e4d9456d1d85958df25184e2451440d4d894b21c.