### PR TITLE
Fixed Gcc error regex

### DIFF
--- a/config/default.focus-config
+++ b/config/default.focus-config
@@ -140,7 +140,7 @@ draw_indent_guides:                                 false
 # For Jai:    ^(?P<file>.*):(?P<line>\d+),(?P<col>\d+): (?P<type>Error|Warning|Info|...):* (?P<msg>.*)|^(?P<msg1>.*error LNK.*)
 # For MSVC:   ^(?P<file>.*)\((?P<line>\d+),?(?P<col>\d+)?\)[ ]?: (?P<type>fatal error|error|warning) (?P<msg>.*)$
 # For Golang: ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<msg>.*)$
-# For Gcc:    ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<type>error|warning): (?P<msg>.*) (\[(?P<msg1>.*)\])?$
+# For Gcc:    ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<type>error|warning): (?P<msg>.*)( \[(?P<msg1>.*)\])?$
 # For Odin:   ^(?P<file>.*)\((?P<line>\d+):(?P<col>\d+)\) (?P<type>Error|Syntax Error): (?P<msg>.*)$
 # ... let us know what regex works for you and we'll add it here
 

--- a/config/example-project.focus-config
+++ b/config/example-project.focus-config
@@ -37,7 +37,7 @@
 # For jai:    ^(?P<file>.*):(?P<line>\d+),(?P<col>\d+): (?P<type>Error|Warning|Info|...):* (?P<msg>.*)|^(?P<msg1>.*error LNK.*)
 # For msvc:   ^(?P<file>.*)\((?P<line>\d+),?(?P<col>\d+)?\)[ ]?: (?P<type>fatal error|error|warning) (?P<msg>.*)$
 # For golang: ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<msg>.*)$
-# For gcc:    ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<type>error|warning): (?P<msg>.*) (\[(?P<msg1>.*)\])?$
+# For gcc:    ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<type>error|warning): (?P<msg>.*)( \[(?P<msg1>.*)\])?$
 # ... let us know what regex works for you and we'll add it here
 
 # NOTE:


### PR DESCRIPTION
Not sure what `(\[(?P<msg1>.*)\])` is for but if it isn't required, the space separating it from `(?P<msg>.*)` also shouldn't be required (as demonstrated from a couple examples):

All of these are not caught with the previous regex and are caught with this modification (only the first line of the error message is included):
`src/efi.h:374:5: error: unknown type name 'EFI_SIMPLE_INPUT_MODE'; did you mean 'EFI_SIMPLE_POINTER_MODE'?`
`src/efi.h:420:8: error: expected ';', ',' or ')' before 'UINT32'`
`src/efi.c:374:5: error: called object is not a function or function pointer`

There might be some example of `(\[(?P<msg1>.*)\])` being used but I don't remember any right now. I left it there in case it is used in some more obscure error messages.

Now without other commits which were already merged before :)