### PR TITLE
Add option to show/hide tab characters

### DIFF
--- a/config/themes/basic-light.focus-theme
+++ b/config/themes/basic-light.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
 
 [colors]
 background0:                            FFFFFFFF

--- a/config/themes/catppuccin-frappe.focus-theme
+++ b/config/themes/catppuccin-frappe.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
       # (https://github.com/catppuccin/catppuccin)
 
 [colors]

--- a/config/themes/catppuccin-latte.focus-theme
+++ b/config/themes/catppuccin-latte.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
       # (https://github.com/catppuccin/catppuccin)
 
 [colors]

--- a/config/themes/catppuccin-macchiato.focus-theme
+++ b/config/themes/catppuccin-macchiato.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
       # (https://github.com/catppuccin/catppuccin)
 
 [colors]

--- a/config/themes/catppuccin-mocha.focus-theme
+++ b/config/themes/catppuccin-mocha.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
       # (https://github.com/catppuccin/catppuccin)
 
 [colors]

--- a/config/themes/everforest-hard.focus-theme
+++ b/config/themes/everforest-hard.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
 
 # Based on Everforest Hard colors from https://github.com/sainnhe/everforest.
 

--- a/config/themes/gruber-darker.focus-theme
+++ b/config/themes/gruber-darker.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
 
 # Based on the gruber darker theme by Jason Blevins
 # https://github.com/rexim/gruber-darker-theme

--- a/config/themes/gruvbox-flat.focus-theme
+++ b/config/themes/gruvbox-flat.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
 
 [colors]
 

--- a/config/themes/halogen.focus-theme
+++ b/config/themes/halogen.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
 
 [colors]
 background0:                            181818FF

--- a/config/themes/handmade-hero.focus-theme
+++ b/config/themes/handmade-hero.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
 
 # Based on Casey Muratori's emacs theme used on Handmade Hero series
 

--- a/config/themes/jblow-nostalgia.focus-theme
+++ b/config/themes/jblow-nostalgia.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
 
 [colors]
 

--- a/config/themes/jblowtorch.focus-theme
+++ b/config/themes/jblowtorch.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
 
 [colors]
 background0:                            072626FF

--- a/config/themes/jellybeans.focus-theme
+++ b/config/themes/jellybeans.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
       # (https://github.com/nanotech/jellybeans.vim)
 
 [colors]

--- a/config/themes/kanagawa.focus-theme
+++ b/config/themes/kanagawa.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
       # (https://github.com/rebelot/kanagawa.nvim)
 
 [colors]

--- a/config/themes/kujukuju.focus-theme
+++ b/config/themes/kujukuju.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
 
 [colors]
 background0:                            141824FF

--- a/config/themes/nord-midnight.focus-theme
+++ b/config/themes/nord-midnight.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
 
 [colors]
 background0:                            1D2129FF

--- a/config/themes/nord.focus-theme
+++ b/config/themes/nord.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
 
 [colors]
 background0:                            2E3440FF

--- a/config/themes/redshift.focus-theme
+++ b/config/themes/redshift.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
 
 [colors]
 background0:                            040608FF

--- a/config/themes/rose-pine-dawn.focus-theme
+++ b/config/themes/rose-pine-dawn.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
       # (https://rosepinetheme.com/)
 
 [colors]

--- a/config/themes/rose-pine-moon.focus-theme
+++ b/config/themes/rose-pine-moon.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
       # (https://rosepinetheme.com/)
 
 [colors]

--- a/config/themes/rose-pine.focus-theme
+++ b/config/themes/rose-pine.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
       # (https://rosepinetheme.com/)
 
 [colors]

--- a/config/themes/solarized-dark.focus-theme
+++ b/config/themes/solarized-dark.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
 
 [colors]
 background0:                            002B36FF

--- a/config/themes/spacemacs-light.focus-theme
+++ b/config/themes/spacemacs-light.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
 
 [colors]
 background0:                            fbf8efFF

--- a/config/themes/steel-breeze.focus-theme
+++ b/config/themes/steel-breeze.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
 
 [colors]
 

--- a/config/themes/tokyo-night-light.focus-theme
+++ b/config/themes/tokyo-night-light.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
 
 [colors]
 background0:                            D5D6DBFF

--- a/config/themes/tokyo-night.focus-theme
+++ b/config/themes/tokyo-night.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
 
 [colors]
 background0:                            1A1B26FF

--- a/config/themes/vscode-dark.focus-theme
+++ b/config/themes/vscode-dark.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
       # Based on VSCode Dark theme
 
 [colors]

