### PR TITLE
Don't copy to clipboard in delete_to_{start,end}_of_line

### DIFF
--- a/FOCUS-CHANGELOG.txt
+++ b/FOCUS-CHANGELOG.txt
@@ -52,6 +52,8 @@
     + Creating cursors above and below will now skip empty lines as this is most likely the behaviour users want (thanks @onelivesleft)
     + The Navigate To File (Ctrl-O) dialog will always show all files and folders instead of applying the ignore rules to them, which will allow to selectively open files which are normally ignored
     + Selecting a word using double left click should now behave identically to selecting a word using the `select_word` action, highlighting only whole-word selection occurrences
+    + The `delete_to_{start,end}_of_line` actions no longer copies the text to the clipboard.
+        + Added two new actions `cut_to_{start,end}_of_line` that deletes the text and copies it to the clipboard.
 
 
 # RELEASES ==================================================================

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -320,6 +320,8 @@ active_editor_handle_event :: (editor: *Editor, buffer: *Buffer, event: Input.Ev
 
             case .delete_to_start_of_line;             delete_to_start_of_line          (editor, buffer);
             case .delete_to_end_of_line;               delete_to_end_of_line            (editor, buffer);
+            case .cut_to_start_of_line;                delete_to_start_of_line          (editor, buffer, copy_to_clipboard = true);
+            case .cut_to_end_of_line;                  delete_to_end_of_line            (editor, buffer, copy_to_clipboard = true);
 
             case;                                   return false;
         }
@@ -3145,7 +3147,7 @@ delete_line :: (editor: *Editor, buffer: *Buffer, go_up := false) {
     editor.cursor_moved = .unimportant;
 }
 
-delete_to_start_of_line :: (editor: *Editor, buffer: *Buffer) {
+delete_to_start_of_line :: (editor: *Editor, buffer: *Buffer, copy_to_clipboard := false) {
     for * cursor : editor.cursors {
         if has_selection(cursor) continue;
 
@@ -3164,7 +3166,10 @@ delete_to_start_of_line :: (editor: *Editor, buffer: *Buffer) {
         cursor.col_wanted = -1;
     }
     organise_cursors(editor);  // resolve overlapping selections
-    copy_selection_to_clipboard(editor, buffer, cut = true, cut_lines_without_selection = false);
+
+    if copy_to_clipboard  copy_selection_to_clipboard(editor, buffer, cut_lines_without_selection = false);
+
+    delete_left_char(editor, buffer);
 }
 
 change_case_of_selected_text :: (editor: *Editor, buffer: *Buffer, mode: enum { upper; lower; caps; cycle; }) {
@@ -3228,13 +3233,16 @@ change_case_of_selected_text :: (editor: *Editor, buffer: *Buffer, mode: enum { 
     }
 }
 
-delete_to_end_of_line :: (editor: *Editor, buffer: *Buffer) {
+delete_to_end_of_line :: (editor: *Editor, buffer: *Buffer, copy_to_clipboard := false) {
     for * cursor : editor.cursors {
         if has_selection(cursor) continue;
         cursor.pos = get_real_line_end_offset(buffer, offset_to_real_line(buffer, cursor.pos));
     }
     organise_cursors(editor);  // resolve overlapping selections
-    copy_selection_to_clipboard(editor, buffer, cut = true, cut_lines_without_selection = false);
+
+    if copy_to_clipboard  copy_selection_to_clipboard(editor, buffer, cut_lines_without_selection = false);
+
+    delete_right_char(editor, buffer);
 }
 
 copy_selection_to_clipboard :: (editor: *Editor, buffer: *Buffer, cut := false, cut_lines_without_selection := true) {

--- a/src/keymap.jai
+++ b/src/keymap.jai
@@ -343,6 +343,8 @@ ACTIONS_COMMON :: string.[
     "delete_right_through_word_throttled",
     "delete_to_start_of_line",
     "delete_to_end_of_line",
+    "cut_to_start_of_line",
+    "cut_to_end_of_line",
     "increase_font_size",
     "decrease_font_size",
     "reset_font_size_to_default",

--- a/src/widgets/commands.jai
+++ b/src/widgets/commands.jai
@@ -143,6 +143,8 @@ base_commands := #run -> [] Command {
         cmd( "Delete Line And Go Up",             .delete_line_and_go_up,            .Single ),
         cmd( "Delete To Start Of Line",           .delete_to_start_of_line,          .Single ),
         cmd( "Delete To End Of Line",             .delete_to_end_of_line,            .Single ),
+        cmd( "Cut To Start Of Line",              .cut_to_start_of_line,             .Single ),
+        cmd( "Cut To End Of Line",                .cut_to_end_of_line,               .Single ),
         cmd( "Move Selected Lines Up",            .move_selected_lines_up,           .Single ),
         cmd( "Move Selected Lines Down",          .move_selected_lines_down,         .Single ),
         cmd( "Move Up To Empty Line",             .move_up_to_empty_line,            .Single ),

--- a/src/widgets/text_input.jai
+++ b/src/widgets/text_input.jai
@@ -50,6 +50,8 @@ text_input_handle_event :: (using input: *Text_Input, event: Input.Event) -> han
 
         case .delete_to_start_of_line;             delete_to_start_of_line             (input);
         case .delete_to_end_of_line;               delete_to_end_of_line               (input);
+        case .cut_to_start_of_line;                delete_to_start_of_line             (input, copy_to_clipboard = true);
+        case .cut_to_end_of_line;                  delete_to_end_of_line               (input, copy_to_clipboard = true);
 
         case;                                    return false;
     }
@@ -311,14 +313,14 @@ delete_right :: (using input: *Text_Input, by: Movement_Type) {
     delete_selection(input);
 }
 
-delete_to_start_of_line :: inline (using input: *Text_Input) {
+delete_to_start_of_line :: inline (using input: *Text_Input, copy_to_clipboard := false) {
     cursor.sel = 0;
-    delete_selection(input, copy_to_clipboard = true);
+    delete_selection(input, copy_to_clipboard = copy_to_clipboard);
 }
 
-delete_to_end_of_line :: inline (using input: *Text_Input) {
+delete_to_end_of_line :: inline (using input: *Text_Input, copy_to_clipboard := false) {
     cursor.sel = xx text.count;
-    delete_selection(input, copy_to_clipboard = true);
+    delete_selection(input, copy_to_clipboard = copy_to_clipboard);
 }
 
 delete_selection :: inline (using input: *Text_Input, copy_to_clipboard := false) {


### PR DESCRIPTION
The delete_to_{start,end}_of_line actions no longer copies the text to the clipboard. Two new actions cut_to_{start,end}_of_line has been added that does copy the text to the clipboard.