### PR TITLE
Add revert_select_word_or_create_another_cursor and move_selection_to_next_word commands

### DIFF
--- a/src/editors.jai
+++ b/src/editors.jai
@@ -72,6 +72,26 @@ editors_handle_file_drop :: (files: [] string) {
     }
 }
 
+revert_select_word_or_create_another_cursor :: (using editor: *Editor, buffer: *Buffer) {
+    if cursors.count == 1 {
+        cursor := *editor.cursors[0];
+        cursor.pos -= cursor.pos - cursor.sel;
+        cursor.sel  = cursor.pos;
+        cursor_moved = .unimportant;
+    } else {
+        organise_cursors(editor);
+        
+        ordered_remove_by_index(*cursors, main_cursor);
+        if main_cursor == 0 {
+            main_cursor = cursors.count - 1;
+        } else {
+            main_cursor -= 1;
+        }
+
+        cursor_moved = .selection;
+    }
+}
+
 active_editor_handle_event :: (editor: *Editor, buffer: *Buffer, event: Input.Event, action: Action_Editors) -> handled: bool {
     context.current_editor_id = editors.active;  // used for edit notifications
     defer context.current_editor_id = -1;
@@ -202,6 +222,11 @@ active_editor_handle_event :: (editor: *Editor, buffer: *Buffer, event: Input.Ev
         case .select_word;                      select_word(editor, buffer); keep_selection = true;
         case .select_word_or_create_another_cursor; enabled_whole_words = select_word_or_create_another_cursor(editor, buffer); keep_selection = true;
         case .select_all_occurrences;               enabled_whole_words = select_all_occurrences              (editor, buffer); keep_selection = true;
+        
+
+        
+        case .revert_select_word_or_create_another_cursor; revert_select_word_or_create_another_cursor(editor, buffer); keep_selection = true;
+        case .select_next_word_or_create_another_cursor; 
 
         case .toggle_line_wrap;                 toggle_line_wrap                    (editor);
         case .toggle_line_numbers;              toggle_line_numbers                 ();

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -1803,6 +1803,7 @@ revert_select_word_or_create_another_cursor :: (using editor: *Editor, buffer: *
         }
     } else {
         organise_cursors(editor);
+        old_main_cursor := main_cursor;
         
         ordered_remove_by_index(*cursors, main_cursor);
         if main_cursor == 0 {
@@ -1810,9 +1811,21 @@ revert_select_word_or_create_another_cursor :: (using editor: *Editor, buffer: *
         } else {
             main_cursor -= 1;
         }
+        
+        if original_cursor > old_main_cursor {
+            original_cursor -= 1;
+        } else if original_cursor == old_main_cursor {
+            // This is suboptimal but can happen. If select_word_or_create_another_cursor does not find a new
+            // word to select it will set the main_cursor to the original_cursor. So it is completely possible
+            // that we revert the original_cursor.
+            // Maybe select_word_or_create_another_cursor should do nothing if it can't find a new word to select?
+            original_cursor = main_cursor;
+        }
     }
-    
     cursor_moved = .selection;
+    
+    assert(main_cursor     < cursors.count);
+    assert(original_cursor < cursors.count);
 }
 
 move_selection_to_next_word :: (using editor: *Editor, buffer: Buffer) 

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -72,26 +72,6 @@ editors_handle_file_drop :: (files: [] string) {
     }
 }
 
