### PR TITLE
Ui fonts settings

### DIFF
--- a/config/default.focus-config
+++ b/config/default.focus-config
@@ -337,8 +337,11 @@ Shift-Ctrl-F8               go_to_previous_build_error_on_the_side
 [[style]]
 
 [fonts]
-font:       default
-font_size:  14
+font:         default
+font_ui:      default
+font_ui_bold: default
+font_size:    14
+font_ui_size: 15
 
 [colors]
 background0:                            15212AFF

--- a/config/default_macos.focus-config
+++ b/config/default_macos.focus-config
@@ -320,8 +320,11 @@ Shift-Cmd-F8                    go_to_previous_build_error_on_the_side
 [[style]]
 
 [fonts]
-font:       default
-font_size:  14
+font:         default
+font_ui:      default
+font_ui_bold: default
+font_size:    14
+font_ui_size: 15
 
 [colors]
 background0:                            15212AFF

--- a/src/config.jai
+++ b/src/config.jai
@@ -259,28 +259,28 @@ reset_color_map_to_default :: () {
 apply_style :: (parsed: Parsed_Config) {
     // Fonts
     if parsed.font {
-        loaded_data, success := load_font_by_name(parsed.font, .font_main);
+        loaded_data, loaded_name, success := load_font_by_name(parsed.font, .font_main);
         if success {
             font_main_data = loaded_data;
-            font_main_name = parsed.font;
+            font_main_name = loaded_name;
         } else {
             add_user_error("Couldn't load font %", parsed.font);
         }
     }
     if parsed.font_ui {
-        loaded_data, success := load_font_by_name(parsed.font_ui, .font_ui);
+        loaded_data, loaded_name, success := load_font_by_name(parsed.font_ui, .font_ui);
         if success {
             font_ui_data = loaded_data;
-            font_ui_name = parsed.font_ui;
+            font_ui_name = loaded_name;
         } else {
             add_user_error("Couldn't load font %", parsed.font_ui);
         }
     }
     if parsed.font_ui_bold {
-        loaded_data, success := load_font_by_name(parsed.font_ui_bold, .font_ui_bold);
+        loaded_data, loaded_name, success := load_font_by_name(parsed.font_ui_bold, .font_ui_bold);
         if success {
             font_ui_bold_data = loaded_data;
-            font_ui_bold_name = parsed.font_ui_bold;
+            font_ui_bold_name = loaded_name;
         } else {
             add_user_error("Couldn't load font %", parsed.font_ui_bold);
         }
@@ -490,30 +490,30 @@ apply_config :: () {
                                                        //       keep pointers to old keymaps when the config is reloaded
 }
 
-load_font_by_name :: (name: string, kind: enum { font_main; font_ui; font_ui_bold; }) -> font_data: string, success: bool {
+load_font_by_name :: (name: string, kind: enum { font_main; font_ui; font_ui_bold; }) -> font_data: string, font_name: string, success: bool {
     if name == "default" {
         if kind == {
-            case .font_main;    return FONT_MAIN.data, true;
-            case .font_ui;      return FONT_UI.data, true;
-            case .font_ui_bold; return FONT_UI_BOLD.data, true;
+            case .font_main;    return FONT_MAIN.data   , FONT_MAIN.name   , true;
+            case .font_ui;      return FONT_UI.data     , FONT_UI.name     , true;
+            case .font_ui_bold; return FONT_UI_BOLD.data, FONT_UI_BOLD.name, true;
         }
     }
-        
+
     push_allocator(focus_allocator);  // we sometimes call this from within a temp allocator, but we will always want to persist fonts
 
     font_path := find_font_by_name(name);
     if font_path {
         cached_data, found := table_find(*font_cache, font_path);
-        if found return cached_data, true;
+        if found return cached_data, name, true;
 
         font_data, success := read_entire_file(font_path);
         if success {
             table_set(*font_cache, copy_string(font_path), font_data);
-            return font_data, true;
+            return font_data, name, true;
         }
     }
 
-    return "", false;
+    return "", name, false;
 }
 
 font_cache: Table(string, string);  // path -> file data

--- a/src/config.jai
+++ b/src/config.jai
@@ -259,28 +259,25 @@ reset_color_map_to_default :: () {
 apply_style :: (parsed: Parsed_Config) {
     // Fonts
     if parsed.font {
-        loaded_data, loaded_name, success := load_font_by_name(parsed.font, .font_main);
+        loaded_font, success := load_font_by_name(parsed.font, .main);
         if success {
-            font_main_data = loaded_data;
-            font_main_name = loaded_name;
+            loaded_fonts.main = loaded_font;
         } else {
             add_user_error("Couldn't load font %", parsed.font);
         }
     }
     if parsed.font_ui {
-        loaded_data, loaded_name, success := load_font_by_name(parsed.font_ui, .font_ui);
+        loaded_font, success := load_font_by_name(parsed.font_ui, .ui);
         if success {
-            font_ui_data = loaded_data;
-            font_ui_name = loaded_name;
+            loaded_fonts.ui = loaded_font;
         } else {
             add_user_error("Couldn't load font %", parsed.font_ui);
         }
     }
     if parsed.font_ui_bold {
-        loaded_data, loaded_name, success := load_font_by_name(parsed.font_ui_bold, .font_ui_bold);
+        loaded_font, success := load_font_by_name(parsed.font_ui_bold, .ui_bold);
         if success {
-            font_ui_bold_data = loaded_data;
-            font_ui_bold_name = loaded_name;
+            loaded_fonts.ui_bold = loaded_font;
         } else {
             add_user_error("Couldn't load font %", parsed.font_ui_bold);
         }
@@ -323,6 +320,7 @@ get_current_project_dir :: () -> string {
 
     return trim_right(path_strip_filename(project_config.path), "/");
 }
+
 
 #scope_file
 
@@ -490,12 +488,12 @@ apply_config :: () {
                                                        //       keep pointers to old keymaps when the config is reloaded
 }
 
-load_font_by_name :: (name: string, kind: enum { font_main; font_ui; font_ui_bold; }) -> font_data: string, font_name: string, success: bool {
+load_font_by_name :: (name: string, kind: enum { main; ui; ui_bold; }) -> Loaded_Font, success: bool {
     if name == "default" {
         if kind == {
-            case .font_main;    return FONT_MAIN.data   , FONT_MAIN.name   , true;
-            case .font_ui;      return FONT_UI.data     , FONT_UI.name     , true;
-            case .font_ui_bold; return FONT_UI_BOLD.data, FONT_UI_BOLD.name, true;
+            case .main;    return FONT_MAIN,    true;
+            case .ui;      return FONT_UI,      true;
+            case .ui_bold; return FONT_UI_BOLD, true;
         }
     }
 
@@ -503,20 +501,21 @@ load_font_by_name :: (name: string, kind: enum { font_main; font_ui; font_ui_bol
 
     font_path := find_font_by_name(name);
     if font_path {
-        cached_data, found := table_find(*font_cache, font_path);
-        if found return cached_data, name, true;
+        cached_font, found := table_find(*font_cache, font_path);
+        if found return cached_font, true;
 
         font_data, success := read_entire_file(font_path);
         if success {
-            table_set(*font_cache, copy_string(font_path), font_data);
-            return font_data, name, true;
+            loaded_font := Loaded_Font.{ copy_string(name), font_data };
+            table_set(*font_cache, copy_string(font_path), loaded_font);
+            return loaded_font, true;
         }
     }
 
-    return "", name, false;
+    return .{}, false;
 }
 
-font_cache: Table(string, string);  // path -> file data
+font_cache: Table(string, Loaded_Font);  // path -> loaded font
 
 #scope_export
 
@@ -540,6 +539,11 @@ Config :: struct {
 Style :: struct {
     theme: string;
     // TODO: add other things in there at some point
+}
+
+Loaded_Font :: struct {
+    name: string;
+    data: string;
 }
 
 Loaded_Config :: struct {

--- a/src/config.jai
+++ b/src/config.jai
@@ -259,10 +259,10 @@ reset_color_map_to_default :: () {
 apply_style :: (parsed: Parsed_Config) {
     // Fonts
     if parsed.font {
-        loaded_data, success := load_font_by_name(parsed.font, .font);
+        loaded_data, success := load_font_by_name(parsed.font, .font_main);
         if success {
-            main_font_data = loaded_data;
-            main_font_name = parsed.font;
+            font_main_data = loaded_data;
+            font_main_name = parsed.font;
         } else {
             add_user_error("Couldn't load font %", parsed.font);
         }
@@ -286,8 +286,8 @@ apply_style :: (parsed: Parsed_Config) {
         }
     }
     if parsed.font_size > 0 {
-        font_size = parsed.font_size;
-        default_font_size = font_size;
+        font_main_size = parsed.font_size;
+        default_font_main_size = font_main_size;
     }
     if parsed.font_ui_size > 0 {
         font_ui_size = parsed.font_ui_size;
@@ -490,10 +490,10 @@ apply_config :: () {
                                                        //       keep pointers to old keymaps when the config is reloaded
 }
 
-load_font_by_name :: (name: string, kind: enum { font; font_ui; font_ui_bold; }) -> font_data: string, success: bool {
+load_font_by_name :: (name: string, kind: enum { font_main; font_ui; font_ui_bold; }) -> font_data: string, success: bool {
     if name == "default" {
         if kind == {
-            case .font;         return FONT.data, true;
+            case .font_main;    return FONT_MAIN.data, true;
             case .font_ui;      return FONT_UI.data, true;
             case .font_ui_bold; return FONT_UI_BOLD.data, true;
         }

--- a/src/config.jai
+++ b/src/config.jai
@@ -259,7 +259,7 @@ reset_color_map_to_default :: () {
 apply_style :: (parsed: Parsed_Config) {
     // Fonts
     if parsed.font {
-        loaded_data, success := load_font_by_name(parsed.font);
+        loaded_data, success := load_font_by_name(parsed.font, .font);
         if success {
             main_font_data = loaded_data;
             main_font_name = parsed.font;
@@ -267,9 +267,31 @@ apply_style :: (parsed: Parsed_Config) {
             add_user_error("Couldn't load font %", parsed.font);
         }
     }
+    if parsed.font_ui {
+        loaded_data, success := load_font_by_name(parsed.font_ui, .font_ui);
+        if success {
+            font_ui_data = loaded_data;
+            font_ui_name = parsed.font_ui;
+        } else {
+            add_user_error("Couldn't load font %", parsed.font_ui);
+        }
+    }
+    if parsed.font_ui_bold {
+        loaded_data, success := load_font_by_name(parsed.font_ui_bold, .font_ui_bold);
+        if success {
+            font_ui_bold_data = loaded_data;
+            font_ui_bold_name = parsed.font_ui_bold;
+        } else {
+            add_user_error("Couldn't load font %", parsed.font_ui_bold);
+        }
+    }
     if parsed.font_size > 0 {
         font_size = parsed.font_size;
         default_font_size = font_size;
+    }
+    if parsed.font_ui_size > 0 {
+        font_ui_size = parsed.font_ui_size;
+        default_font_ui_size = font_ui_size;
     }
 
     apply_parsed_colors(parsed.colors);
@@ -468,9 +490,15 @@ apply_config :: () {
                                                        //       keep pointers to old keymaps when the config is reloaded
 }
 
-load_font_by_name :: (name: string) -> font_data: string, success: bool {
-    if name == "default" return FONT.data, true;
-
+load_font_by_name :: (name: string, kind: enum { font; font_ui; font_ui_bold; }) -> font_data: string, success: bool {
+    if name == "default" {
+        if kind == {
+            case .font;         return FONT.data, true;
+            case .font_ui;      return FONT_UI.data, true;
+            case .font_ui_bold; return FONT_UI_BOLD.data, true;
+        }
+    }
+        
     push_allocator(focus_allocator);  // we sometimes call this from within a temp allocator, but we will always want to persist fonts
 
     font_path := find_font_by_name(name);

--- a/src/config_parser.jai
+++ b/src/config_parser.jai
@@ -494,7 +494,7 @@ parse_style_line :: (using parser: *Config_Parser, line: string) -> success: boo
             setting, value := break_by_spaces(line);
             setting = trim_right(setting, ":");
 
-            font_settings := string.[ "font", "font_size" ];
+            font_settings := string.[ "font", "font_ui", "font_ui_bold", "font_size", "font_ui_size" ];
             if !array_find(font_settings, setting) {
                 add_highlight(parser, 0, setting.count, .error);
                 return true, tprint("Unknown font option '%'. Available options: ", setting, join(..font_settings, ", ",, temp));
@@ -510,6 +510,24 @@ parse_style_line :: (using parser: *Config_Parser, line: string) -> success: boo
                         result.config.font = "default";
                         return true, error_msg;
                     }
+                case "font_ui";
+                    found, error_msg := find_font_by_name(value);
+                    if found {
+                        result.config.font_ui = value;
+                    } else {
+                        add_highlight(parser, value.data - line.data, value.count, .error);
+                        result.config.font_ui = "default";
+                        return true, error_msg;
+                    }
+                case "font_ui_bold";
+                    found, error_msg := find_font_by_name(value);
+                    if found {
+                        result.config.font_ui_bold = value;
+                    } else {
+                        add_highlight(parser, value.data - line.data, value.count, .error);
+                        result.config.font_ui_bold = "default";
+                        return true, error_msg;
+                    }
                 case "font_size";
                     value_copy := value;
                     int_val, success := parse_int(*value_copy);
@@ -518,6 +536,16 @@ parse_style_line :: (using parser: *Config_Parser, line: string) -> success: boo
                     } else {
                         add_highlight(parser, value.data - line.data, value.count, .error);
                         result.config.font_size = DEFAULT_FONT_SIZE;
+                        return false, tprint("Couldn't parse '%' - expected a valid integer, got '%'", setting, value);
+                    }
+                case "font_ui_size";
+                    value_copy := value;
+                    int_val, success := parse_int(*value_copy);
+                    if success {
+                        result.config.font_ui_size = int_val;
+                    } else {
+                        add_highlight(parser, value.data - line.data, value.count, .error);
+                        result.config.font_ui_size = DEFAULT_FONT_UI_SIZE;
                         return false, tprint("Couldn't parse '%' - expected a valid integer, got '%'", setting, value);
                     }
             }
@@ -620,12 +648,18 @@ parse_style_line :: (using parser: *Config_Parser, line: string) -> success: boo
 
                         // Copy colors and font data (it points into the theme file data)
                         array_add(*result.config.colors, ..theme_parse_result.config.colors);
-                        result.config.font      = theme_parse_result.config.font;
-                        result.config.font_size = theme_parse_result.config.font_size;
+                        result.config.font         = theme_parse_result.config.font;
+                        result.config.font_ui      = theme_parse_result.config.font_ui;
+                        result.config.font_ui_bold = theme_parse_result.config.font_ui_bold;
+                        result.config.font_size    = theme_parse_result.config.font_size;
+                        result.config.font_ui_size = theme_parse_result.config.font_ui_size;
 
                         // If font details are not specified in the theme, assume default
-                        if !result.config.font      then result.config.font = "default";
-                        if !result.config.font_size then result.config.font_size = DEFAULT_FONT_SIZE;
+                        if !result.config.font         then result.config.font         = "default";
+                        if !result.config.font_ui      then result.config.font_ui      = "default";
+                        if !result.config.font_ui_bold then result.config.font_ui_bold = "default";
+                        if !result.config.font_size    then result.config.font_size    = DEFAULT_FONT_SIZE;
+                        if !result.config.font_ui_size then result.config.font_ui_size = DEFAULT_FONT_UI_SIZE;
                     }
                 case;
                     add_highlight(parser, 0, setting.count, .error);
@@ -1193,6 +1227,9 @@ Parsed_Config :: struct {
     theme: string;
     font: string;
     font_size: int;
+    font_ui: string;
+    font_ui_bold: string;
+    font_ui_size: int;
     colors:     [..] Parsed_Color;
     color_refs: [..] Color_Reference;  // @colorref: not finished
 

--- a/src/config_parser.jai
+++ b/src/config_parser.jai
@@ -535,7 +535,7 @@ parse_style_line :: (using parser: *Config_Parser, line: string) -> success: boo
                         result.config.font_size = int_val;
                     } else {
                         add_highlight(parser, value.data - line.data, value.count, .error);
-                        result.config.font_size = DEFAULT_FONT_SIZE;
+                        result.config.font_size = DEFAULT_FONT_MAIN_SIZE;
                         return false, tprint("Couldn't parse '%' - expected a valid integer, got '%'", setting, value);
                     }
                 case "font_ui_size";
@@ -658,7 +658,7 @@ parse_style_line :: (using parser: *Config_Parser, line: string) -> success: boo
                         if !result.config.font         then result.config.font         = "default";
                         if !result.config.font_ui      then result.config.font_ui      = "default";
                         if !result.config.font_ui_bold then result.config.font_ui_bold = "default";
-                        if !result.config.font_size    then result.config.font_size    = DEFAULT_FONT_SIZE;
+                        if !result.config.font_size    then result.config.font_size    = DEFAULT_FONT_MAIN_SIZE;
                         if !result.config.font_ui_size then result.config.font_ui_size = DEFAULT_FONT_UI_SIZE;
                     }
                 case;

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -1414,14 +1414,14 @@ draw_editor :: (editor_id: s64, main_area: Rect, status_bar_height: float, ui_id
             array_add(*selections, selection);
         }
 
-        draw_code(font, pen, code_lines, selections, start_col = hidden_chars_on_the_left, is_colored = buffer.tokens.count > 0);
+        draw_code(font_main, pen, code_lines, selections, start_col = hidden_chars_on_the_left, is_colored = buffer.tokens.count > 0);
 
         // Draw continuation markers for wrapped lines
         if line_wrap_is_active(editor) && !config.settings.show_line_numbers && !as_build_panel {
             Simp.set_shader_for_rects();
 
             radius   := char_x_advance / 4;
-            y_offset := (font.character_height - char_x_advance / 2) / 2;
+            y_offset := (font_main.character_height - char_x_advance / 2) / 2;
 
             for line_num : visible_lines_start .. visible_lines_end {
                 end_offset := get_line_end_offset(editor, buffer, line_num);
@@ -1462,7 +1462,7 @@ draw_editor :: (editor_id: s64, main_area: Rect, status_bar_height: float, ui_id
                 if cursor_as_block {
                     letter := get_char_at_offset_as_string(buffer, cursor.pos);
                     if letter != "\n" {
-                        Simp.draw_text(font, xx cursor_rect.x, xx (cursor_rect.y + (line_height - char_x_advance) / 2), letter, xx Color.CHAR_UNDER_CURSOR);
+                        Simp.draw_text(font_main, xx cursor_rect.x, xx (cursor_rect.y + (line_height - char_x_advance) / 2), letter, xx Color.CHAR_UNDER_CURSOR);
                     }
                 }
             }
@@ -1555,8 +1555,8 @@ draw_editor :: (editor_id: s64, main_area: Rect, status_bar_height: float, ui_id
 
                 if real_line_num != last_line_num {
                     active := array_find(active_lines, real_line_num);
-                    width := Simp.prepare_text(font, tprint("%", real_line_num + 1));
-                    Simp.draw_prepared_text(font, xx (x - width), xx y, color = ifx active then cast(u8) Color.UI_DEFAULT else cast(u8) Color.UI_DIM);
+                    width := Simp.prepare_text(font_main, tprint("%", real_line_num + 1));
+                    Simp.draw_prepared_text(font_main, xx (x - width), xx y, color = ifx active then cast(u8) Color.UI_DEFAULT else cast(u8) Color.UI_DIM);
                     last_line_num = real_line_num;
                 }
 
@@ -1565,8 +1565,8 @@ draw_editor :: (editor_id: s64, main_area: Rect, status_bar_height: float, ui_id
         } else {
             for line_num : visible_lines_start .. visible_lines_end {
                 active := array_find(active_lines, line_num);
-                width := Simp.prepare_text(font, tprint("%", line_num + 1));
-                Simp.draw_prepared_text(font, xx (x - width), xx y, color = ifx active then cast(u8) Color.UI_DEFAULT else cast(u8) Color.UI_DIM);
+                width := Simp.prepare_text(font_main, tprint("%", line_num + 1));
+                Simp.draw_prepared_text(font_main, xx (x - width), xx y, color = ifx active then cast(u8) Color.UI_DEFAULT else cast(u8) Color.UI_DIM);
                 y -= line_height;
             }
         }
@@ -1820,7 +1820,7 @@ draw_editor :: (editor_id: s64, main_area: Rect, status_bar_height: float, ui_id
                     pen.x = text_x;
                     if col_offset > 0 {
                         // Line was cut on the left, draw an ellipsis
-                        Simp.draw_text(font, xx pen.x, xx pen.y, "…", color = xx Color.UI_DIM);
+                        Simp.draw_text(font_main, xx pen.x, xx pen.y, "…", color = xx Color.UI_DIM);
                         pen.x += char_x_advance;
                     }
 
@@ -1840,7 +1840,7 @@ draw_editor :: (editor_id: s64, main_area: Rect, status_bar_height: float, ui_id
                         tokens := to_view(buffer.tokens, visible_offset_range.start, line_str.count);
                         code_lines: [1] Simp.Code_Line;
                         code_lines[0] = .{ line = line_str, tab_spaces = 0, tokens = xx tokens };
-                        draw_code(font, pen, code_lines, is_colored = buffer.tokens.count > 0, start_col = line_indent + col_offset);
+                        draw_code(font_main, pen, code_lines, is_colored = buffer.tokens.count > 0, start_col = line_indent + col_offset);
                     }
                 }
             }
@@ -3031,7 +3031,7 @@ draw_finder :: () {
                 pen.x = text_x;
                 if col_offset > 0 {
                     // Line was cut on the left, draw an ellipsis
-                    Simp.draw_text(font, xx pen.x, xx pen.y, "…", color = xx Color.UI_DIM);
+                    Simp.draw_text(font_main, xx pen.x, xx pen.y, "…", color = xx Color.UI_DIM);
                     pen.x += char_x_advance;
                 }
                 if buffer_needs_tokenizing(buffer) then retokenize(buffer);  // right before drawing
@@ -3052,7 +3052,7 @@ draw_finder :: () {
                     tokens := to_view(buffer.tokens, visible_range.start, line_str.count);
                     code_lines: [1] Simp.Code_Line;
                     code_lines[0] = .{ line = line_str, tab_spaces = 0, tokens = xx tokens };
-                    draw_code(font, pen, code_lines, is_colored = buffer.tokens.count > 0, start_col = line_indent + col_offset);
+                    draw_code(font_main, pen, code_lines, is_colored = buffer.tokens.count > 0, start_col = line_indent + col_offset);
                 }
             }
         }

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -1976,9 +1976,9 @@ draw_file_info :: (buffer: Buffer, width: float, padding: float, _pen: Vector2, 
 
     if buffer.modified {
         pen.x += width + padding;
-        width = xx Simp.prepare_text(font_icons_tiny, PEN_ICON);
-        y_padding := (font_icons.character_height - font_icons_tiny.character_height) / 4.0;
-        Simp.draw_prepared_text(font_icons_tiny, xx pen.x, xx (pen.y + y_padding), color = xx file_name_color);
+        width = xx Simp.prepare_text(font_icons_very_small, PEN_ICON);
+        y_padding := (font_icons.character_height - font_icons_very_small.character_height) / 4.0;
+        Simp.draw_prepared_text(font_icons_very_small, xx pen.x, xx (pen.y + y_padding), color = xx file_name_color);
     }
 
     // Maybe warnings

--- a/src/main.jai
+++ b/src/main.jai
@@ -441,21 +441,21 @@ maybe_execute_a_build_command :: (action: Action_Build) -> handled: bool {
 init_fonts_and_dependent_things :: () {
     push_allocator(focus_allocator);  // we sometimes call this from within a temp allocator
 
-    font_size    = clamp(font_size   , MIN_FONT_SIZE, MAX_FONT_SIZE);
-    font_ui_size = clamp(font_ui_size, MIN_FONT_SIZE, MAX_FONT_SIZE);
+    font_main_size = clamp(font_main_size, MIN_FONT_SIZE, MAX_FONT_SIZE);
+    font_ui_size   = clamp(font_ui_size  , MIN_FONT_SIZE, MAX_FONT_SIZE);
 
     delta := font_ui_size - DEFAULT_FONT_UI_SIZE;
 
-    font_icons_size         = clamp(DEFAULT_FONT_ICONS_SIZE         + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
-    font_icons_small_size   = clamp(DEFAULT_FONT_ICONS_SMALL_SIZE   + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
-    font_icons_tiny_size    = clamp(DEFAULT_FONT_ICONS_TINY_SIZE    + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
     font_ui_big_size        = clamp(DEFAULT_FONT_UI_BIG_SIZE        + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
     font_ui_medium_size     = clamp(DEFAULT_FONT_UI_MEDIUM_SIZE     + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
     font_ui_small_size      = clamp(DEFAULT_FONT_UI_SMALL_SIZE      + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
     font_ui_very_small_size = clamp(DEFAULT_FONT_UI_VERY_SMALL_SIZE + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
+    font_icons_size         = clamp(DEFAULT_FONT_ICONS_SIZE         + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
+    font_icons_small_size   = clamp(DEFAULT_FONT_ICONS_SMALL_SIZE   + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
+    font_icons_tiny_size    = clamp(DEFAULT_FONT_ICONS_TINY_SIZE    + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
 
-    font = Simp.get_font_at_size(main_font_name, main_font_data, cast(int) (font_size * dpi_scale));
-    assert(font != null, "Couldn't init main text font\n");
+    font_main = Simp.get_font_at_size(font_main_name, font_main_data, cast(int) (font_main_size * dpi_scale));
+    assert(font_main != null, "Couldn't init main text font\n");
 
     font_ui = Simp.get_font_at_size(font_ui_name, font_ui_data, cast(int) (font_ui_size * dpi_scale));
     assert(font_ui != null, "Couldn't init main ui font\n");
@@ -492,7 +492,7 @@ init_fonts_and_dependent_things :: () {
     // we have all the font atlases loaded in the GPU memory once
     // (TODO: maybe there's an easy way for Simp to only update textures on flush?)
     COMMON_CHARS :: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789… ~!@#$%^&*()-|\"':;_+={}[]\\/`,.<>?АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧЩЪЫЬЭЮЯабвгдеёжзийклмнопрстуфхцчщъыьэюя¶•";
-    Simp.prepare_text(font,             COMMON_CHARS);
+    Simp.prepare_text(font_main,        COMMON_CHARS);
     Simp.prepare_text(font_ui,          COMMON_CHARS);
     Simp.prepare_text(font_ui_bold,     COMMON_CHARS);
     Simp.prepare_text(font_ui_small,    COMMON_CHARS);
@@ -509,16 +509,16 @@ init_fonts_and_dependent_things :: () {
     append(*common_icons, XMARK_ICON);
     icons_string := builder_to_string(*common_icons,, allocator = temp);
 
-    Simp.prepare_text(font_icons,       icons_string);
+    Simp.prepare_text(font_icons,      icons_string);
     Simp.prepare_text(font_icons_tiny, icons_string);
 
     // Things that depend on char size
-    char_size       = cast(float) font.em_width;
-    char_x_advance  = cast(float) font.x_advance;
+    char_size       = cast(float) font_main.em_width;
+    char_x_advance  = cast(float) font_main.x_advance;
     old_line_height = line_height;
-    line_height     = floor(cast(float) font.default_line_spacing * cast(float)config.settings.line_height_scale_percent / 100.0);
+    line_height     = floor(cast(float) font_main.default_line_spacing * cast(float) config.settings.line_height_scale_percent / 100.0);
     scrollbar_size  = floor(1.5 * char_size);
-    rounding_radius = floor(char_size / 2);
+    rounding_radius       = floor(char_size / 2);
     rounding_radius_large = floor(char_size / 1.5);
     rounding_radius_small = floor(char_size / 3);
 }
@@ -622,8 +622,8 @@ open_another_editor_instance :: () {
 
 increase_font_size :: () {
     should_reinit_fonts: bool;
-    if (font_size + 1) <= MAX_FONT_SIZE {
-        font_size += 1;
+    if (font_main_size + 1) <= MAX_FONT_SIZE {
+        font_main_size += 1;
         should_reinit_fonts = true;
     }
     if (font_ui_size + 1) <= MAX_FONT_SIZE {
@@ -635,8 +635,8 @@ increase_font_size :: () {
 
 decrease_font_size :: () {
     should_reinit_fonts: bool;
-    if (font_size - 1) >= MIN_FONT_SIZE {
-        font_size -= 1;
+    if (font_main_size - 1) >= MIN_FONT_SIZE {
+        font_main_size -= 1;
         should_reinit_fonts = true;
     }
     if (font_ui_size - 1) >= MIN_FONT_SIZE {
@@ -647,8 +647,8 @@ decrease_font_size :: () {
 }
 
 reset_font_size_to_default :: () {
-    font_size    = default_font_size;
-    font_ui_size = default_font_ui_size;
+    font_main_size = default_font_main_size;
+    font_ui_size   = default_font_ui_size;
     init_fonts_and_dependent_things();
 }
 
@@ -807,7 +807,7 @@ XMARK_ICON          :: #run to_string(*convert_utf32_to_utf8(0xf057));
 
 TAB_SIZE: s32 = 4;
 
-font:               *Simp.Dynamic_Font;
+font_main:          *Simp.Dynamic_Font;
 font_ui:            *Simp.Dynamic_Font;
 font_ui_bold:       *Simp.Dynamic_Font;
 font_ui_big:        *Simp.Dynamic_Font;
@@ -818,7 +818,7 @@ font_icons:         *Simp.Dynamic_Font;
 font_icons_small:   *Simp.Dynamic_Font;
 font_icons_tiny:    *Simp.Dynamic_Font;
 
-DEFAULT_FONT_SIZE               :: 14;
+DEFAULT_FONT_MAIN_SIZE          :: 14;
 DEFAULT_FONT_UI_SIZE            :: 15;
 DEFAULT_FONT_UI_BIG_SIZE        :: 28;
 DEFAULT_FONT_UI_MEDIUM_SIZE     :: 18;
@@ -828,8 +828,8 @@ DEFAULT_FONT_ICONS_SIZE         :: 16;
 DEFAULT_FONT_ICONS_SMALL_SIZE   :: 12;
 DEFAULT_FONT_ICONS_TINY_SIZE    :: 8;
 
-main_font_name := "default";
-main_font_data := #run FONT.data;
+font_main_name := "default";
+font_main_data := #run FONT_MAIN.data;
 
 font_ui_name := "default";
 font_ui_data := #run FONT_UI.data;
@@ -838,11 +838,11 @@ font_ui_bold_name := "default";
 font_ui_bold_data := #run FONT_UI_BOLD.data;
 
 // can be changed in the config file
-default_font_size       := DEFAULT_FONT_SIZE;
+default_font_main_size  := DEFAULT_FONT_MAIN_SIZE;
 default_font_ui_size    := DEFAULT_FONT_UI_SIZE;
 
-// when changing font size, we change just font_size and font_ui_size and then derive the other ones from it
-font_size               := DEFAULT_FONT_SIZE;  
+// when changing font size, we change font_main_size and font_ui_size and then derive the other ones from it
+font_main_size          := DEFAULT_FONT_MAIN_SIZE;  
 font_ui_size            := DEFAULT_FONT_UI_SIZE;
 font_ui_big_size        := DEFAULT_FONT_UI_BIG_SIZE;
 font_ui_medium_size     := DEFAULT_FONT_UI_MEDIUM_SIZE;
@@ -1063,7 +1063,7 @@ DOUBLE_CLICK_SPEED     :: 0.3;  // how many seconds between clicks to consider i
 DOUBLE_CLICK_TOLERANCE :: 2;    // how many pixels between the click locations are allowed
 
 // Embed default fonts
-FONT         :: #run load_font("FiraCode-Retina.ttf");
+FONT_MAIN    :: #run load_font("FiraCode-Retina.ttf");
 FONT_UI      :: #run load_font("OpenSans-Regular.ttf");
 FONT_UI_BOLD :: #run load_font("OpenSans-SemiBold.ttf");
 FONT_ICONS   :: #run load_font("font-awesome/Font Awesome 6 Free-Solid-900.otf");

--- a/src/main.jai
+++ b/src/main.jai
@@ -829,13 +829,13 @@ DEFAULT_FONT_ICONS_SIZE            :: 16;
 DEFAULT_FONT_ICONS_SMALL_SIZE      :: 12;
 DEFAULT_FONT_ICONS_VERY_SMALL_SIZE :: 8;
 
-font_main_name := "default";
-font_main_data := #run FONT_MAIN.data;
+font_main_name    := #run FONT_MAIN.name;
+font_main_data    := #run FONT_MAIN.data;
 
-font_ui_name := "default";
-font_ui_data := #run FONT_UI.data;
+font_ui_name      := #run FONT_UI.name;
+font_ui_data      := #run FONT_UI.data;
 
-font_ui_bold_name := "default";
+font_ui_bold_name := #run FONT_UI_BOLD.name;
 font_ui_bold_data := #run FONT_UI_BOLD.data;
 
 // can be changed in the config file

--- a/src/main.jai
+++ b/src/main.jai
@@ -441,39 +441,41 @@ maybe_execute_a_build_command :: (action: Action_Build) -> handled: bool {
 init_fonts_and_dependent_things :: () {
     push_allocator(focus_allocator);  // we sometimes call this from within a temp allocator
 
-    font_size = clamp(font_size, MIN_FONT_SIZE, MAX_FONT_SIZE);
-    delta := font_size - DEFAULT_FONT_SIZE;
-    font_ui_size            = clamp(DEFAULT_FONT_UI_SIZE            + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
+    font_size    = clamp(font_size   , MIN_FONT_SIZE, MAX_FONT_SIZE);
+    font_ui_size = clamp(font_ui_size, MIN_FONT_SIZE, MAX_FONT_SIZE);
+
+    delta := font_ui_size - DEFAULT_FONT_UI_SIZE;
+
+    font_icons_size         = clamp(DEFAULT_FONT_ICONS_SIZE         + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
+    font_icons_small_size   = clamp(DEFAULT_FONT_ICONS_SMALL_SIZE   + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
+    font_icons_tiny_size    = clamp(DEFAULT_FONT_ICONS_TINY_SIZE    + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
     font_ui_big_size        = clamp(DEFAULT_FONT_UI_BIG_SIZE        + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
     font_ui_medium_size     = clamp(DEFAULT_FONT_UI_MEDIUM_SIZE     + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
     font_ui_small_size      = clamp(DEFAULT_FONT_UI_SMALL_SIZE      + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
     font_ui_very_small_size = clamp(DEFAULT_FONT_UI_VERY_SMALL_SIZE + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
-    font_icons_size         = clamp(DEFAULT_FONT_ICONS_SIZE         + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
-    font_icons_small_size   = clamp(DEFAULT_FONT_ICONS_SMALL_SIZE   + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
-    font_icons_tiny_size    = clamp(DEFAULT_FONT_ICONS_TINY_SIZE    + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
 
     font = Simp.get_font_at_size(main_font_name, main_font_data, cast(int) (font_size * dpi_scale));
     assert(font != null, "Couldn't init main text font\n");
 
-    font_ui = Simp.get_font_at_size(FONT_UI.name, FONT_UI.data, cast(int) (font_ui_size * dpi_scale));
+    font_ui = Simp.get_font_at_size(font_ui_name, font_ui_data, cast(int) (font_ui_size * dpi_scale));
     assert(font_ui != null, "Couldn't init main ui font\n");
     font_ui_line_height = cast(float) font_ui.default_line_spacing;
 
-    font_ui_big = Simp.get_font_at_size(FONT_UI.name, FONT_UI.data, cast(int) (font_ui_big_size * dpi_scale));
+    font_ui_big = Simp.get_font_at_size(font_ui_name, font_ui_data, cast(int) (font_ui_big_size * dpi_scale));
     assert(font_ui_big != null, "Couldn't init big ui font\n");
     font_ui_big_line_height = cast(float) font_ui_big.default_line_spacing;
 
-    font_ui_medium = Simp.get_font_at_size(FONT_UI.name, FONT_UI.data, cast(int) (font_ui_medium_size * dpi_scale));
+    font_ui_medium = Simp.get_font_at_size(font_ui_name, font_ui_data, cast(int) (font_ui_medium_size * dpi_scale));
     assert(font_ui_medium != null, "Couldn't init medium ui font\n");
     font_ui_medium_line_height = cast(float) font_ui_medium.default_line_spacing;
 
-    font_ui_bold = Simp.get_font_at_size(FONT_UI_BOLD.name, FONT_UI_BOLD.data, cast(int) (font_ui_size * dpi_scale));
+    font_ui_bold = Simp.get_font_at_size(font_ui_bold_name, font_ui_bold_data, cast(int) (font_ui_size * dpi_scale));
     assert(font_ui_bold != null, "Couldn't init bold ui font\n");
 
-    font_ui_small = Simp.get_font_at_size(FONT_UI.name, FONT_UI.data, cast(int) (font_ui_small_size * dpi_scale));
+    font_ui_small = Simp.get_font_at_size(font_ui_name, font_ui_data, cast(int) (font_ui_small_size * dpi_scale));
     assert(font_ui_small != null, "Couldn't init small ui font\n");
 
-    font_ui_very_small = Simp.get_font_at_size(FONT_UI.name, FONT_UI.data, cast(int) (font_ui_very_small_size * dpi_scale));
+    font_ui_very_small = Simp.get_font_at_size(font_ui_name, font_ui_data, cast(int) (font_ui_very_small_size * dpi_scale));
     assert(font_ui_very_small != null, "Couldn't init small ui font\n");
 
     font_icons = Simp.get_font_at_size(FONT_ICONS.name, FONT_ICONS.data, cast(int) (font_icons_size * dpi_scale));
@@ -619,21 +621,34 @@ open_another_editor_instance :: () {
 }
 
 increase_font_size :: () {
+    should_reinit_fonts: bool;
     if (font_size + 1) <= MAX_FONT_SIZE {
         font_size += 1;
-        init_fonts_and_dependent_things();
+        should_reinit_fonts = true;
     }
+    if (font_ui_size + 1) <= MAX_FONT_SIZE {
+        font_ui_size += 1;
+        should_reinit_fonts = true;
+    }
+    if should_reinit_fonts init_fonts_and_dependent_things();
 }
 
 decrease_font_size :: () {
+    should_reinit_fonts: bool;
     if (font_size - 1) >= MIN_FONT_SIZE {
         font_size -= 1;
-        init_fonts_and_dependent_things();
+        should_reinit_fonts = true;
     }
+    if (font_ui_size - 1) >= MIN_FONT_SIZE {
+        font_ui_size -= 1;
+        should_reinit_fonts = true;
+    }
+    if should_reinit_fonts init_fonts_and_dependent_things();
 }
 
 reset_font_size_to_default :: () {
-    font_size = default_font_size;
+    font_size    = default_font_size;
+    font_ui_size = default_font_ui_size;
     init_fonts_and_dependent_things();
 }
 
@@ -816,9 +831,18 @@ DEFAULT_FONT_ICONS_TINY_SIZE    :: 8;
 main_font_name := "default";
 main_font_data := #run FONT.data;
 
-default_font_size       := DEFAULT_FONT_SIZE;  // can be changed in the config
+font_ui_name := "default";
+font_ui_data := #run FONT_UI.data;
 
-font_size               := DEFAULT_FONT_SIZE;  // when changing font size, we change just this one and then derive the other ones from it
+font_ui_bold_name := "default";
+font_ui_bold_data := #run FONT_UI_BOLD.data;
+
+// can be changed in the config file
+default_font_size       := DEFAULT_FONT_SIZE;
+default_font_ui_size    := DEFAULT_FONT_UI_SIZE;
+
+// when changing font size, we change just font_size and font_ui_size and then derive the other ones from it
+font_size               := DEFAULT_FONT_SIZE;  
 font_ui_size            := DEFAULT_FONT_UI_SIZE;
 font_ui_big_size        := DEFAULT_FONT_UI_BIG_SIZE;
 font_ui_medium_size     := DEFAULT_FONT_UI_MEDIUM_SIZE;

--- a/src/main.jai
+++ b/src/main.jai
@@ -454,28 +454,28 @@ init_fonts_and_dependent_things :: () {
     font_icons_small_size      = clamp(DEFAULT_FONT_ICONS_SMALL_SIZE      + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
     font_icons_very_small_size = clamp(DEFAULT_FONT_ICONS_VERY_SMALL_SIZE + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
 
-    font_main = Simp.get_font_at_size(font_main_name, font_main_data, cast(int) (font_main_size * dpi_scale));
+    font_main = Simp.get_font_at_size(loaded_fonts.main.name, loaded_fonts.main.data, cast(int) (font_main_size * dpi_scale));
     assert(font_main != null, "Couldn't init main text font\n");
 
-    font_ui = Simp.get_font_at_size(font_ui_name, font_ui_data, cast(int) (font_ui_size * dpi_scale));
+    font_ui = Simp.get_font_at_size(loaded_fonts.ui.name, loaded_fonts.ui.data, cast(int) (font_ui_size * dpi_scale));
     assert(font_ui != null, "Couldn't init main ui font\n");
     font_ui_line_height = cast(float) font_ui.default_line_spacing;
 
-    font_ui_big = Simp.get_font_at_size(font_ui_name, font_ui_data, cast(int) (font_ui_big_size * dpi_scale));
+    font_ui_big = Simp.get_font_at_size(loaded_fonts.ui.name, loaded_fonts.ui.data, cast(int) (font_ui_big_size * dpi_scale));
     assert(font_ui_big != null, "Couldn't init big ui font\n");
     font_ui_big_line_height = cast(float) font_ui_big.default_line_spacing;
 
-    font_ui_medium = Simp.get_font_at_size(font_ui_name, font_ui_data, cast(int) (font_ui_medium_size * dpi_scale));
+    font_ui_medium = Simp.get_font_at_size(loaded_fonts.ui.name, loaded_fonts.ui.data, cast(int) (font_ui_medium_size * dpi_scale));
     assert(font_ui_medium != null, "Couldn't init medium ui font\n");
     font_ui_medium_line_height = cast(float) font_ui_medium.default_line_spacing;
 
-    font_ui_bold = Simp.get_font_at_size(font_ui_bold_name, font_ui_bold_data, cast(int) (font_ui_size * dpi_scale));
+    font_ui_bold = Simp.get_font_at_size(loaded_fonts.ui_bold.name, loaded_fonts.ui_bold.data, cast(int) (font_ui_size * dpi_scale));
     assert(font_ui_bold != null, "Couldn't init bold ui font\n");
 
-    font_ui_small = Simp.get_font_at_size(font_ui_name, font_ui_data, cast(int) (font_ui_small_size * dpi_scale));
+    font_ui_small = Simp.get_font_at_size(loaded_fonts.ui.name, loaded_fonts.ui.data, cast(int) (font_ui_small_size * dpi_scale));
     assert(font_ui_small != null, "Couldn't init small ui font\n");
 
-    font_ui_very_small = Simp.get_font_at_size(font_ui_name, font_ui_data, cast(int) (font_ui_very_small_size * dpi_scale));
+    font_ui_very_small = Simp.get_font_at_size(loaded_fonts.ui.name, loaded_fonts.ui.data, cast(int) (font_ui_very_small_size * dpi_scale));
     assert(font_ui_very_small != null, "Couldn't init very small ui font\n");
 
     font_icons = Simp.get_font_at_size(FONT_ICONS.name, FONT_ICONS.data, cast(int) (font_icons_size * dpi_scale));
@@ -829,14 +829,11 @@ DEFAULT_FONT_ICONS_SIZE            :: 16;
 DEFAULT_FONT_ICONS_SMALL_SIZE      :: 12;
 DEFAULT_FONT_ICONS_VERY_SMALL_SIZE :: 8;
 
-font_main_name    := #run FONT_MAIN.name;
-font_main_data    := #run FONT_MAIN.data;
-
-font_ui_name      := #run FONT_UI.name;
-font_ui_data      := #run FONT_UI.data;
-
-font_ui_bold_name := #run FONT_UI_BOLD.name;
-font_ui_bold_data := #run FONT_UI_BOLD.data;
+loaded_fonts: struct {
+    main:    Loaded_Font = FONT_MAIN;
+    ui:      Loaded_Font = FONT_UI;
+    ui_bold: Loaded_Font = FONT_UI_BOLD;
+};
 
 // can be changed in the config file
 default_font_main_size  := DEFAULT_FONT_MAIN_SIZE;
@@ -1069,22 +1066,22 @@ FONT_UI      :: #run load_font("OpenSans-Regular.ttf");
 FONT_UI_BOLD :: #run load_font("OpenSans-SemiBold.ttf");
 FONT_ICONS   :: #run load_font("font-awesome/Font Awesome 6 Free-Solid-900.otf");
 
-MIN_FONT_SIZE :: 4;
-MAX_FONT_SIZE :: 30;  // setting a larger size has caused freetype to crash - not sure yet why.
-                      // Probably we don't give it enough memory for a glyph bitmap when rendering it?
+#scope_file
 
-load_font :: (name: string) -> Embedded_Font {
+load_font :: (name: string) -> Loaded_Font {
     path := tprint("fonts/%", name);
     data, success := read_entire_file(path);
     assert(success, "Couldn't load font '%'", path);
 
-    return Embedded_Font.{ name = name, data = data};
+    return Loaded_Font.{ name = name, data = data};
 }
 
-Embedded_Font :: struct {
-    name: string;
-    data: string;
-}
+#scope_export
+
+MIN_FONT_SIZE :: 4;
+MAX_FONT_SIZE :: 30;  // setting a larger size has caused freetype to crash - not sure yet why.
+                      // Probably we don't give it enough memory for a glyph bitmap when rendering it?
+
 
 DEBUG_FILE_REFRESH :: false;  // TODO: remove when done debugging
 DEBUG_MEMORY_LEAKS :: false;

--- a/src/main.jai
+++ b/src/main.jai
@@ -446,13 +446,13 @@ init_fonts_and_dependent_things :: () {
 
     delta := font_ui_size - DEFAULT_FONT_UI_SIZE;
 
-    font_ui_big_size        = clamp(DEFAULT_FONT_UI_BIG_SIZE        + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
-    font_ui_medium_size     = clamp(DEFAULT_FONT_UI_MEDIUM_SIZE     + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
-    font_ui_small_size      = clamp(DEFAULT_FONT_UI_SMALL_SIZE      + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
-    font_ui_very_small_size = clamp(DEFAULT_FONT_UI_VERY_SMALL_SIZE + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
-    font_icons_size         = clamp(DEFAULT_FONT_ICONS_SIZE         + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
-    font_icons_small_size   = clamp(DEFAULT_FONT_ICONS_SMALL_SIZE   + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
-    font_icons_tiny_size    = clamp(DEFAULT_FONT_ICONS_TINY_SIZE    + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
+    font_ui_big_size           = clamp(DEFAULT_FONT_UI_BIG_SIZE           + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
+    font_ui_medium_size        = clamp(DEFAULT_FONT_UI_MEDIUM_SIZE        + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
+    font_ui_small_size         = clamp(DEFAULT_FONT_UI_SMALL_SIZE         + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
+    font_ui_very_small_size    = clamp(DEFAULT_FONT_UI_VERY_SMALL_SIZE    + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
+    font_icons_size            = clamp(DEFAULT_FONT_ICONS_SIZE            + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
+    font_icons_small_size      = clamp(DEFAULT_FONT_ICONS_SMALL_SIZE      + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
+    font_icons_very_small_size = clamp(DEFAULT_FONT_ICONS_VERY_SMALL_SIZE + delta, MIN_FONT_SIZE, MAX_FONT_SIZE);
 
     font_main = Simp.get_font_at_size(font_main_name, font_main_data, cast(int) (font_main_size * dpi_scale));
     assert(font_main != null, "Couldn't init main text font\n");
@@ -476,16 +476,16 @@ init_fonts_and_dependent_things :: () {
     assert(font_ui_small != null, "Couldn't init small ui font\n");
 
     font_ui_very_small = Simp.get_font_at_size(font_ui_name, font_ui_data, cast(int) (font_ui_very_small_size * dpi_scale));
-    assert(font_ui_very_small != null, "Couldn't init small ui font\n");
+    assert(font_ui_very_small != null, "Couldn't init very small ui font\n");
 
     font_icons = Simp.get_font_at_size(FONT_ICONS.name, FONT_ICONS.data, cast(int) (font_icons_size * dpi_scale));
     assert(font_icons != null, "Couldn't init main icon font\n");
 
     font_icons_small = Simp.get_font_at_size(FONT_ICONS.name, FONT_ICONS.data, cast(int) (font_icons_small_size * dpi_scale));
-    assert(font_icons_small != null, "Couldn't init main icon font\n");
+    assert(font_icons_small != null, "Couldn't init small icon font\n");
 
-    font_icons_tiny = Simp.get_font_at_size(FONT_ICONS.name, FONT_ICONS.data, cast(int) (font_icons_tiny_size * dpi_scale));
-    assert(font_icons_tiny != null, "Couldn't init tiny icon font\n");
+    font_icons_very_small = Simp.get_font_at_size(FONT_ICONS.name, FONT_ICONS.data, cast(int) (font_icons_very_small_size * dpi_scale));
+    assert(font_icons_very_small != null, "Couldn't init very small icon font\n");
 
     // WORKAROUND:
     // Make a dummy call with most common chars for each font so that
@@ -509,15 +509,16 @@ init_fonts_and_dependent_things :: () {
     append(*common_icons, XMARK_ICON);
     icons_string := builder_to_string(*common_icons,, allocator = temp);
 
-    Simp.prepare_text(font_icons,      icons_string);
-    Simp.prepare_text(font_icons_tiny, icons_string);
+    Simp.prepare_text(font_icons,            icons_string);
+    Simp.prepare_text(font_icons_small,      icons_string);
+    Simp.prepare_text(font_icons_very_small, icons_string);
 
     // Things that depend on char size
-    char_size       = cast(float) font_main.em_width;
-    char_x_advance  = cast(float) font_main.x_advance;
-    old_line_height = line_height;
-    line_height     = floor(cast(float) font_main.default_line_spacing * cast(float) config.settings.line_height_scale_percent / 100.0);
-    scrollbar_size  = floor(1.5 * char_size);
+    char_size             = cast(float) font_main.em_width;
+    char_x_advance        = cast(float) font_main.x_advance;
+    old_line_height       = line_height;
+    line_height           = floor(cast(float) font_main.default_line_spacing * cast(float) config.settings.line_height_scale_percent / 100.0);
+    scrollbar_size        = floor(1.5 * char_size);
     rounding_radius       = floor(char_size / 2);
     rounding_radius_large = floor(char_size / 1.5);
     rounding_radius_small = floor(char_size / 3);
@@ -807,26 +808,26 @@ XMARK_ICON          :: #run to_string(*convert_utf32_to_utf8(0xf057));
 
 TAB_SIZE: s32 = 4;
 
-font_main:          *Simp.Dynamic_Font;
-font_ui:            *Simp.Dynamic_Font;
-font_ui_bold:       *Simp.Dynamic_Font;
-font_ui_big:        *Simp.Dynamic_Font;
-font_ui_small:      *Simp.Dynamic_Font;
-font_ui_very_small: *Simp.Dynamic_Font;
-font_ui_medium:     *Simp.Dynamic_Font;
-font_icons:         *Simp.Dynamic_Font;
-font_icons_small:   *Simp.Dynamic_Font;
-font_icons_tiny:    *Simp.Dynamic_Font;
+font_main:             *Simp.Dynamic_Font;
+font_ui:               *Simp.Dynamic_Font;
+font_ui_bold:          *Simp.Dynamic_Font;
+font_ui_big:           *Simp.Dynamic_Font;
+font_ui_small:         *Simp.Dynamic_Font;
+font_ui_very_small:    *Simp.Dynamic_Font;
+font_ui_medium:        *Simp.Dynamic_Font;
+font_icons:            *Simp.Dynamic_Font;
+font_icons_small:      *Simp.Dynamic_Font;
+font_icons_very_small: *Simp.Dynamic_Font;
 
-DEFAULT_FONT_MAIN_SIZE          :: 14;
-DEFAULT_FONT_UI_SIZE            :: 15;
-DEFAULT_FONT_UI_BIG_SIZE        :: 28;
-DEFAULT_FONT_UI_MEDIUM_SIZE     :: 18;
-DEFAULT_FONT_UI_SMALL_SIZE      :: 14;
-DEFAULT_FONT_UI_VERY_SMALL_SIZE :: 12;
-DEFAULT_FONT_ICONS_SIZE         :: 16;
-DEFAULT_FONT_ICONS_SMALL_SIZE   :: 12;
-DEFAULT_FONT_ICONS_TINY_SIZE    :: 8;
+DEFAULT_FONT_MAIN_SIZE             :: 14;
+DEFAULT_FONT_UI_SIZE               :: 15;
+DEFAULT_FONT_UI_BIG_SIZE           :: 28;
+DEFAULT_FONT_UI_MEDIUM_SIZE        :: 18;
+DEFAULT_FONT_UI_SMALL_SIZE         :: 14;
+DEFAULT_FONT_UI_VERY_SMALL_SIZE    :: 12;
+DEFAULT_FONT_ICONS_SIZE            :: 16;
+DEFAULT_FONT_ICONS_SMALL_SIZE      :: 12;
+DEFAULT_FONT_ICONS_VERY_SMALL_SIZE :: 8;
 
 font_main_name := "default";
 font_main_data := #run FONT_MAIN.data;
@@ -842,15 +843,15 @@ default_font_main_size  := DEFAULT_FONT_MAIN_SIZE;
 default_font_ui_size    := DEFAULT_FONT_UI_SIZE;
 
 // when changing font size, we change font_main_size and font_ui_size and then derive the other ones from it
-font_main_size          := DEFAULT_FONT_MAIN_SIZE;  
-font_ui_size            := DEFAULT_FONT_UI_SIZE;
-font_ui_big_size        := DEFAULT_FONT_UI_BIG_SIZE;
-font_ui_medium_size     := DEFAULT_FONT_UI_MEDIUM_SIZE;
-font_ui_small_size      := DEFAULT_FONT_UI_SMALL_SIZE;
-font_ui_very_small_size := DEFAULT_FONT_UI_VERY_SMALL_SIZE;
-font_icons_size         := DEFAULT_FONT_ICONS_SIZE;
-font_icons_small_size   := DEFAULT_FONT_ICONS_SMALL_SIZE;
-font_icons_tiny_size    := DEFAULT_FONT_ICONS_TINY_SIZE;
+font_main_size             := DEFAULT_FONT_MAIN_SIZE;
+font_ui_size               := DEFAULT_FONT_UI_SIZE;
+font_ui_big_size           := DEFAULT_FONT_UI_BIG_SIZE;
+font_ui_medium_size        := DEFAULT_FONT_UI_MEDIUM_SIZE;
+font_ui_small_size         := DEFAULT_FONT_UI_SMALL_SIZE;
+font_ui_very_small_size    := DEFAULT_FONT_UI_VERY_SMALL_SIZE;
+font_icons_size            := DEFAULT_FONT_ICONS_SIZE;
+font_icons_small_size      := DEFAULT_FONT_ICONS_SMALL_SIZE;
+font_icons_very_small_size := DEFAULT_FONT_ICONS_VERY_SMALL_SIZE;
 
 // Depend on font size
 char_size:                  float;


### PR DESCRIPTION
- New settings to modify the ui / bold ui fonts families and the ui font size
- Rename `font` to `font_main` in the codebase for clarity (the setting is still called font)
- Rename `icons_tiny` to `icons_very_small` to match with  `ui_very_small` 


https://github.com/user-attachments/assets/0c2e387d-30b3-46d0-b9f3-2c4d440b27e8
