### PR TITLE
Fix error in auto_delete_closing_bracket detection

### DIFF
--- a/src/editors.jai
+++ b/src/editors.jai
@@ -829,7 +829,7 @@ all_cursors_can_auto_delete_closing_bracket :: (using editor: Editor, buffer: Bu
     for editor.cursors {
         if it.pos - 1 < 0 || has_selection(it) return false;
 
-        ch_prev := get_char_at_offset(buffer, it.pos - 1);
+        _, ch_prev := prev_char_offset(buffer.bytes, it.pos);
         ch_curr := get_char_at_offset(buffer, it.pos);
 
         if !is_auto_closeable_char(ch_prev) return false;


### PR DESCRIPTION
Detection of previous char in the function all_cursors_can_auto_delete_closing_bracket doesn't account for characters longer than 1 byte.  

This could lead to a consistent crash in the case where you had the character sequence `è)` and deleted the `è` with backspace.

Full reproduction steps:
- Open a new file and have `auto_close_brackets` set to true in your config
- Type `è)`
- Delete the `è` with backspace

The reason is `è` is encoded as 0xC3 0xA8. With the previous code, the previous byte was checked rather than the previous character. Here we got 0xA8, which wraps back to 0x28. 0x28 is `(`, leading to an erroneous auto_delete_closing_bracket detection in this case.