### PR TITLE
Bugfix in change_case_of_selected_text

### DIFF
--- a/src/editors.jai
+++ b/src/editors.jai
@@ -4048,6 +4048,7 @@ change_case_of_selected_text :: (editor: *Editor, buffer: *Buffer, mode: enum { 
             else                           continue;
         }
 
+        auto_release_temp();
         new_text := copy_temporary_string(current_text);
         if mode == {
             case .upper;

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -4031,14 +4031,14 @@ change_case_of_selected_text :: (editor: *Editor, buffer: *Buffer, mode: enum { 
         if !has_selection(cursor)  continue;
 
         selection := get_selection(cursor);
-        s := get_selected_string(cursor, buffer);
+        current_text := get_selected_string(cursor, buffer);
 
         if mode == .cycle {
             found_lower := false;
             found_upper := false;
-            for 0 .. s.count - 1 {
-                if      is_lower(s[it])  found_lower = true;
-                else if is_upper(s[it])  found_upper = true;
+            for 0 .. current_text.count - 1 {
+                if      is_lower(current_text[it])  found_lower = true;
+                else if is_upper(current_text[it])  found_upper = true;
 
                 if found_lower && found_upper  break;
             }
@@ -4048,27 +4048,28 @@ change_case_of_selected_text :: (editor: *Editor, buffer: *Buffer, mode: enum { 
             else                           continue;
         }
 
+        new_text := copy_temporary_string(current_text);
         if mode == {
             case .upper;
-                for 0 .. s.count - 1 {
-                    s[it] = to_upper(s[it]);
+                for 0 .. new_text.count - 1 {
+                    new_text[it] = to_upper(new_text[it]);
                 }
 
             case .lower;
-                for 0 .. s.count - 1 {
-                    s[it] = to_lower(s[it]);
+                for 0 .. new_text.count - 1 {
+                    new_text[it] = to_lower(new_text[it]);
                 }
 
             case .caps;
                 caps_next := true;
-                for 0 .. s.count - 1 {
-                    if is_alpha(s[it]) {
+                for 0 .. new_text.count - 1 {
+                    if is_alpha(new_text[it]) {
                         if caps_next {
                             caps_next = false;
-                            s[it] = to_upper(s[it]);
+                            new_text[it] = to_upper(new_text[it]);
                         }
                         else {
-                            s[it] = to_lower(s[it]);
+                            new_text[it] = to_lower(new_text[it]);
                         }
                     }
                     else {
@@ -4077,7 +4078,7 @@ change_case_of_selected_text :: (editor: *Editor, buffer: *Buffer, mode: enum { 
                 }
         }
 
-        replace_range(buffer, .{selection.start, selection.end}, s);
+        replace_range(buffer, .{selection.start, selection.end}, new_text);
     }
 }
 


### PR DESCRIPTION
change_case_of_selected_text was modifying buffer directly in place. It wasn't marking file as dirty and it wasn't working with undo/redo. replace_range called at the end of this function wasn't really doing anything.
This is fixed by introducing temporary string copy that is modified and passed to replace_range.