### PR TITLE
Change the macOS system fonts dir

### DIFF
--- a/src/platform/macos.jai
+++ b/src/platform/macos.jai
@@ -129,7 +129,7 @@ platform_find_font_by_name :: (name: string, allocator := temp) -> bool, string 
 }
 
 platform_get_fonts_dir :: inline () -> string {
-    return "/Library/Fonts";
+    return "/System/Library/Fonts";
 }
 
 platform_open_in_explorer :: (path: string, reveal := false) {


### PR DESCRIPTION
`/Library/Fonts` is typically used for fonts installed by the user and made available to all users (in contrast to `$HOME/Library/Fonts`). `/System/Library/Fonts` is where the actual system fonts reside.