### PR TITLE
Fix a bug in draw_range_full_width_lines if range is only one line

### DIFF
--- a/src/draw.jai
+++ b/src/draw.jai
@@ -3346,7 +3346,8 @@ draw_range_full_width_lines :: (range: Coords_Range, editor_rect: Rect, visible_
         if line_num == end {
             if range.end.col > 0 {
                 br = .in;
-                rect = cut_left(rect, text_gap_x + range.end.col * char_x_advance);
+                cols := ifx start == end then range.end.col - range.start.col - 1 else range.end.col;
+                rect = cut_left(rect, text_gap_x + cols * char_x_advance);
             } else {
                 rect.w = 0;
             }


### PR DESCRIPTION
This fixes a bug where the background color in a single line buffer region was too wide.

E.g. #string jai struct jai