### PR TITLE
Attempt to make directory when saving as

### DIFF
--- a/src/deferred_actions.jai
+++ b/src/deferred_actions.jai
@@ -278,6 +278,14 @@ execute_save_as :: (action: Deferred_Action) -> Action_Result {
             push_action(.confirm_overwrite, .{ confirm_overwrite = .{ buffer_id = buffer_id, is_move = is_move, file_path = copy_string(file_path) } });
             return .NEXT;
         } else {
+            found, directory, file := split_from_right(file_path, #char "/");
+            if found && directory.count > 0 {
+                success := make_directory_if_it_does_not_exist(directory, recursive=true);
+                if !success {
+                    add_user_error("Unable to make directory '%'", directory);
+                    return .CANCEL;
+                }
+            }
             save_buffer_to_file(buffer, buffer_id, file_path);
             if buffer.error_when_saving {
                 add_user_error("Unable to save file into '%'", file_path);


### PR DESCRIPTION
If the user enters a filename like "test/dir/file" we create the test/dir directory before saving the file.