### PR TITLE
Move some default key combos to the common section

### DIFF
--- a/config/default.focus-config
+++ b/config/default.focus-config
@@ -150,10 +150,6 @@ Ctrl-Shift-D                duplicate_lines
 # Shift-Backspace             delete_line_and_go_up
 # Shift-Delete                delete_line
 
-Ctrl-K                      cut_to_end_of_line
-Ctrl-Shift-Delete           delete_to_end_of_line
-Ctrl-Shift-Backspace        delete_to_start_of_line
-
 Alt-ArrowUp                 move_selected_lines_up
 Alt-ArrowDown               move_selected_lines_down
 
@@ -291,6 +287,10 @@ Ctrl-Shift-Z                redo
 
 Ctrl-D                      select_word
 Ctrl-A                      select_all
+
+Ctrl-K                      cut_to_end_of_line
+Ctrl-Shift-Delete           delete_to_end_of_line
+Ctrl-Shift-Backspace        delete_to_start_of_line
 
 Ctrl-W                      close_current_editor
 Ctrl-Shift-W                close_other_editor

--- a/config/default_macos.focus-config
+++ b/config/default_macos.focus-config
@@ -138,10 +138,6 @@ Cmd-Shift-D                     duplicate_lines
 # Shift-Backspace                 delete_line_and_go_up
 # Shift-Delete                    delete_line
 
-Cmd-K                           cut_to_end_of_line
-Cmd-Delete                      delete_to_end_of_line
-Cmd-Backspace                   delete_to_start_of_line
-
 Opt-ArrowUp                     move_selected_lines_up
 Opt-ArrowDown                   move_selected_lines_down
 
@@ -269,6 +265,10 @@ Cmd-Shift-Z                     redo
 
 Cmd-D                           select_word
 Cmd-A                           select_all
+
+Cmd-K                           cut_to_end_of_line
+Cmd-Delete                      delete_to_end_of_line
+Cmd-Backspace                   delete_to_start_of_line
 
 Cmd-W                           close_current_editor
 Cmd-Shift-W                     close_other_editor


### PR DESCRIPTION
Move the default key combos Ctrl-K, Ctrl-Shift-Delete, and Ctrl-Shift-Backspace to the common section. Otherwise these combos don't work in the various dialogs by default.