### PR TITLE
Use C++ syntax highlighting for .tpp files

### DIFF
--- a/src/editors.jai
+++ b/src/editors.jai
@@ -2197,6 +2197,7 @@ get_lang_from_path :: (full_path: string) -> Buffer.Lang {
         case "hh";              lang = .Cpp;
         case "m";               lang = .Cpp;
         case "mm";              lang = .Cpp;
+        case "tpp";             lang = .Cpp;
 
         case "html";            lang = .Html;
         case "htm";             lang = .Html;


### PR DESCRIPTION
This change applies C++ syntax highlighting to .tpp files by default.
Fixes https://github.com/focus-editor/focus/issues/511