### PR TITLE
Add %FILE_LINE%, %FILE_COLUMN% to substitute_variables

### DIFF
--- a/config/default.focus-config
+++ b/config/default.focus-config
@@ -154,6 +154,8 @@ draw_indent_guides:                                 false
 # %FILE_DIR%  - the directory of the currently active file
 # %FILE_NAME% - current file name, with extension
 # %FILE_NAME_NO_EXTENSION% - current file name, without extension
+# %FILE_LINE%   - line under cursor in current file
+# %FILE_COLUMN% - column under cursor in current file
 # %BUILD_WORKING_DIR%  - working dir of the build command
 # %RUN_WORKING_DIR%    - working dir of the run command
 # %PROJECT_CONFIG_DIR% - the dir containing the active project config file

--- a/config/default_macos.focus-config
+++ b/config/default_macos.focus-config
@@ -148,6 +148,8 @@ draw_indent_guides:                                 false
 # %FILE_DIR%  - the directory of the currently active file
 # %FILE_NAME% - current file name, with extension
 # %FILE_NAME_NO_EXTENSION% - current file name, without extension
+# %FILE_LINE%   - line under cursor in current file
+# %FILE_COLUMN% - column under cursor in current file
 # %BUILD_WORKING_DIR%  - working dir of the build command
 # %RUN_WORKING_DIR%    - working dir of the run command
 # %PROJECT_CONFIG_DIR% - the dir containing the active project config file

--- a/config/example-project.focus-config
+++ b/config/example-project.focus-config
@@ -46,6 +46,8 @@
 # %FILE_DIR%  - the directory of the currently active file
 # %FILE_NAME% - current file name, with extension
 # %FILE_NAME_NO_EXTENSION% - current file name, without extension
+# %FILE_LINE%   - line under cursor in current file
+# %FILE_COLUMN% - column under cursor in current file
 # %BUILD_WORKING_DIR% - working dir of the build command
 # %RUN_WORKING_DIR%   - working dir of the run command
 # %PROJECT_CONFIG_DIR% - path of the directory containing the active project config file

