### PR TITLE
Fix crash when doing block-comment as fallback with multiple cursors

### DIFF
--- a/src/editors.jai
+++ b/src/editors.jai
@@ -4580,25 +4580,39 @@ toggle_block_comment :: (editor: *Editor, buffer: *Buffer, is_fallback := false)
     } else {
         comment_total_length := cast(s32)(comment_start.count + comment_end.count);
 
-        for * cursor : editor.cursors {
-            move_count := cast(s32)it_index * comment_total_length;
+        ranges_to_comment_out : [..]Offset_Range;
+        ranges_to_comment_out.allocator = temp;
 
-            selection := get_selection(cursor);
+        array_resize(*ranges_to_comment_out, editor.cursors.count);
+
+        // Precalculate line start offsets when using block comments as a fallback
+        // for commenting out single line with multiple cursors. This way we don't
+        // need to run rescan_for_lines() after each comment block is inserted.
+        for * cursor : editor.cursors {
+            range := get_selection(cursor);
 
             // If it's a fallback we want to comment out lines entirely, not just selection (as we do in toggle_comment)
             if is_fallback {
-                selection_start_line_index := offset_to_real_line(buffer, selection.start);
-                selection_end_line_index   := offset_to_real_line(buffer, selection.end);
+                selection_start_line_index := offset_to_real_line(buffer, range.start);
+                selection_end_line_index   := offset_to_real_line(buffer, range.end);
 
-                selection.start = get_real_line_start_offset(buffer, selection_start_line_index);
-                selection.end   = get_real_line_end_offset(buffer, selection_end_line_index);
+                range.start = get_real_line_start_offset(buffer, selection_start_line_index);
+                range.end   = get_real_line_end_offset(buffer, selection_end_line_index);
             }
 
-            start_pos := selection.start + move_count;
-            end_pos   := selection.end   + move_count + cast(s32) comment_start.count;
+            ranges_to_comment_out[it_index] = range;
+        }
+
+        for * cursor : editor.cursors {
+            move_count := cast(s32)it_index * comment_total_length;
+
+            range     := ranges_to_comment_out[it_index];
+            start_pos := range.start + move_count;
+            end_pos   := range.end + move_count + cast(s32)comment_start.count;
 
             insert_string_at_offset(buffer, start_pos, comment_start);
             insert_string_at_offset(buffer, end_pos,   comment_end);
+
             cursor.pos += cast(s32)comment_start.count + move_count;
             cursor.sel += cast(s32)comment_start.count + move_count;
         }


### PR DESCRIPTION
Fixes a crash due to trying to calculate line start index from a dirty buffer after the previous cursor's selection was commented out. This change calculates the line start indices before any text is inserted.

I initially fixed this by running rescan_for_lines() for each cursor, but that seemed like a lot of unnecessary work, especially if working in a big file.

This bug was originally reported on Discord as follows:
> Focus crashes when you toggle comment (Ctrl-/) with multiple cursors in a .css file. 
Minimal reproduction: enter two empty lines, put a cursor on each and run the toggle-comment command. 
![image](https://github.com/user-attachments/assets/bfcd8144-8189-4751-9e93-305fff77ddf7)

https://discord.com/channels/1106007785193345104/1354900494459473990