### PR TITLE
Experimental quick cursor navigation

### DIFF
--- a/config/default.focus-config
+++ b/config/default.focus-config
@@ -64,6 +64,7 @@ show_cursors_off_screen:                            true
 persist_local_search_results:                       false  # if true, search results will stay highlighted and you have to dismiss them using the `escape` action
 load_most_recent_project_on_start:                  false
 projects_sorting_order:                             most_recent_first
+grid_navigation_display_duration:                   2.0
 
 build_panel_stays_in_one_place:                     false  # if false, the build panel will flip to the inactive pane in two pane layouts
 build_panel_line_wrap_always_on:                    true
@@ -202,6 +203,17 @@ Ctrl-Shift-Enter            new_line_above_without_breaking
 NumpadEnter                 break_line
 Ctrl-NumpadEnter            new_line_below_without_breaking
 Ctrl-Shift-NumpadEnter      new_line_above_without_breaking
+
+{Shift}-Ctrl-Numpad0        grid_navigation_reset
+{Shift}-Ctrl-Numpad1        grid_navigation_southwest
+{Shift}-Ctrl-Numpad2        grid_navigation_south
+{Shift}-Ctrl-Numpad3        grid_navigation_southeast
+{Shift}-Ctrl-Numpad4        grid_navigation_west
+{Shift}-Ctrl-Numpad5        grid_navigation_center
+{Shift}-Ctrl-Numpad6        grid_navigation_east
+{Shift}-Ctrl-Numpad7        grid_navigation_northwest
+{Shift}-Ctrl-Numpad8        grid_navigation_north
+{Shift}-Ctrl-Numpad9        grid_navigation_northeast
 
 Ctrl-1                      switch_to_left_editor
 Ctrl-2                      switch_to_right_editor

--- a/config/default_macos.focus-config
+++ b/config/default_macos.focus-config
@@ -61,6 +61,7 @@ show_cursors_off_screen:                            true
 persist_local_search_results:                       false  # if true, search results will stay highlighted and you have to dismiss them using the `escape` action
 load_most_recent_project_on_start:                  false
 projects_sorting_order:                             most_recent_first
+grid_navigation_display_duration:                   2.0
 
 build_panel_stays_in_one_place:                     false  # if true, the build panel will flip to the inactive pane in two pane layouts
 build_panel_line_wrap_always_on:                    true
@@ -180,6 +181,17 @@ Cmd-Shift-Enter                 new_line_above_without_breaking
 NumpadEnter                     break_line
 Cmd-NumpadEnter                 new_line_below_without_breaking
 Cmd-Shift-NumpadEnter           new_line_above_without_breaking
+
+{Shift}-Cmd-Numpad0             grid_navigation_reset
+{Shift}-Cmd-Numpad1             grid_navigation_southwest
+{Shift}-Cmd-Numpad2             grid_navigation_south
+{Shift}-Cmd-Numpad3             grid_navigation_southeast
+{Shift}-Cmd-Numpad4             grid_navigation_west
+{Shift}-Cmd-Numpad5             grid_navigation_center
+{Shift}-Cmd-Numpad6             grid_navigation_east
+{Shift}-Cmd-Numpad7             grid_navigation_northwest
+{Shift}-Cmd-Numpad8             grid_navigation_north
+{Shift}-Cmd-Numpad9             grid_navigation_northeast
 
 Cmd-1                           switch_to_left_editor
 Cmd-2                           switch_to_right_editor