--- a/config/themes/zenburn.focus-theme
+++ b/config/themes/zenburn.focus-theme
@@ -1,4 +1,4 @@
-[23]  # Version number. Do not delete.
+[24]  # Version number. Do not delete.
 
 # Based on the original Zenburn Vim theme:
 # https://github.com/jnurmine/Zenburn/blob/master/colors/zenburn.vim

--- a/modules/Simp/font.jai
+++ b/modules/Simp/font.jai
@@ -650,6 +650,26 @@ generate_quads_for_prepared_text :: (font: *Dynamic_Font, x: s64, y: s64) {
     }
 }
 
+refresh_tab_glyph_for_all_fonts :: ()
+{
+    utf32 : u32 = #char "\t";
+
+    // All the different possible variations of the glyph.
+    hash_key_1 := glyph_hash(utf32, Font_Anti_Aliasing.lcd,    hinting = true);
+    hash_key_2 := glyph_hash(utf32, Font_Anti_Aliasing.lcd,    hinting = false);
+    hash_key_3 := glyph_hash(utf32, Font_Anti_Aliasing.normal, hinting = true);
+    hash_key_4 := glyph_hash(utf32, Font_Anti_Aliasing.normal, hinting = false);
+
+    for dynamic_fonts {
+        // Remove the glyph from the hash map so it will be recreated in find_or_create_glyph().
+        // This feels a bit dirty but I don't want be intrusive and change lots of code.
+        table_remove(*it.glyph_lookup, hash_key_1);
+        table_remove(*it.glyph_lookup, hash_key_2);
+        table_remove(*it.glyph_lookup, hash_key_3);
+        table_remove(*it.glyph_lookup, hash_key_4);
+    }
+}
+
 #scope_file
 
 ft_library    : FT_Library;
@@ -764,13 +784,25 @@ copy_glyph_to_bitmap :: (face: FT_Face, data: *Glyph_Data) {
     font_line.page.dirty = true;
 }
 
+glyph_hash :: inline (utf32: u32, anti_aliasing: Font_Anti_Aliasing, hinting: bool) -> u64 {
+    hash_key := (cast(u64) utf32) | ((cast(u64) anti_aliasing) << 32) | ((cast(u64) hinting) << 36);
+    return hash_key;
+}
+
 find_or_create_glyph :: (using font: *Dynamic_Font, utf32: u32) -> *Glyph_Data {
-    hash_key := (cast(u64) utf32) | ((cast(u64) font_anti_aliasing) << 32) | ((cast(u64) font_hinting) << 36);
+    hash_key := glyph_hash(utf32, font_anti_aliasing, font_hinting);
 
     success, data := table_find_new(*font.glyph_lookup, hash_key);
     if success  return data;
 
-    if utf32 == #char "\t" then utf32 = #char "→";  // draw tabs as arrows
+    if utf32 == #char "\t" {
+        if font_show_tabs {
+            utf32 = #char "→";  // draw tabs as arrows
+        } else {
+            utf32 = #char " ";  // hide tabs.
+        }
+    }
+
     if utf32 == #char "\n" then utf32 = #char "¶";  // draw newlines as paragraph symbols
 
     glyph_index := FT_Get_Char_Index(face, utf32);