--- a/src/build_system.jai
+++ b/src/build_system.jai
@@ -492,14 +492,23 @@ print_to_output_panel_from_main_thread :: (s: string, mark_as: Buffer_Region.Kin
 substitute_variables :: (using work: *Build_Thread_Work) {
     // Figure out the current file
     file := "";
+    coords_under_cursor: Coords;
     active_pane_editor_id := get_active_editor_id();
     if active_pane_editor_id > 0 {
         buffer := open_buffers[open_editors[active_pane_editor_id].buffer_id];
-        if buffer.has_file then file = copy_string(buffer.file.full_path);
+        if buffer.has_file
+        {
+            file = copy_string(buffer.file.full_path);
+            if buffer.cursors.count > 0
+            {
+                cursor := buffer.cursors[0];
+                coords_under_cursor = offset_to_real_coords(buffer, cursor.pos);
+            }
+        }
     }
 
     file_vars_are_used := false;
-    file_vars := string.["%FILE%", "%FILE_DIR%", "%FILE_NAME%", "%FILE_NAME_NO_EXTENSION%"];
+    file_vars := string.["%FILE%", "%FILE_DIR%", "%FILE_NAME%", "%FILE_NAME_NO_EXTENSION%", "%FILE_LINE%", "%FILE_COLUMN%"];
     for file_vars {
         if contains(build_command, it) || contains(run_command, it) || contains(build_working_dir, it) || contains(run_working_dir, it) {
             file_vars_are_used = true;
@@ -511,26 +520,36 @@ substitute_variables :: (using work: *Build_Thread_Work) {
 
         file_dir, file_name_no_extension, _, file_name := path_decomp(file);
         file_dir = trim_right(file_dir, "/");
+        file_line := sprint("%", coords_under_cursor.line + 1);
+        file_column := sprint("%", coords_under_cursor.col + 1);
 
         build_working_dir = replace(build_working_dir, "%FILE%",                   file);
         build_working_dir = replace(build_working_dir, "%FILE_DIR%",               file_dir);
         build_working_dir = replace(build_working_dir, "%FILE_NAME%",              file_name);
         build_working_dir = replace(build_working_dir, "%FILE_NAME_NO_EXTENSION%", file_name_no_extension);
+        build_working_dir = replace(build_working_dir, "%FILE_LINE%",              file_line);
+        build_working_dir = replace(build_working_dir, "%FILE_COLUMN%",            file_column);
 
         run_working_dir   = replace(run_working_dir,   "%FILE%",                   file);
         run_working_dir   = replace(run_working_dir,   "%FILE_DIR%",               file_dir);
         run_working_dir   = replace(run_working_dir,   "%FILE_NAME%",              file_name);
         run_working_dir   = replace(run_working_dir,   "%FILE_NAME_NO_EXTENSION%", file_name_no_extension);
+        run_working_dir   = replace(run_working_dir,   "%FILE_LINE%",              file_line);
+        run_working_dir   = replace(run_working_dir,   "%FILE_COLUMN%",            file_column);
 
         build_command     = replace(build_command,     "%FILE%",                   file);
         build_command     = replace(build_command,     "%FILE_DIR%",               file_dir);
         build_command     = replace(build_command,     "%FILE_NAME%",              file_name);
         build_command     = replace(build_command,     "%FILE_NAME_NO_EXTENSION%", file_name_no_extension);
+        build_command     = replace(build_command,     "%FILE_LINE%",              file_line);
+        build_command     = replace(build_command,     "%FILE_COLUMN%",            file_column);
 
         run_command       = replace(run_command,       "%FILE%",                   file);
         run_command       = replace(run_command,       "%FILE_DIR%",               file_dir);
         run_command       = replace(run_command,       "%FILE_NAME%",              file_name);
         run_command       = replace(run_command,       "%FILE_NAME_NO_EXTENSION%", file_name_no_extension);
+        run_command       = replace(run_command,       "%FILE_LINE%",              file_line);
+        run_command       = replace(run_command,       "%FILE_COLUMN%",            file_column);
     }
 
     // Replace %PROJECT_CONFIG_DIR% if used

--- a/src/build_system.jai
+++ b/src/build_system.jai
@@ -490,21 +490,18 @@ print_to_output_panel_from_main_thread :: (s: string, mark_as: Buffer_Region.Kin
 }
 
 substitute_variables :: (using work: *Build_Thread_Work) {
-    // Figure out the current file
+    // Figure out the current file and cursor coords
     file := "";
-    coords_under_cursor: Coords;
+    cursor_coords: Coords;
+
     active_pane_editor_id := get_active_editor_id();
     if active_pane_editor_id > 0 {
         buffer := open_buffers[open_editors[active_pane_editor_id].buffer_id];
-        if buffer.has_file
-        {
-            file = copy_string(buffer.file.full_path);
-            if buffer.cursors.count > 0
-            {
-                cursor := buffer.cursors[0];
-                coords_under_cursor = offset_to_real_coords(buffer, cursor.pos);
-            }
-        }
+        if buffer.has_file then file = copy_string(buffer.file.full_path);
+
+        editor := *open_editors[active_pane_editor_id];
+        main_cursor := editor.cursors[editor.main_cursor];
+        cursor_coords = offset_to_real_coords(buffer, main_cursor.pos);
     }
 
     file_vars_are_used := false;
@@ -520,8 +517,8 @@ substitute_variables :: (using work: *Build_Thread_Work) {
 
         file_dir, file_name_no_extension, _, file_name := path_decomp(file);
         file_dir = trim_right(file_dir, "/");
-        file_line := sprint("%", coords_under_cursor.line + 1);
-        file_column := sprint("%", coords_under_cursor.col + 1);
+        file_line := sprint("%", cursor_coords.line + 1);
+        file_column := sprint("%", cursor_coords.col + 1);
 
         build_working_dir = replace(build_working_dir, "%FILE%",                   file);
         build_working_dir = replace(build_working_dir, "%FILE_DIR%",               file_dir);

--- a/src/config_parser.jai
+++ b/src/config_parser.jai
@@ -847,7 +847,8 @@ parse_build_line :: (using parser: *Config_Parser, line: string) -> success: boo
                             // Exit early if variables are used in path
                             vars_used := false;
                             var_names := string.[
-                                "%FILE%", "%FILE_DIR%", "%FILE_NAME%", "%FILE_NAME_NO_EXTENSION%", "%PROJECT_CONFIG_DIR%",
+                                "%FILE%", "%FILE_DIR%", "%FILE_NAME%", "%FILE_NAME_NO_EXTENSION%",
+                                "%FILE_LINE%", "%FILE_COLUMN%", "%PROJECT_CONFIG_DIR%",
                             ];
                             for var : var_names {
                                 start_index := 0;
@@ -898,6 +899,7 @@ parse_build_line :: (using parser: *Config_Parser, line: string) -> success: boo
                         code := #string JAI
                             var_names := string.[
                                 "%FILE%", "%FILE_DIR%", "%FILE_NAME%", "%FILE_NAME_NO_EXTENSION%",
+                                "%FILE_LINE%", "%FILE_COLUMN%",
                                 "%BUILD_WORKING_DIR%", "%RUN_WORKING_DIR%", "%PROJECT_CONFIG_DIR%",
                             ];
                             for var : var_names {


### PR DESCRIPTION
Querying file line and file column is useful for interacting with other programs like debuggers via commands.
For example: `run_command: raddbg --ipc find_code_location "%FILE%:%FILE_LINE%:%FILE_COLUMN%"`