--- a/modules/Simp/backend/gl.jai
+++ b/modules/Simp/backend/gl.jai
@@ -347,8 +347,8 @@ vec3 hsl2rgb( in vec3 c )
 
 void main () {
     vec2 uv = vec2((gl_FragCoord.x - rect.x) / rect.z, (gl_FragCoord.y - rect.y) / rect.w);
-    // This is line 44
-    switch (mode) {
+    float a = iterated_color.a;
+    switch (mode) {  // mode values come from Gradient_Mode in color_picker.jai
         case 0x00:  // 2d controlled by red
         color.r = value;
         color.gb = uv.xy;
@@ -443,13 +443,21 @@ void main () {
         case 0x26: // 1d horizontal displaying alpha
         color.rgb = vec3(uv.x);
         break;
+
+        case 0x30: // Checkboard alpha
+        int i = int((gl_FragCoord.x - rect.x) / value);
+        int j = int((gl_FragCoord.y - rect.y) / value);
+        i = (i ^ j) & 1;
+        a = iterated_color.a * float(i);
+        color = iterated_color;
+        break;
     }
 
     // When color is between two displayable values dither it to avoid banding; round it up or down randomly,
     // proportionate to which it is nearer to.
     vec4 remainder = fract(color * 255.0);
     color = color - (remainder / 255.0) + (1.0 / 255.0) - (step(remainder, random4(uv)) / 255.0);
-    color.a = iterated_color.a;
+    color.a = a;
 }
 #endif // FRAGMENT_SHADER
 GLSL

--- a/src/config.jai
+++ b/src/config.jai
@@ -609,6 +609,7 @@ Settings :: struct {
     search_is_case_sensitive_when_uppercase_present         := false;
     show_selected_text_length                               := false;
     load_most_recent_project_on_start                       := false;
+    grid_navigation_display_duration                        := 2.0;
 
     build_panel_width_percent                               := 50;
     build_panel_height_percent                              := 50;

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -736,12 +736,16 @@ get_text_offset :: inline () -> Vector2 {
     return Vector2.{char_x_advance, -char_x_advance};
 }
 
-coords_from_mouse_position :: (using editor: Editor, rect: Rect) -> Coords {
-    pointer := snap_to_rect(mouse.pointer, rect);  // when we drag outside the editor we still want to interact
+coords_from_screen_position :: (using editor: Editor, rect: Rect, position: Vector2) -> Coords {
+    pointer := snap_to_rect(position, rect);  // when we drag outside the editor we still want to interact
     mouse_pos := pointer - bottom_left(rect) - get_text_offset();
     mouse_pos.x += viewport.left;
     mouse_pos.y = rect.h - mouse_pos.y + viewport.top - ifx dpi_scale > 1.0 then 1 else 0;
     return .{ line = xx (mouse_pos.y / line_height), col = xx ((mouse_pos.x / char_x_advance) + 0.5) };
+}
+
+coords_from_mouse_position :: (using editor: Editor, rect: Rect) -> Coords {
+    return coords_from_screen_position(editor, rect, mouse.pointer);
 }
 
 draw_editor :: (editor_id: s64, main_area: Rect, status_bar_height: float, ui_id: Ui_Id, total_editor_area := Rect.{}) {
@@ -1523,6 +1527,71 @@ draw_editor :: (editor_id: s64, main_area: Rect, status_bar_height: float, ui_id
                 }
                 draw_rect_raw(cursor_mark_rect, Color.CURSOR);
             }
+        }
+
+        if grid_navigation.editor_id_should_jump == editor_id {
+            // Performing a grid jump on the cursor: move it to the cursor position which is nearest to the center of our grid.
+            // This depends on the lenghts of the surrounding lines.
+            grid_navigation.editor_id_should_jump = -1;
+            position: Vector2;
+            position.x = rect.x + rect.w * (grid_navigation.uv.x + grid_navigation.size / 2);
+            position.y = rect.y + rect.h * (grid_navigation.uv.y + grid_navigation.size / 2);
+            desired_coords := coords_from_screen_position(editor, rect, position);
+
+            // Loop over nearby lines to find the closest possible cursor.
+            cursor := leave_only_original_cursor(editor);
+            cursor.pos = coords_to_offset(editor, buffer, desired_coords);
+            best_pos := cursor.pos;
+            actual_coords := get_cursor_coords(editor, buffer, cursor);
+            cursor_screen_pos := get_cursor_screen_pos(text_origin, actual_coords.pos);
+            cursor_screen_pos.y += line_height / 2; // get_cursor_screen_pos returns the bottom of the cursor.
+            min_distance := distance_squared(position, cursor_screen_pos);
+            for line_offset : -5 .. +5 {
+                if !line_offset  continue;
+                cursor.pos = coords_to_offset(editor, buffer, .{desired_coords.line + cast(s32) line_offset, desired_coords.col});
+                actual_coords := get_cursor_coords(editor, buffer, cursor);
+                cursor_screen_pos := get_cursor_screen_pos(text_origin, actual_coords.pos);
+                cursor_screen_pos.y += line_height / 2;
+                distance := distance_squared(position, cursor_screen_pos);
+                if distance < min_distance {
+                    min_distance = distance;
+                    best_pos = cursor.pos;
+                }
+            }
+            cursor.pos = best_pos;
+            if !grid_navigation.extend_selection  cursor.sel = cursor.pos;
+            cursor.col_wanted = -1;
+            cursor_moved = .jumped;
+            cursors_start_blinking();
+
+            if grid_navigation.size < grid_navigation.finish_when_smaller_than  reset_grid_navigation();
+        }
+
+        if frame_time64 < grid_navigation.last_press_time + config.settings.grid_navigation_display_duration {
+            remaining_duration : float64 = config.settings.grid_navigation_display_duration - (frame_time64 - grid_navigation.last_press_time);
+            pulse_rate :: CURSOR_BLINK_SPEED_MS / 1000.0;
+            pulse_t := fmod_cycling(cast(float) frame_time64, pulse_rate * 2) / pulse_rate;
+            if pulse_t > 1.0  pulse_t = 2.0 - pulse_t;
+            color := lerp(map_color_to_vec4(.CURSOR), .{1, 1, 1, 1}, pulse_t * 0.5);
+            color.w = ifx remaining_duration > grid_navigation.fade_out_duration then 1.0 else cast(float) (remaining_duration / grid_navigation.fade_out_duration);
+
+            Simp.set_shader_for_gradient(cast,force(Vector4) rect, cast(u8) Gradient_Mode.checkered_alpha, char_x_advance / 2);
+
+            grid := Vector2.{rect.w * grid_navigation.size, rect.h * grid_navigation.size};
+            r := Rect.{rect.x + rect.w * grid_navigation.uv.x, rect.y + rect.h * grid_navigation.uv.y, grid.x, grid.y};
+            grid /= 3;
+
+            horizontal := r;
+            horizontal.h = 1;
+            horizontal.y += grid.y;  draw_rect_with_raw_color(horizontal, color);
+            horizontal.y += grid.y;  draw_rect_with_raw_color(horizontal, color);
+
+            vertical := r;
+            vertical.w = 1;
+            vertical.x += grid.x;  draw_rect_with_raw_color(vertical, color);
+            vertical.x += grid.x;  draw_rect_with_raw_color(vertical, color);
+
+            Simp.immediate_flush();
         }
     }
 

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -48,6 +48,59 @@ editors_handle_event :: (event: Input.Event) -> handled: bool {
     return false;
 }
 
+grid_navigation : struct {
+    last_press_time: float64;
+    editor_id_should_jump: int;
+    extend_selection: bool;
+    uv: Vector2;
+    size: float;
+
+    finish_when_smaller_than :: 1.0 / 3.0 / 3.0;
+    fade_out_duration : float64 : 0.2;
+}
+
+handle_grid_navigate :: (grid_action : enum { northwest; north; northeast; west; center; east; southwest; south; southeast; reset; }, keep_selection: bool) {
+    using grid_navigation;
+
+    if last_press_time + config.settings.grid_navigation_display_duration < frame_time64 || grid_action == .reset {
+        reset_grid_navigation();
+    }
+
+    if grid_action != .reset  size /= 3;
+
+    u, v: float;
+    if grid_action == {
+        case .reset; #through;
+        case .southwest;  u = size * 0; v = size * 0;
+        case .south;      u = size * 1; v = size * 0;
+        case .southeast;  u = size * 2; v = size * 0;
+        case .west;       u = size * 0; v = size * 1;
+        case .center;     u = size * 1; v = size * 1;
+        case .east;       u = size * 2; v = size * 1;
+        case .northwest;  u = size * 0; v = size * 2;
+        case .north;      u = size * 1; v = size * 2;
+        case .northeast;  u = size * 2; v = size * 2;
+    }
+
+    uv.x += u;
+    uv.y += v;
+    editor_id_should_jump = editors.active;
+    extend_selection = keep_selection;
+    last_press_time = frame_time64;
+}
+
+soft_reset_grid_navigation :: () { // Will cause the drawn grid to fade out rather than instantly vanish.
+    using grid_navigation;
+    last_press_time = min(last_press_time, frame_time64 - config.settings.grid_navigation_display_duration + grid_navigation.fade_out_duration);
+}
+
+reset_grid_navigation :: () {
+    using grid_navigation;
+    last_press_time = 0;
+    size = 1.0;
+    uv = .{};
+}
+
 activate_editors :: () {
     active_global_widget = .editors;
     cursors_start_blinking();
@@ -241,6 +294,17 @@ active_editor_handle_event :: (editor: *Editor, buffer: *Buffer, event: Input.Ev
         case .jump_to_file_end;                 move_to_file_end                    (editor, buffer);
         case .jump_to_matching_bracket;         move_to_matching_bracket            (editor, buffer, shift_pressed); keep_selection = true;
 
+        case .grid_navigation_northwest;        handle_grid_navigate                (.northwest, shift_pressed);
+        case .grid_navigation_north;            handle_grid_navigate                (.north,     shift_pressed);
+        case .grid_navigation_northeast;        handle_grid_navigate                (.northeast, shift_pressed);
+        case .grid_navigation_west;             handle_grid_navigate                (.west,      shift_pressed);
+        case .grid_navigation_center;           handle_grid_navigate                (.center,    shift_pressed);
+        case .grid_navigation_east;             handle_grid_navigate                (.east,      shift_pressed);
+        case .grid_navigation_southwest;        handle_grid_navigate                (.southwest, shift_pressed);
+        case .grid_navigation_south;            handle_grid_navigate                (.south,     shift_pressed);
+        case .grid_navigation_southeast;        handle_grid_navigate                (.southeast, shift_pressed);
+        case .grid_navigation_reset;            handle_grid_navigate                (.reset,     shift_pressed);
+
         case .select_line;                      select_lines                        (editor, buffer); keep_selection = true;
         case .copy;                             copy_selection_to_clipboard         (editor, buffer);
 
@@ -301,6 +365,7 @@ active_editor_handle_event :: (editor: *Editor, buffer: *Buffer, event: Input.Ev
 
     if new_group then new_edit_group(buffer, editor);  // do it after action
 
+    if !is_a_grid_navigation_action(action)  soft_reset_grid_navigation();
     if is_a_move_action(action) && shift_pressed then keep_selection = true;
 
     if editor.cursor_moved && !keep_selection {
@@ -340,6 +405,8 @@ active_editor_type_char :: (char: u32) {
         editor.search_bar.scroll_to_selected = .snap;
         return;
     }
+
+    soft_reset_grid_navigation();
 
     if buffer.readonly return;
 
@@ -2093,6 +2160,25 @@ is_a_move_action :: (action: Action_Editors) -> bool {
         case .jump_to_line_end;                 return true;
         case .jump_to_file_start;               return true;
         case .jump_to_file_end;                 return true;
+    }
+
+    if is_a_grid_navigation_action(action)      return true;
+
+    return false;
+}
+
+is_a_grid_navigation_action :: (action: Action_Editors) -> bool {
+    if action == {
+        case .grid_navigation_northwest;        return true;
+        case .grid_navigation_north;            return true;
+        case .grid_navigation_northeast;        return true;
+        case .grid_navigation_west;             return true;
+        case .grid_navigation_center;           return true;
+        case .grid_navigation_east;             return true;
+        case .grid_navigation_southwest;        return true;
+        case .grid_navigation_south;            return true;
+        case .grid_navigation_southeast;        return true;
+        case .grid_navigation_reset;            return true;
     }
     return false;
 }
@@ -4053,6 +4139,8 @@ move_to_editor_history_frame :: (frame: Editor_History_Frame, old_frame: Editor_
     put_cursor_in_valid_spot(cursor, open_buffers[editor.buffer_id]);
 }
 
+CURSOR_BLINK_SPEED_MS   :: 500;
+
 #scope_file
 
 cursor_blink_start: Apollo_Time;
@@ -4061,6 +4149,5 @@ cursors_blinking := false;
 global_config_buffer_id := -1;
 global_troubleshooting_buffer_id := -1;
 
-CURSOR_BLINK_SPEED_MS   :: 500;
 
 #import "Clipboard";

--- a/src/keymap.jai
+++ b/src/keymap.jai
@@ -417,6 +417,17 @@ ACTIONS_EDITORS :: #run arrays_concat(ACTIONS_COMMON, string.[
     "toggle_line_wrap",
     "toggle_line_numbers",
     "copy_current_line_info",
+
+    "grid_navigation_northwest",
+    "grid_navigation_north",
+    "grid_navigation_northeast",
+    "grid_navigation_west",
+    "grid_navigation_center",
+    "grid_navigation_east",
+    "grid_navigation_southwest",
+    "grid_navigation_south",
+    "grid_navigation_southeast",
+    "grid_navigation_reset",
 ]);
 
 ACTIONS_OPEN_FILE_DIALOG :: #run arrays_concat(ACTIONS_COMMON, string.[

--- a/src/widgets/color_picker.jai
+++ b/src/widgets/color_picker.jai
@@ -36,6 +36,8 @@ Gradient_Mode :: enum u8 {
     saturation_horizontal_1d :: 0x24;
     lightness_horizontal_1d  :: 0x25;
     alpha_horizontal_1d      :: 0x26;
+
+    checkered_alpha          :: 0x30;
 }
 
 color_picker_set_mode :: (mode: Gradient_Mode) {


### PR DESCRIPTION
Adds the ability to jump the cursor by narrowing in on screen region.  By default this is bound to ctrl+numpad; the screen is divided into a 3x3 grid, the number you hit selects a cell. Hitting again will divide that cell into a 3x3 grid, and so on.

Added config setting: `grid_navigation_display_duration` 

Added keybinds: 
```
grid_navigation_reset
grid_navigation_southwest
grid_navigation_south
grid_navigation_southeast
grid_navigation_west
grid_navigation_center
grid_navigation_east
grid_navigation_northwest
grid_navigation_north
grid_navigation_northeast
```

The code should allow for holding shift to extend the selection while you do this. However, dumb windows behavior screws this up; that is, holding shift on windows disables numlock, so the keys register differently (i.e you get Home instead of Numpad7).  If the user were to remap, for instance to `ctrl+tyughjbn`, then the shift selection extension should work.  I think we might be able to add the ability to bind explicit scancodes rather than virtual ones, to get round this problem: https://learn.microsoft.com/en-us/windows/win32/inputdev/about-keyboard-input#scan-codes