--- a/modules/Simp/font.jai
+++ b/modules/Simp/font.jai
@@ -250,7 +250,8 @@ draw_code :: (font: *Dynamic_Font, x: s64, y: s64, char_x_advance: float, line_h
                     color = COLOR_MAP[0];  // always use default color
 
                     // Only draw tabs if they are within a selection
-                    if character_is_selected(start_offset + cast(s32)(t - line.data), selections) {
+                    is_selected := character_is_selected(start_offset + cast(s32)(t - line.data), selections);
+                    if show_tab_characters_in_selection && is_selected {
                         color.w = 0.2;
                     } else {
                         color.w = 0.0;
@@ -650,26 +651,6 @@ generate_quads_for_prepared_text :: (font: *Dynamic_Font, x: s64, y: s64) {
     }
 }
 
-refresh_tab_glyph_for_all_fonts :: ()
-{
-    utf32 : u32 = #char "\t";
-
-    // All the different possible variations of the glyph.
-    hash_key_1 := glyph_hash(utf32, Font_Anti_Aliasing.lcd,    hinting = true);
-    hash_key_2 := glyph_hash(utf32, Font_Anti_Aliasing.lcd,    hinting = false);
-    hash_key_3 := glyph_hash(utf32, Font_Anti_Aliasing.normal, hinting = true);
-    hash_key_4 := glyph_hash(utf32, Font_Anti_Aliasing.normal, hinting = false);
-
-    for dynamic_fonts {
-        // Remove the glyph from the hash map so it will be recreated in find_or_create_glyph().
-        // This feels a bit dirty but I don't want be intrusive and change lots of code.
-        table_remove(*it.glyph_lookup, hash_key_1);
-        table_remove(*it.glyph_lookup, hash_key_2);
-        table_remove(*it.glyph_lookup, hash_key_3);
-        table_remove(*it.glyph_lookup, hash_key_4);
-    }
-}
-
 #scope_file
 
 ft_library    : FT_Library;
@@ -795,14 +776,7 @@ find_or_create_glyph :: (using font: *Dynamic_Font, utf32: u32) -> *Glyph_Data {
     success, data := table_find_new(*font.glyph_lookup, hash_key);
     if success  return data;
 
-    if utf32 == #char "\t" {
-        if font_show_tabs {
-            utf32 = #char "→";  // draw tabs as arrows
-        } else {
-            utf32 = #char " ";  // hide tabs.
-        }
-    }
-
+    if utf32 == #char "\t" then utf32 = #char "→";  // draw tabs as arrows
     if utf32 == #char "\n" then utf32 = #char "¶";  // draw newlines as paragraph symbols
 
     glyph_index := FT_Get_Char_Index(face, utf32);

--- a/modules/Simp/module.jai
+++ b/modules/Simp/module.jai
@@ -156,6 +156,13 @@ set_hinting :: (value: bool) {
     font_hinting = value;
 }
 
+set_show_tabs :: (value: bool) {
+    if value != font_show_tabs {
+        font_show_tabs = value;
+        refresh_tab_glyph_for_all_fonts();
+    }
+}
+
 // @Cleanup: This has a lot of overlap with Window_Creation’s "get_dimensions"
 get_render_dimensions :: (window: Window_Type) -> (width: s32, height: s32) {
     #if OS == .WINDOWS {
@@ -197,6 +204,7 @@ find_window_info :: (window: Window_Type) -> *Window_Info {
 COLOR_MAP: [] Vector4;
 font_anti_aliasing: Font_Anti_Aliasing = .lcd;
 font_hinting := true;
+font_show_tabs := true;
 
 #scope_file
 

--- a/modules/Simp/module.jai
+++ b/modules/Simp/module.jai
@@ -156,11 +156,8 @@ set_hinting :: (value: bool) {
     font_hinting = value;
 }
 
-set_show_tabs :: (value: bool) {
-    if value != font_show_tabs {
-        font_show_tabs = value;
-        refresh_tab_glyph_for_all_fonts();
-    }
+set_show_tab_characters_in_selection :: (value: bool) {
+    show_tab_characters_in_selection = value;
 }
 
 // @Cleanup: This has a lot of overlap with Window_Creation’s "get_dimensions"
@@ -201,10 +198,12 @@ find_window_info :: (window: Window_Type) -> *Window_Info {
     return null;
 }
 
+show_tab_characters_in_selection := true;
+
+// Style settings.
 COLOR_MAP: [] Vector4;
 font_anti_aliasing: Font_Anti_Aliasing = .lcd;
 font_hinting := true;
-font_show_tabs := true;
 
 #scope_file
 

--- a/src/config.jai
+++ b/src/config.jai
@@ -727,7 +727,7 @@ Settings :: struct {
     closing_last_editor_in_pane_should_close_pane           := true;    @v23
     closing_last_editor_should_exit_program                 := false;   @v23
     show_pane_numbers                                       := false;   @v23
-    show_tabs                                               := true;    @v24
+    show_tab_characters_in_selection                       := true;    @v24
 
     // TODO
     // load_last_session_on_start:         true

--- a/src/config.jai
+++ b/src/config.jai
@@ -1,6 +1,6 @@
 // Increment this if your PR adds a setting, color or default keybinding (and amend the relevant array
 // in config_migrator.jai).  You don't need to increase it for each such change; once per PR is fine.
-CURRENT_CONFIG_VERSION :: 23;
+CURRENT_CONFIG_VERSION :: 24;
 
 load_global_config :: (fallback_to_default_on_failure := false, force := false) -> success: bool, changed: bool, there_were_warnings: bool {
     config_path := tprint("%/global.focus-config", config_dir);
@@ -755,6 +755,7 @@ Settings :: struct {
     status_bar_show_cursors_off_screen                      := true;                                                @v11 @overridable
     status_bar_show_selected_text_length                    := false;                                               @v3  @overridable
     show_scrollbar_marks                                    := true;                                                @v15 @overridable
+    show_tabs                                               := true;                                                @v24 @overridable
 }
 
 // Generate a struct for the settings that can be overridden

--- a/src/config.jai
+++ b/src/config.jai
@@ -727,6 +727,7 @@ Settings :: struct {
     closing_last_editor_in_pane_should_close_pane           := true;    @v23
     closing_last_editor_should_exit_program                 := false;   @v23
     show_pane_numbers                                       := false;   @v23
+    show_tabs                                               := true;    @v24
 
     // TODO
     // load_last_session_on_start:         true
@@ -755,7 +756,6 @@ Settings :: struct {
     status_bar_show_cursors_off_screen                      := true;                                                @v11 @overridable
     status_bar_show_selected_text_length                    := false;                                               @v3  @overridable
     show_scrollbar_marks                                    := true;                                                @v15 @overridable
-    show_tabs                                               := true;                                                @v24 @overridable
 }
 
 // Generate a struct for the settings that can be overridden

--- a/src/config_migrator.jai
+++ b/src/config_migrator.jai
@@ -530,7 +530,7 @@ ADDED_SETTINGS :: Added_Setting.[
     .{ 23, "closing_last_editor_should_exit_program",            "false" },
     .{ 23, "show_pane_numbers",                                  "false" },
 
-    .{ 24, "show_tabs",                                          "true" },
+    .{ 24, "show_tab_characters_in_selection",                   "true" },
 ];
 
 RENAMED_SETTINGS :: Renamed_Setting.[

--- a/src/config_migrator.jai
+++ b/src/config_migrator.jai
@@ -529,6 +529,8 @@ ADDED_SETTINGS :: Added_Setting.[
     .{ 23, "closing_last_editor_in_pane_should_close_pane",      "true"  },
     .{ 23, "closing_last_editor_should_exit_program",            "false" },
     .{ 23, "show_pane_numbers",                                  "false" },
+
+    .{ 24, "show_tabs",                                          "true" },
 ];
 
 RENAMED_SETTINGS :: Renamed_Setting.[

--- a/src/config_migrator.jai
+++ b/src/config_migrator.jai
@@ -1405,6 +1405,7 @@ cursor_position_after_jump:                      0.45  # controls where the curs
 closing_last_editor_in_pane_should_close_pane:   true
 closing_last_editor_should_exit_program:         false
 show_pane_numbers:                               false
+show_tab_characters_in_selection:                true
 
 FOCUS_CONFIG
 
@@ -1554,6 +1555,7 @@ cursor_position_after_jump:                      0.45  # controls where the curs
 closing_last_editor_in_pane_should_close_pane:   true
 closing_last_editor_should_exit_program:         false
 show_pane_numbers:                               false
+show_tab_characters_in_selection:                true
 
 FOCUS_CONFIG
 
@@ -1941,6 +1943,7 @@ cursor_position_after_jump:                      0.45  # controls where the curs
 closing_last_editor_in_pane_should_close_pane:   true
 closing_last_editor_should_exit_program:         false
 show_pane_numbers:                               false
+show_tab_characters_in_selection:                true
 
 [[keymap]]
 # ...

--- a/src/main.jai
+++ b/src/main.jai
@@ -490,7 +490,7 @@ init_fonts_and_dependent_things :: () {
     Simp.set_anti_aliasing(config.style.font_anti_aliasing);
     Simp.set_hinting(config.style.font_hinting);
 
-    Simp.set_show_tabs(config.settings.show_tabs);
+    Simp.set_show_tab_characters_in_selection(config.settings.show_tab_characters_in_selection);
 
     font_main_size = clamp(font_main_size, MIN_FONT_SIZE, MAX_FONT_SIZE);
     font_ui_size   = clamp(font_ui_size  , MIN_FONT_SIZE, MAX_FONT_SIZE);

--- a/src/main.jai
+++ b/src/main.jai
@@ -490,6 +490,8 @@ init_fonts_and_dependent_things :: () {
     Simp.set_anti_aliasing(config.style.font_anti_aliasing);
     Simp.set_hinting(config.style.font_hinting);
 
+    Simp.set_show_tabs(config.settings.show_tabs);
+
     font_main_size = clamp(font_main_size, MIN_FONT_SIZE, MAX_FONT_SIZE);
     font_ui_size   = clamp(font_ui_size  , MIN_FONT_SIZE, MAX_FONT_SIZE);
 


### PR DESCRIPTION
Adds a setting to show/hide tab characters. 

A global in the Simp module controls which glyph is used for tab characters; an arrow when enabled, a space (nothing) when disabled. When the setting is changed, the glyph currently used for tab characters is removed from the glyph lookup of all fonts, forcing it to be recreated the next time it is used.

Currently I think the glyph ends up being redrawn by FreeType every time the setting is changed, which isn't ideal - the desired glyph may well already have been rendered. But hey, how often are people really going to be enabling/disabling tabs?