### PR TITLE
Do not wait indefinitely in wl_update_window_events

### DIFF
--- a/modules/Linux_Display/ldw_input.jai
+++ b/modules/Linux_Display/ldw_input.jai
@@ -283,7 +283,7 @@ wl_wait_for_events :: (display: *Display) {
 
 wl_update_window_events :: (display: *Display) {
     wl_check_usage(display);
-    wl_event_loop_step(display, -1);
+    wl_event_loop_step(display, 0);
 }
 
 wl_get_mouse_pointer_position :: (window: *Window, right_handed: bool) -> x: int, y: int, success: bool {


### PR DESCRIPTION
On KDE Wayland (maybe other compositors also), there is huge input glitching. The reason is that we wait indefinitely in both `platform_wait_message` and `Input.update_window_events`.