### PR TITLE
CSS and TS improvements

### DIFF
--- a/src/langs/css.jai
+++ b/src/langs/css.jai
@@ -83,7 +83,7 @@ read_css_identifier_string :: (using tokenizer: *Tokenizer) -> string {
     t += 1;
     if t >= max_t then t = max_t;
 
-    while t < max_t && is_alnum(<<t) || <<t == #char "-" {
+    while t < max_t && (is_alnum(<<t) || <<t == #char "-") {
         t += 1;
     }
     if t >= max_t then t = max_t;
@@ -165,13 +165,23 @@ parse_slash_or_comment :: (using tokenizer: *Tokenizer, token: *Token) {
         case #char "*";
             token.type = .multiline_comment;
             t += 1;
-            while t + 1 < max_t {
-                if << t == #char "*" && << (t + 1) == #char "/" {
-                  t += 2;
+
+            while t < max_t {
+              if <<t == #char "*" {
+                if t + 1 < max_t && <<(t + 1) == #char "/" {
+                  t += 2; // Both the * and /
                   break;
                 }
-                t += 1;
+              }
+
+              t += 1;
             }
+
+        case #char "/";
+            token.type = .comment;
+            t += 1;
+
+            while t < max_t && <<t != #char "\n"  t += 1;
     }
 }
 

--- a/src/langs/js.jai
+++ b/src/langs/js.jai
@@ -448,7 +448,7 @@ OPERATIONS :: string.[
 KEYWORDS :: string.[
     "as", "async", "abstract", "arguments", "await", "break", "case", "catch", "class", "const", "continue", "debugger", "default",
     "delete", "do", "else", "enum", "eval", "export", "extends", "finally", "for", "from", "function", "if", "import", "in",
-    "instanceof", "interface", "let", "new", "of", "private", "protected", "public", "return", "static", "super", "switch",
+    "instanceof", "interface", "keyof", "let", "new", "of", "private", "protected", "public", "return", "static", "super", "switch",
     "throw", "try", "type", "typeof", "var", "while", "with", "yield",
 ];
 


### PR DESCRIPTION
- Added `keyof` keyword to the JS parser.
- Fixed a bug that made the last character in a CSS comment not have the correct color.
- Added support for single line CSS comments. These are available in SCSS.