### PR TITLE
Fix crash on reloading a workspace if a file path is too long

### DIFF
--- a/src/workspace.jai
+++ b/src/workspace.jai
@@ -458,6 +458,10 @@ directory_scan_threadproc :: (group: *Thread_Group, thread: *Thread, work: *void
         auto_release_temp();
         if !should_ignore_file(path) {
             buffer_id, created := find_or_create_buffer(path);
+            if buffer_id < 0 {
+                log_error("Couldn't open file because path is too long for %: \"%\"\n", OS, path);
+                continue;
+            }
             if !created then reload_from_disk(buffer_id, force = true);  // when refreshing workspace we want up to date data from disk
         }
     }


### PR DESCRIPTION
I'm not sure whether it is the correct place to check it or not. But the issue comes from `find_or_create_buffer` returning -1 because of this:
![image](https://github.com/user-attachments/assets/2df87879-60f3-4efb-a4c1-f93f3c41cc21)
