### PR TITLE
Mac: Added Hide command and Services menu

### DIFF
--- a/FOCUS-CHANGELOG.txt
+++ b/FOCUS-CHANGELOG.txt
@@ -11,6 +11,7 @@
     + New builtin themes:
         + Catppuccin, Rosé Pine, Jellybeans, Kanagawa, VSCode Dark (thanks @daolgierd)
         + Redshift (thanks @MusaMahmood)
+    + Mac: Hide command and Services menu added
 
 
 # RELEASES ==================================================================

--- a/modules/Objective_C/AppKit.jai
+++ b/modules/Objective_C/AppKit.jai
@@ -119,6 +119,18 @@ NSApplication :: struct {
         func :: #type (*void, Selector, NSUInteger) #c_call;
         (cast(func) objc_msgSend)(self, _sel.replyToOpenOrPrint_, reply);
     }
+    
+    // Added for Focus
+    setServicesProvider :: (self: *NSApplication, dg: id) #no_context {
+        func :: #type (*void, Selector, id) -> void #c_call;
+        (cast(func) objc_msgSend)(self, _sel.setServicesProvider_, dg);
+    }
+
+    // Added for Focus
+    setServicesMenu :: (self: *NSApplication, menu: *NSMenu) #no_context {
+        func :: #type (*void, Selector, *NSMenu) -> void #c_call;
+        (cast(func) objc_msgSend)(self, _sel.setServicesMenu_, menu);
+    }
 }
 
 
@@ -845,10 +857,27 @@ NSMenu :: struct {
         func = xx objc_msgSend;
         return func(self, _sel.addItemWithTitle_action_keyEquivalent_, title, action, keyEquivalent);
     }
+    
+    // Added for Focus
+    setTitle :: (self: *NSMenu, title: *NSString) -> id {
+        func :: #type (*void, Selector, *NSString) -> id #c_call;
+        return (cast(func) objc_msgSend)(self, _sel.setTitle_, title);
+    }
+    
+    // helper functions. Added for Focus
+    setTitle :: (self: *NSMenu, title: string) -> id {
+        nsstring := NSString.initWithString(objc_alloc(NSString), title);
+        defer release(nsstring);
+        return setTitle(self, nsstring);
+    }
 }
 
 NSMenuItem :: struct {
     using #as super: NSObject;
+
+    separatorItem :: () -> *NSMenuItem {
+        return xx objc_msgSend_typed(class(NSMenuItem), _sel.separatorItem);
+    }
 
     initWithTitle :: (self: *NSMenuItem, title: *NSString, action: Selector, keyEquivalent: *NSString) -> *NSMenuItem {
         func :: #type (*void, Selector, *NSString, Selector, *NSString) -> *NSMenuItem #c_call;
@@ -1562,6 +1591,9 @@ _sel: struct #type_info_no_size_complaint {
     screen: Selector;
     postEvent_atStart_: Selector;
     otherEventWithType_location_modifierFlags_timestamp_windowNumber_context_subtype_data1_data2_: Selector;
+    separatorItem: Selector;
+    setServicesProvider_: Selector;
+    setServicesMenu_: Selector;
 }
 
 #import "Objective_C";

--- a/modules/Window_Creation/osx.jai
+++ b/modules/Window_Creation/osx.jai
@@ -23,35 +23,57 @@ init_mac_app :: () {
     #if #run macos_create_app_delegate_exists() { // :DecoupleWindowCreationAndInput:
         dg := context._macos_create_app_delegate();
         NSApplication.setDelegate(NSApp, dg);
+        NSApplication.setServicesProvider(NSApp, dg);
     }
 
+    // Create main menu
     menu_bar := objc_init(objc_alloc(NSMenu));
     autorelease(menu_bar);
     NSApp.setMainMenu(NSApp, menu_bar);
 
     S :: NSString.getTempString;
 
+    // Apple menu
     app_menu_item := menu_bar.addItemWithTitle(menu_bar, S(""), null, S(""));
     autorelease(app_menu_item);
 
     app_menu := objc_init(objc_alloc(NSMenu));
     autorelease(app_menu);
 
-    // @TODO we should probably override toggleFullScreen: in NSApplication in order to also set presentation options
-    // like we do in toggle_fullscreen
+    // Apple menu items
+    // app_menu.addItem(app_menu, services_menu_item);
+    app_menu.addItem(app_menu, NSMenuItem.separatorItem());
+    
     fullscreen_item := app_menu.addItemWithTitle(app_menu, S("Enter Full Screen"), selector("toggleFullScreen:"), S("f"));
-
-    // Change keyboard shortcut for fullscreen to the standard Ctrl-Cmd-F (instead of the default Cmd-F)
-    new_mask := NSEventModifierFlagControl | NSEventModifierFlagCommand;
-    NSMenuItem.setKeyEquivalentModifierMask(fullscreen_item, new_mask);
-
-    app_menu.addItemWithTitle(app_menu, S(tprint("Quit")), selector("terminate:"), S("q"));
-
+    NSMenuItem.setKeyEquivalentModifierMask(fullscreen_item, NSEventModifierFlagControl | NSEventModifierFlagCommand);
+    app_menu.addItemWithTitle(app_menu, S("Quit Focus"), selector("terminate:"), S("q"));
+    
     app_menu_item.setSubmenu(app_menu_item, app_menu);
 
+    // Window menu
+    window_menu_item := menu_bar.addItemWithTitle(menu_bar, S(""), null, S(""));
+    autorelease(window_menu_item);
+    window_menu := objc_init(objc_alloc(NSMenu));
+    autorelease(window_menu);
+    window_menu.setTitle(window_menu, S("Window"));
+
+    // Window menu items
+    window_menu.addItemWithTitle(window_menu, S("Minimize"), selector("miniaturize:"), S("m"));
+    window_menu.addItemWithTitle(window_menu, S("Hide"), selector("hide:"), S("h"));
+    
+    window_menu_item.setSubmenu(window_menu_item, window_menu);
+    
+    // Services menu
+    services_menu_item := app_menu.addItemWithTitle(menu_bar, S(""), null, S(""));
+    autorelease(services_menu_item);
+    services_menu := objc_init(objc_alloc(NSMenu));
+    autorelease(services_menu);
+    services_menu.setTitle(services_menu, S("Services"));
+    services_menu_item.setSubmenu(services_menu_item, services_menu);
+    NSApplication.setServicesMenu(NSApp, services_menu);
+    
     NSApplication.setAppleMenu(NSApp, app_menu);
     NSApplication.finishLaunching(NSApp);
-
     application_initialized = true;
 }
 


### PR DESCRIPTION
I've been annoyed at times not being able to Cmd+H Focus away. Now I can.

Adding the Services menu, if you're asking why, allows for system keyboard shortcuts to work within Focus. This includes things like user-created scripts in the Shortcuts app. Previously, they did not work when Focus was focused.