### PR TITLE
no_output build option

### DIFF
--- a/first.jai
+++ b/first.jai
@@ -45,6 +45,8 @@ build :: () {
             options.null_pointer_check = .ON;
             options.arithmetic_overflow_check = .OFF;
           case "debug";
+          case "no_output";
+            options.output_type = .NO_OUTPUT;
           case "windows7";
             windows7 = true;
             options.output_executable_name = "focus_windows7";
@@ -91,7 +93,12 @@ build :: () {
     while true {
         message := compiler_wait_for_message();
         if message.workspace != w continue;
-        if message.kind == .COMPLETE {
+        if message.kind == .PHASE {
+            phase_message := cast(*Message_Phase) message;
+            if phase_message.phase == .ALL_TARGET_CODE_BUILT {
+                if options.output_type == .NO_OUTPUT  exit(0);
+            }
+        } else if message.kind == .COMPLETE {
             m := cast(*Message_Complete) message;
             if m.error_code == .COMPILATION_FAILED then failed = true;
             break;


### PR DESCRIPTION
One style of developing is to compile frequently after making changes; either to jump to the next error you want to fix, or merely to check you haven't introduced one.  But, when you do this  on a working codebase you need to wait for the compilation to finish building, which feels long.  This PR lets you do this: `jai first.jai - no_output`
This will do the first stages of the compilation, checking for any errors in the code, but then exit as soon as it can.  On a working build this goes from 8+ seconds to 1.2 seconds on my PC.