### PR TITLE
Add gcc regex to example config

### DIFF
--- a/config/default.focus-config
+++ b/config/default.focus-config
@@ -108,6 +108,7 @@ color_preview_popup:                    enabled  # options: enabled, minimized, 
 # For jai:    ^(?P<file>.*):(?P<line>\d+),(?P<col>\d+): (?P<type>Error|Warning|Info|...):* (?P<msg>.*)|^(?P<msg1>.*error LNK.*)
 # For msvc:   ^(?P<file>.*)\((?P<line>\d+),?(?P<col>\d+)?\)[ ]?: (?P<type>error|warning) (?P<msg>.*)$
 # For golang: ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<msg>.*)$
+# For gcc:    ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<type>error|warning): (?P<msg>.*) (\[(?P<msg1>.*)\])?$
 # ... let us know what regex works for you and we'll add it here
 
 # NOTE:

--- a/config/example-project.focus-config
+++ b/config/example-project.focus-config
@@ -37,6 +37,7 @@
 # For jai:    ^(?P<file>.*):(?P<line>\d+),(?P<col>\d+): (?P<type>Error|Warning|Info|...):* (?P<msg>.*)|^(?P<msg1>.*error LNK.*)
 # For msvc:   ^(?P<file>.*)\((?P<line>\d+),?(?P<col>\d+)?\)[ ]?: (?P<type>error|warning) (?P<msg>.*)$
 # For golang: ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<msg>.*)$
+# For gcc:    ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<type>error|warning): (?P<msg>.*) (\[(?P<msg1>.*)\])?$
 # ... let us know what regex works for you and we'll add it here
 
 # NOTE:


### PR DESCRIPTION
This regex worked for me with GCC 13 on Linux.

Unfortunately this is all I can contribute for now as I don't have access to the Jai beta yet. But this editor is awesome! Keep up the good work!