### PR TITLE
Improve touchpad scrolling on Wayland

### DIFF
--- a/modules/Linux_Display/ldw_input.jai
+++ b/modules/Linux_Display/ldw_input.jai
@@ -168,10 +168,9 @@ pointer_listener :: wl_pointer_listener.{
         ctx: Context;
         push_context ctx {
             d: *Wayland_Display = wl_proxy_get_user_data(self);
-            sign := ifx (wl_fixed_to_double(value) < 0) then cast(s32)-1 else 1;
-            delta := (WHEEL_DELTA / 2); // @TODO: this is set on a "feels good on my machine" basis, should be calculated some other way (perhaps based on the height of a line?)
+            delta := wl_fixed_to_int(value);
             if !d.pointer_axis_accumulator[axis] {
-                d.pointer_axis_accumulator[axis] = d.pointer_axis_multiplier[axis] * sign * delta;
+                d.pointer_axis_accumulator[axis] = -delta * 4;
             }
         }
     },


### PR DESCRIPTION
This change makes touchpad scrolling scroll the distance the Wayland compositor tells us to scroll.

It also fixes a bug that made natural scrolling not work when it was enabled in the compositor.