### PR TITLE
Prevent out of bound array access in color preview

### DIFF
--- a/src/main.jai
+++ b/src/main.jai
@@ -75,7 +75,7 @@ main :: () {
         for path : array_view(args, 1, args.count - 1) {
             if is_directory(path) {
                 dir := trim_right(path, "\\/");
-                project_config_path := tprint("%.focus-config", dir);
+                project_config_path := tprint("%/.focus-config", dir);
                 if !project_config.loaded && file_exists(project_config_path) {
                     success := load_project_config(project_config_path);
                     if !success then add_user_error("Tried to load project config from % but couldn't due to errors", project_config_path);

--- a/src/main.jai
+++ b/src/main.jai
@@ -75,7 +75,7 @@ main :: () {
         for path : array_view(args, 1, args.count - 1) {
             if is_directory(path) {
                 dir := trim_right(path, "\\/");
-                project_config_path := tprint("%/.focus-config", dir);
+                project_config_path := tprint("%.focus-config", dir);
                 if !project_config.loaded && file_exists(project_config_path) {
                     success := load_project_config(project_config_path);
                     if !success then add_user_error("Tried to load project config from % but couldn't due to errors", project_config_path);

--- a/src/widgets/color_preview.jai
+++ b/src/widgets/color_preview.jai
@@ -241,6 +241,9 @@ color_preview_draw_color_picker :: (rect: Rect) {
     }
 
     offset += 1;
+
+    if offset >= buffer.bytes.count return;
+
     while is_unicode_space(buffer.bytes[offset]) {
         offset += 1;
         if offset >= buffer.bytes.count || buffer.bytes[offset] == #char "\n" return;


### PR DESCRIPTION
Previously, when changing region colors such as region_heredoc with the color preview opened, adding a colon as the last character on the last line would make the editor crash.