-revert_select_word_or_create_another_cursor :: (using editor: *Editor, buffer: *Buffer) {
-    if cursors.count == 1 {
-        cursor := *editor.cursors[0];
-        cursor.pos -= cursor.pos - cursor.sel;
-        cursor.sel  = cursor.pos;
-        cursor_moved = .unimportant;
-    } else {
-        organise_cursors(editor);
-        
-        ordered_remove_by_index(*cursors, main_cursor);
-        if main_cursor == 0 {
-            main_cursor = cursors.count - 1;
-        } else {
-            main_cursor -= 1;
-        }
-
-        cursor_moved = .selection;
-    }
-}
-
 active_editor_handle_event :: (editor: *Editor, buffer: *Buffer, event: Input.Event, action: Action_Editors) -> handled: bool {
     context.current_editor_id = editors.active;  // used for edit notifications
     defer context.current_editor_id = -1;
@@ -223,10 +203,8 @@ active_editor_handle_event :: (editor: *Editor, buffer: *Buffer, event: Input.Ev
         case .select_word_or_create_another_cursor; enabled_whole_words = select_word_or_create_another_cursor(editor, buffer); keep_selection = true;
         case .select_all_occurrences;               enabled_whole_words = select_all_occurrences              (editor, buffer); keep_selection = true;
         
-
-        
         case .revert_select_word_or_create_another_cursor; revert_select_word_or_create_another_cursor(editor, buffer); keep_selection = true;
-        case .select_next_word_or_create_another_cursor; 
+        case .move_selection_to_next_word;                 move_selection_to_next_word(editor, buffer);                 keep_selection = true;
 
         case .toggle_line_wrap;                 toggle_line_wrap                    (editor);
         case .toggle_line_numbers;              toggle_line_numbers                 ();
@@ -1815,6 +1793,39 @@ select_word_or_create_another_cursor :: (using editor: *Editor, buffer: Buffer) 
     }
 
     return editor.search_whole_words;
+}
+
+revert_select_word_or_create_another_cursor :: (using editor: *Editor, buffer: *Buffer) {
+    if !get_selected_text_all_cursors(editor, buffer) || cursors.count == 1 {
+        for *cursors {
+            it.pos -= it.pos - it.sel;
+            it.sel  = it.pos;
+        }
+    } else {
+        organise_cursors(editor);
+        
+        ordered_remove_by_index(*cursors, main_cursor);
+        if main_cursor == 0 {
+            main_cursor = cursors.count - 1;
+        } else {
+            main_cursor -= 1;
+        }
+    }
+    
+    cursor_moved = .selection;
+}
+
+move_selection_to_next_word :: (using editor: *Editor, buffer: Buffer) 
+{
+    if !get_selected_text_all_cursors(editor, buffer) return;
+
+    old_main_cursor := main_cursor;
+    
+    select_word_or_create_another_cursor(editor, buffer);
+    ordered_remove_by_index(*cursors, old_main_cursor);
+    
+    main_cursor = cursors.count - 1;
+    if old_main_cursor == original_cursor then original_cursor = 0;
 }
 
 select_all_occurrences :: (using editor: *Editor, buffer: Buffer, search_str := "") -> whole_words: bool {

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -1818,17 +1818,33 @@ revert_select_word_or_create_another_cursor :: (using editor: *Editor, buffer: *
 move_selection_to_next_word :: (using editor: *Editor, buffer: Buffer) 
 {
     if !get_selected_text_all_cursors(editor, buffer) return;
-
+    
+    organise_cursors(editor);
     old_main_cursor := main_cursor;
     
     select_word_or_create_another_cursor(editor, buffer);
+    if cursors.count == 1 return;
     
-    if old_main_cursor != main_cursor
-    {
-        ordered_remove_by_index(*cursors, old_main_cursor);
-        main_cursor = cursors.count - 1;
-        if old_main_cursor == original_cursor then original_cursor = 0;
+    ordered_remove_by_index(*cursors, old_main_cursor);
+
+    if old_main_cursor == main_cursor {
+        // We have deleted the main_cursor. This happens if the select_word_or_create_another_cursor
+        // call does not change the main_cursor. In this case we select the 'next' cursor as the main_cursor,
+        // wrapping around if needed.
+        main_cursor = ifx main_cursor >= cursors.count then 0 else main_cursor;
+    } else if old_main_cursor < main_cursor {
+        // Due to the deletion we have to decrement the main_cursor index by one.
+        main_cursor -= 1;
     }
+    
+    if old_main_cursor == original_cursor {
+        original_cursor = main_cursor;    
+    } else if old_main_cursor < original_cursor {
+        original_cursor -= 1;
+    }
+    
+    assert(main_cursor     < cursors.count);
+    assert(original_cursor < cursors.count);
 }
 
 select_all_occurrences :: (using editor: *Editor, buffer: Buffer, search_str := "") -> whole_words: bool {

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -1796,31 +1796,31 @@ select_word_or_create_another_cursor :: (using editor: *Editor, buffer: Buffer) 
 }
 
 revert_select_word_or_create_another_cursor :: (using editor: *Editor, buffer: *Buffer) {
-    if !get_selected_text_all_cursors(editor, buffer) || cursors.count == 1 {
-        for *cursors {
-            it.pos -= it.pos - it.sel;
-            it.sel  = it.pos;
-        }
+    if cursors.count == 1 {
+        cursor := *cursors[0];
+        cursor.pos = cursor.sel;
+    } else if !get_selected_text_all_cursors(editor, buffer) {
+        // If we have multiple cursors and their selected text is not the same, we do nothing.
+        // While we could remove the selections of those cursors, this approach seems unintuitive.
     } else {
         organise_cursors(editor);
+        
+        // The main_cursor is the cursor most recently added by select_word_or_create_another_cursor().
+        // When every instance of the word is selected, the selection will wrap back to the original_cursor.
+        // Therefore, this function will delete the main_cursor, except when the original_cursor 
+        // and main_cursor are the same. In that case, we need to delete the cursor positioned
+        // "above" the main_cursor to maintain consistency with the general editor behavior.
+        if original_cursor == main_cursor {
+            main_cursor -= 1;
+            if main_cursor < 0 then main_cursor = cursors.count - 1;
+        }
         old_main_cursor := main_cursor;
         
         ordered_remove_by_index(*cursors, main_cursor);
-        if main_cursor == 0 {
-            main_cursor = cursors.count - 1;
-        } else {
-            main_cursor -= 1;
-        }
         
-        if original_cursor > old_main_cursor {
-            original_cursor -= 1;
-        } else if original_cursor == old_main_cursor {
-            // This is suboptimal but can happen. If select_word_or_create_another_cursor does not find a new
-            // word to select it will set the main_cursor to the original_cursor. So it is completely possible
-            // that we revert the original_cursor.
-            // Maybe select_word_or_create_another_cursor should do nothing if it can't find a new word to select?
-            original_cursor = main_cursor;
-        }
+        main_cursor -= 1;
+        if main_cursor < 0 then main_cursor = cursors.count - 1;
+        if original_cursor > old_main_cursor then original_cursor -= 1;
     }
     cursor_moved = .selection;
     
@@ -1828,8 +1828,7 @@ revert_select_word_or_create_another_cursor :: (using editor: *Editor, buffer: *
     assert(original_cursor < cursors.count);
 }
 
-move_selection_to_next_word :: (using editor: *Editor, buffer: Buffer) 
-{
+move_selection_to_next_word :: (using editor: *Editor, buffer: Buffer) {
     if !get_selected_text_all_cursors(editor, buffer) return;
     
     organise_cursors(editor);
@@ -1846,7 +1845,6 @@ move_selection_to_next_word :: (using editor: *Editor, buffer: Buffer)
         // wrapping around if needed.
         main_cursor = ifx main_cursor >= cursors.count then 0 else main_cursor;
     } else if old_main_cursor < main_cursor {
-        // Due to the deletion we have to decrement the main_cursor index by one.
         main_cursor -= 1;
     }
     

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -1822,10 +1822,13 @@ move_selection_to_next_word :: (using editor: *Editor, buffer: Buffer)
     old_main_cursor := main_cursor;
     
     select_word_or_create_another_cursor(editor, buffer);
-    ordered_remove_by_index(*cursors, old_main_cursor);
     
-    main_cursor = cursors.count - 1;
-    if old_main_cursor == original_cursor then original_cursor = 0;
+    if old_main_cursor != main_cursor
+    {
+        ordered_remove_by_index(*cursors, old_main_cursor);
+        main_cursor = cursors.count - 1;
+        if old_main_cursor == original_cursor then original_cursor = 0;
+    }
 }
 
 select_all_occurrences :: (using editor: *Editor, buffer: Buffer, search_str := "") -> whole_words: bool {

--- a/src/keymap.jai
+++ b/src/keymap.jai
@@ -357,7 +357,7 @@ ACTIONS_COMMON :: string.[
 ACTIONS_EDITORS :: #run arrays_concat(ACTIONS_COMMON, string.[
     "select_word_or_create_another_cursor",
     "revert_select_word_or_create_another_cursor",
-    "select_next_word_or_create_another_cursor",
+    "move_selection_to_next_word",
     "select_all_occurrences",
     "create_cursor_above",
     "create_cursor_below",

--- a/src/keymap.jai
+++ b/src/keymap.jai
@@ -356,6 +356,8 @@ ACTIONS_COMMON :: string.[
 
 ACTIONS_EDITORS :: #run arrays_concat(ACTIONS_COMMON, string.[
     "select_word_or_create_another_cursor",
+    "revert_select_word_or_create_another_cursor",
+    "select_next_word_or_create_another_cursor",
     "select_all_occurrences",
     "create_cursor_above",
     "create_cursor_below",


### PR DESCRIPTION
Hello,

my workflow involves heavy usage of the `select_word_or_create_another_cursor` command. To make this command more powerful this pull request adds two new commands:
1. `revert_select_word_or_create_another_cursor`: Reverts the action of `select_word_or_create_another_cursor`
2. `move_selection_to_next_word`: Executes a `select_word_or_create_another_cursor` and deletes the previously 'newest' cursor. It basically allows you to skip a selection.

For a better comprehension see the following demo video:

https://github.com/user-attachments/assets/7a590fa5-3bed-4e1f-825a-e92b9692238f

