### PR TITLE
Fix gcc error regex

### DIFF
--- a/config/default.focus-config
+++ b/config/default.focus-config
@@ -140,7 +140,7 @@ draw_indent_guides:                                 false
 # For Jai:    ^(?P<file>.*):(?P<line>\d+),(?P<col>\d+): (?P<type>Error|Warning|Info|...):* (?P<msg>.*)|^(?P<msg1>.*error LNK.*)
 # For MSVC:   ^(?P<file>.*)\((?P<line>\d+),?(?P<col>\d+)?\)[ ]?: (?P<type>fatal error|error|warning) (?P<msg>.*)$
 # For Golang: ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<msg>.*)$
-# For Gcc:    ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<type>error|warning): (?P<msg>.*)( \[(?P<msg1>.*)\])?$
+# For Gcc:    ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<type>fatal error|error|warning): (?P<msg>.*)( \[(?P<msg1>.*)\])?$
 # For Odin:   ^(?P<file>.*)\((?P<line>\d+):(?P<col>\d+)\) (?P<type>Error|Syntax Error): (?P<msg>.*)$
 # ... let us know what regex works for you and we'll add it here
 

--- a/config/example-project.focus-config
+++ b/config/example-project.focus-config
@@ -37,7 +37,7 @@
 # For jai:    ^(?P<file>.*):(?P<line>\d+),(?P<col>\d+): (?P<type>Error|Warning|Info|...):* (?P<msg>.*)|^(?P<msg1>.*error LNK.*)
 # For msvc:   ^(?P<file>.*)\((?P<line>\d+),?(?P<col>\d+)?\)[ ]?: (?P<type>fatal error|error|warning) (?P<msg>.*)$
 # For golang: ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<msg>.*)$
-# For gcc:    ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<type>error|warning): (?P<msg>.*)( \[(?P<msg1>.*)\])?$
+# For gcc:    ^(?P<file>.*):(?P<line>\d+):(?P<col>\d+): (?P<type>fatal error|error|warning): (?P<msg>.*)( \[(?P<msg1>.*)\])?$
 # ... let us know what regex works for you and we'll add it here
 
 # NOTE:


### PR DESCRIPTION
Hopefully the last fix needed for gcc.

Gcc can also show fatal errors, easiest way to get a fatal error:
Try to #include a file which doesn't exist:
```
src/cursor.h:4:10: fatal error: efi.h: No such file or directory
    4 | #include "efi.h"
      |          ^~~~~~~
```
