### PR TITLE
Fixed MSVC error regex

### DIFF
--- a/config/default.focus-config
+++ b/config/default.focus-config
@@ -138,7 +138,7 @@ draw_indent_guides:                                 false
 
 # Example error regexes:
 # For Jai:    ^(?P<file>.*):(?P<line>\d+),(?P<col>\d+): (?P<type>Error|Warning|Info|...):* (?P<msg>.*)|^(?P<msg1>.*error LNK.*)
-# For MSVC:   ^(?P<file>.*)\((?P<line>\d+),?(?P<col>\d+)?\)[ ]?: (?P<type>error|warning) (?P<msg>.*)$
+# For MSVC:   ^(?P<file>.*)\((?P<line>\d+),?(?P<col>\d+)?\):[ ]?(?P<type>fatal error|error|warning) (?P<msg>.*)$
 # For Golang: ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<msg>.*)$
 # For Gcc:    ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<type>error|warning): (?P<msg>.*) (\[(?P<msg1>.*)\])?$
 # For Odin:   ^(?P<file>.*)\((?P<line>\d+):(?P<col>\d+)\) (?P<type>Error|Syntax Error): (?P<msg>.*)$

--- a/config/default.focus-config
+++ b/config/default.focus-config
@@ -138,7 +138,7 @@ draw_indent_guides:                                 false
 
 # Example error regexes:
 # For Jai:    ^(?P<file>.*):(?P<line>\d+),(?P<col>\d+): (?P<type>Error|Warning|Info|...):* (?P<msg>.*)|^(?P<msg1>.*error LNK.*)
-# For MSVC:   ^(?P<file>.*)\((?P<line>\d+),?(?P<col>\d+)?\):[ ]?(?P<type>fatal error|error|warning) (?P<msg>.*)$
+# For MSVC:   ^(?P<file>.*)\((?P<line>\d+),?(?P<col>\d+)?\)[ ]?: (?P<type>fatal error|error|warning) (?P<msg>.*)$
 # For Golang: ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<msg>.*)$
 # For Gcc:    ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<type>error|warning): (?P<msg>.*) (\[(?P<msg1>.*)\])?$
 # For Odin:   ^(?P<file>.*)\((?P<line>\d+):(?P<col>\d+)\) (?P<type>Error|Syntax Error): (?P<msg>.*)$

--- a/config/example-project.focus-config
+++ b/config/example-project.focus-config
@@ -35,7 +35,7 @@
 
 # Example error regexes:
 # For jai:    ^(?P<file>.*):(?P<line>\d+),(?P<col>\d+): (?P<type>Error|Warning|Info|...):* (?P<msg>.*)|^(?P<msg1>.*error LNK.*)
-# For msvc:   ^(?P<file>.*)\((?P<line>\d+),?(?P<col>\d+)?\)[ ]?: (?P<type>error|warning) (?P<msg>.*)$
+# For msvc:   ^(?P<file>.*)\((?P<line>\d+),?(?P<col>\d+)?\):[ ]?(?P<type>fatal error|error|warning) (?P<msg>.*)$
 # For golang: ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<msg>.*)$
 # For gcc:    ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<type>error|warning): (?P<msg>.*) (\[(?P<msg1>.*)\])?$
 # ... let us know what regex works for you and we'll add it here

--- a/config/example-project.focus-config
+++ b/config/example-project.focus-config
@@ -35,7 +35,7 @@
 
 # Example error regexes:
 # For jai:    ^(?P<file>.*):(?P<line>\d+),(?P<col>\d+): (?P<type>Error|Warning|Info|...):* (?P<msg>.*)|^(?P<msg1>.*error LNK.*)
-# For msvc:   ^(?P<file>.*)\((?P<line>\d+),?(?P<col>\d+)?\):[ ]?(?P<type>fatal error|error|warning) (?P<msg>.*)$
+# For msvc:   ^(?P<file>.*)\((?P<line>\d+),?(?P<col>\d+)?\)[ ]?: (?P<type>fatal error|error|warning) (?P<msg>.*)$
 # For golang: ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<msg>.*)$
 # For gcc:    ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<type>error|warning): (?P<msg>.*) (\[(?P<msg1>.*)\])?$
 # ... let us know what regex works for you and we'll add it here


### PR DESCRIPTION
The previous regex wouldn't catch fatal errors.
The easiest way to cause a fatal error is to compile this: \#error this should cause a fatal error
See: https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-fatal-errors-c999-through-c1999