### PR TITLE
Added autosave in x seconds feature.

### DIFF
--- a/config/default.focus-config
+++ b/config/default.focus-config
@@ -61,6 +61,7 @@ prefer_system_file_dialogs:                         false  # Windows only
 persist_local_search_results:                       false  # if true, search results will stay highlighted and you have to dismiss them using the `escape` action
 load_most_recent_project_on_start:                  false
 projects_sorting_order:                             most_recent_first
+autosave_in_x_seconds:                              0
 
 build_panel_stays_in_one_place:                     false  # if false, the build panel will flip to the inactive pane in two pane layouts
 build_panel_line_wrap_always_on:                    true

--- a/config/default_macos.focus-config
+++ b/config/default_macos.focus-config
@@ -60,6 +60,7 @@ auto_close_brackets:                                false
 persist_local_search_results:                       false  # if true, search results will stay highlighted and you have to dismiss them using the `escape` action
 load_most_recent_project_on_start:                  false
 projects_sorting_order:                             most_recent_first
+autosave_in_x_seconds:                              0
 
 build_panel_stays_in_one_place:                     false  # if true, the build panel will flip to the inactive pane in two pane layouts
 build_panel_line_wrap_always_on:                    true

--- a/src/config.jai
+++ b/src/config.jai
@@ -647,6 +647,7 @@ Settings :: struct {
     scrollbar_max_opacity                                   := 1.0;     @v16
     scrollbar_fade_in_sensitivity                           := 10.0;    @v16
     scrollbar_fade_out_delay_seconds                        := 2.0;     @v16
+    autosave_in_x_seconds                                   := 0;       @v16
 
     // TODO
     // load_last_session_on_start:         true

--- a/src/config_migrator.jai
+++ b/src/config_migrator.jai
@@ -483,6 +483,7 @@ ADDED_SETTINGS :: Added_Setting.[
 
     .{  6, "search_is_case_sensitive_when_uppercase_present",    "false" },
     .{  6, "projects_sorting_order",                             "most_recent_first  #options: most_recent_first, alphabetical, alphabetical_no_case" },
+    
 
     .{  7, "show_ruler_at_column",                               "0" },
 
@@ -497,6 +498,7 @@ ADDED_SETTINGS :: Added_Setting.[
     .{ 16, "scrollbar_max_opacity",                              "1.0" },
     .{ 16, "scrollbar_fade_in_sensitivity",                      "10.0  # controls when the scrollbar appears as the mouse pointer gets close" },
     .{ 16, "scrollbar_fade_out_delay_seconds",                   "2.0   # how long the scrollbar stays visible after scrolling" },
+    .{ 16, "autosave_in_x_seconds",                              "0"},
 ];
 
 RENAMED_SETTINGS :: Renamed_Setting.[
@@ -1242,6 +1244,7 @@ color_preview_popup:                             enabled  # options: enabled, mi
 highlight_matching_brackets:                     false
 search_is_case_sensitive_when_uppercase_present: false
 projects_sorting_order:                          most_recent_first  #options: most_recent_first, alphabetical, alphabetical_no_case
+autosave_in_x_seconds:                           0
 show_ruler_at_column:                            0
 detect_indentation:                              true  # if true, existing files will be scanned to detect indentation, new files will use the `indent_using` and `tab_size` settings
 status_bar_show_indentation:                     true
@@ -1358,6 +1361,7 @@ color_preview_popup:                             enabled  # options: enabled, mi
 highlight_matching_brackets:                     false
 search_is_case_sensitive_when_uppercase_present: false
 projects_sorting_order:                          most_recent_first  #options: most_recent_first, alphabetical, alphabetical_no_case
+autosave_in_x_seconds:                           0
 show_ruler_at_column:                            0
 detect_indentation:                              true  # if true, existing files will be scanned to detect indentation, new files will use the `indent_using` and `tab_size` settings
 status_bar_show_indentation:                     true
@@ -1684,6 +1688,7 @@ color_preview_popup:                             enabled  # options: enabled, mi
 highlight_matching_brackets:                     false
 search_is_case_sensitive_when_uppercase_present: false
 projects_sorting_order:                          most_recent_first  #options: most_recent_first, alphabetical, alphabetical_no_case
+autosave_in_x_seconds:                           0
 show_ruler_at_column:                            0
 detect_indentation:                              true  # if true, existing files will be scanned to detect indentation, new files will use the `indent_using` and `tab_size` settings
 status_bar_show_indentation:                     true

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -3,7 +3,7 @@
 editors_handle_event :: (event: Input.Event) -> handled: bool {
     mods := event.modifier_flags;
 
-    if event.type == {
+    if event.type ==  {
         case .KEYBOARD;
             if event.key_pressed {
                 action, mapping := map_event_to_action(event, Action_Editors);
@@ -440,6 +440,7 @@ active_editor_type_char :: (char: u32) {
     buffer.last_edit_time = frame_time64;
     editor.cursor_moved = .unimportant;
     cursors_start_blinking();
+    autosave_start_timer();
     if !is_empty(editor.search_bar.results) then search_and_update_results(editor, buffer, jump = false);
 }
 
@@ -1924,6 +1925,7 @@ save :: (editor: Editor, editor_id: s64) {
     if is_color_preview_panel(editor_id) then buffer_id = color_preview_get_target_buffer_id();
 
     save(buffer_id);
+    autosave_stop_timer();
 }
 
 save :: (buffer_id: s64) {
@@ -1956,6 +1958,47 @@ open_file_directory :: (buffer_id: s64) {
 
     platform_open_in_explorer(path);
 }
+
+autosave_start_timer :: inline () {
+    if config.settings.autosave_in_x_seconds <= 0 return;
+
+    autosave_timer_start = frame_time;
+    platform_set_autosave_timer(window);
+    autosave_active = true;
+}
+
+autosave_stop_timer :: inline () {
+    platform_kill_autosave_timer(window);
+    autosave_active = false;
+}
+
+#scope_export
+
+check_if_autosave_timer_should_start :: () {
+    has_unsaved_buffer := false;
+    for buffer, buffer_id : open_buffers {
+        if is_unsaved(buffer) && !buffer.modified_on_disk has_unsaved_buffer = true;
+    }
+    if !autosave_active && has_unsaved_buffer autosave_start_timer();
+    if autosave_active && !has_unsaved_buffer autosave_stop_timer();
+}
+
+check_for_autosave_timer :: () {
+    if !autosave_active || config.settings.autosave_in_x_seconds <= 0 return;
+
+    ms_since_start := cast(s64) (to_float64_seconds(frame_time - autosave_timer_start) * 1000);
+    
+    if ms_since_start > config.settings.autosave_in_x_seconds * 1000 {
+        for buffer, buffer_id : open_buffers {
+            if is_unsaved(buffer) && !buffer.modified_on_disk {
+                    save(buffer_id);
+                }
+        }
+        autosave_stop_timer();
+    }
+}
+
+#scope_file
 
 switch_to_editor :: (side: enum { left; right; other; }, duplicate_current := false) {
     if build_panel_is_active() then build_panel_lose_focus();
@@ -4240,6 +4283,8 @@ move_to_editor_history_frame :: (frame: Editor_History_Frame, old_frame: Editor_
 
 cursor_blink_start: Apollo_Time;
 cursors_blinking := false;
+autosave_timer_start : Apollo_Time;
+autosave_active := false;
 
 global_config_buffer_id := -1;
 global_troubleshooting_buffer_id := -1;

--- a/src/main.jai
+++ b/src/main.jai
@@ -325,6 +325,9 @@ main :: () {
 
         execute_deferred_actions();
 
+        check_if_autosave_timer_should_start();
+        check_for_autosave_timer();
+
         build_system_update();
         maybe_revert_temporary_theme();
         refresh_open_buffers();

--- a/src/platform/linux.jai
+++ b/src/platform/linux.jai
@@ -205,6 +205,14 @@ platform_kill_cursor_timer :: (window: Window_Type) {
     LD.timer_stop(cursor_timer);
 }
 
+platform_set_autosave_timer :: (window: Window_Type) {
+    LD.timer_start(autosave_timer, 0, 50);
+}
+
+platform_kill_autosave_timer :: (window: Window_Type) {
+    LD.timer_stop(autosave_timer);
+}
+
 platform_enumerate_logical_drives :: () -> [] string {
     logical_drives: [..]string;
 
@@ -483,6 +491,7 @@ Linux_Icon :: struct {
 }
 
 cursor_timer: LD.Timer;
+autosave_timer: LD.Timer;
 refresh_timer: LD.Timer;
 xdg_reap_timer: LD.Timer;
 

--- a/src/platform/macos.jai
+++ b/src/platform/macos.jai
@@ -88,6 +88,16 @@ platform_kill_cursor_timer :: inline (window: Window_Type) {
     cursor_timer = null;
 }
 
+platform_set_autosave_timer :: inline (window: Window_Type) {
+    destroy_timer(autosave_timer);
+    autosave_timer = create_timer(50, true);
+}
+
+platform_kill_autosave_timer :: inline (window: Window_Type) {
+    destroy_timer(autosave_timer);
+    autosave_timer = null;
+}
+
 platform_enumerate_logical_drives :: inline () -> [] string {
     return .["/"];
 }
@@ -198,6 +208,7 @@ monitors : [..] Monitor;
 native_timers: Table(*Focus_Timer, *NSTimer);
 refresh_timer: *Focus_Timer;
 cursor_timer:  *Focus_Timer;
+autosave_timer: *Focus_Timer;
 
 timer_class_registered := false;
 Focus_Timer :: struct {

--- a/src/platform/windows.jai
+++ b/src/platform/windows.jai
@@ -98,6 +98,14 @@ platform_kill_cursor_timer :: (window: Window_Type) {
     KillTimer(window, CURSOR_TIMER_ID);
 }
 
+platform_set_autosave_timer :: (window: Window_Type) {
+    SetTimer(window, AUTOSAVE_TIMER_ID, 50, cast(*void) 0);
+}
+
+platform_kill_autosave_timer :: (window: Window_Type) {
+    KillTimer(window, AUTOSAVE_TIMER_ID);
+}
+
 platform_enumerate_logical_drives :: () -> [] string {
     drives: [..] string;
 
@@ -307,6 +315,7 @@ monitors : [..] Monitor;
 
 REFRESH_TIMER_ID :: 0;
 CURSOR_TIMER_ID  :: 1;
+AUTOSAVE_TIMER_ID :: 2;
 
 WM_USER :: 0x0400;
 


### PR DESCRIPTION
Hey, I implemented a feature for autosaving modified files in x seconds. Currently, it works by checking if there is no input for the specified amount of time in the configuration, and then it will save all modified buffers in the editor. For files that have been modified on the disk with changes in the editor, it will not autosave the new changes. There is a bug currently when inputting backspaces, as it does not reset the timer for the autosave and will autosave as if no changes are being made, even though there is user input. The session modified buffer functionality has some overlap with this, and once it is implemented it may be able to fix the problem. You may already be trying to implement this with the session modified buffer code, so you might want to discard or take what pieces you want from this, thanks.