### PR TITLE
Construct valid config path

### DIFF
--- a/src/main.jai
+++ b/src/main.jai
@@ -75,7 +75,7 @@ main :: () {
         for path : array_view(args, 1, args.count - 1) {
             if is_directory(path) {
                 dir := trim_right(path, "\\/");
-                project_config_path := tprint("%.focus-config", dir);
+                project_config_path := tprint("%/.focus-config", dir);
                 if !project_config.loaded && file_exists(project_config_path) {
                     success := load_project_config(project_config_path);
                     if !success then add_user_error("Tried to load project config from % but couldn't due to errors", project_config_path);

--- a/src/main.jai
+++ b/src/main.jai
@@ -75,7 +75,7 @@ main :: () {
         for path : array_view(args, 1, args.count - 1) {
             if is_directory(path) {
                 dir := trim_right(path, "\\/");
-                project_config_path := tprint("%/.focus-config", dir);
+                project_config_path := tprint("%.focus-config", dir);
                 if !project_config.loaded && file_exists(project_config_path) {
                     success := load_project_config(project_config_path);
                     if !success then add_user_error("Tried to load project config from % but couldn't due to errors", project_config_path);

--- a/src/widgets/color_preview.jai
+++ b/src/widgets/color_preview.jai
@@ -241,6 +241,9 @@ color_preview_draw_color_picker :: (rect: Rect) {
     }
 
     offset += 1;
+
+    if offset >= buffer.bytes.count return;
+
     while is_unicode_space(buffer.bytes[offset]) {
         offset += 1;
         if offset >= buffer.bytes.count || buffer.bytes[offset] == #char "\n" return;

--- a/src/widgets/color_preview.jai
+++ b/src/widgets/color_preview.jai
@@ -241,9 +241,6 @@ color_preview_draw_color_picker :: (rect: Rect) {
     }
 
     offset += 1;
-
-    if offset >= buffer.bytes.count return;
-
     while is_unicode_space(buffer.bytes[offset]) {
         offset += 1;
         if offset >= buffer.bytes.count || buffer.bytes[offset] == #char "\n" return;


### PR DESCRIPTION
From https://github.com/focus-editor/focus/pull/457

> What was the problem you were having with config paths that led you to change that line?

I'm trying to open the editor loading a specific project-config and opening a specific file.
From reading the code, I'm thinking the intended way is to have the arguments be something like

`focus C:/Jai/projects/project_name C:/Jai/projects/project_name/src/main.jai`

However, the way the config path is currently written, I don't see how a valid project_config_path can be constructed. 
What I did seemed the simplest/most logical to me, and seems to match the fact that the projects folder has an example config file in it.

But I wondered if maybe you intended to extract the project name from the folder and construct the project_config_path with something like `config_path := tprint("%/%.focus-config", projects_dir, project);` similar to what's done above.