### PR TITLE
C syntax highlighting: Highlighting for UL and ULL suffixes

### DIFF
--- a/src/langs/common.jai
+++ b/src/langs/common.jai
@@ -230,6 +230,15 @@ parse_number_c_like :: (using tokenizer: *Tokenizer, token: *$Token) {
             }
             } else if  t.* == #char "u" || t.* == #char "U" {     // u
                 t += 1;
+                if t >= max_t return;
+
+                if t.* == #char "l" || t.* == #char "L" {         // ul
+                    t += 1;
+                    if t >= max_t return;
+                    if t.* == #char "l" || t.* == #char "L" {     // ull
+                        t += 1;
+                    }
+                }
             }
         }
     } else if start_char == #char "0" {


### PR DESCRIPTION
Color highlighting for UL and ULL suffixes. 

example:
```C
u64 foo = 1000000000ULL;
```