### PR TITLE
Path, theme and input fixes

### DIFF
--- a/config/themes/gruber-darker.focus-theme
+++ b/config/themes/gruber-darker.focus-theme
@@ -47,8 +47,8 @@ region_error:                           772222FF
 region_heredoc:                         141414FF
 
 build_panel_background:                 262624FF
-build_panel_scrollbar:                  33CCCC19
-build_panel_scrollbar_hover:            33CCCC4C
+build_panel_scrollbar:                  484848FF
+build_panel_scrollbar_hover:            484848FF
 build_panel_scrollbar_background:       2626244C
 build_panel_title_bar:                  141416FF
 

--- a/src/main.jai
+++ b/src/main.jai
@@ -320,10 +320,14 @@ main :: () {
             }
 
             // Ignore text input events if either we've handled a keyboard event for the same combo or the user holds Ctrl/Cmd/Meta
-            // (can't ignore wnen Alt/Opt is held because this is sometimes used to type characters)
+            // (can't ignore when Alt/Opt is held because this is sometimes used to type characters)
             if event.type == .KEYBOARD {
-                if handled || event.modifier_flags.packed & Mods.{ctrl_pressed=true, cmd_meta_pressed=true}.packed then num_text_input_events_to_ignore = event.text_input_count;
-                if event.modifier_flags.alt_pressed then num_text_input_events_to_ignore = 0;
+                if handled {
+                    num_text_input_events_to_ignore = event.text_input_count;
+                } else {
+                    if event.modifier_flags.packed & Mods.{ctrl_pressed=true, cmd_meta_pressed=true}.packed then num_text_input_events_to_ignore = event.text_input_count;
+                    if event.modifier_flags.alt_pressed then num_text_input_events_to_ignore = 0;
+                }
             }
 
             handled = key_sequence_input_process_event(event, handled);

--- a/src/widgets/open_file_dialog.jai
+++ b/src/widgets/open_file_dialog.jai
@@ -501,11 +501,12 @@ refresh_entries :: (clear_input := true) {
     }
 
     if (mode == .save || mode == .move) && !is_empty(input.text) && path_chunks {
+        folder_path := ifx get_current_folder_path() != "/" else "";
         entry_name: string;
         if mode == .save {
-            entry_name = sprint("Save as '%/%'", get_current_folder_path(), to_string(input.text));
+            entry_name = sprint("Save as '%/%'", folder_path, to_string(input.text));
         } else {
-            entry_name = sprint("Move to '%/%'", get_current_folder_path(), to_string(input.text));
+            entry_name = sprint("Move to '%/%'", folder_path, to_string(input.text));
         }
         array_add(*entries.filtered, Entry.{
             file = File_Info.{ full_path = "", name = "", path = "", icon = .save },
@@ -549,13 +550,9 @@ get_current_folder_path :: () -> string {
         path_chunks_trimmed := array_view(path_chunks, 1, path_chunks.count - 1);
         dir_path = sprint("%/%", root_dir, join(..path_chunks_trimmed, separator = "/"));
     } else {
-        if path_chunks[0] == "/" {
-            path_chunks_trimmed := array_view(path_chunks, 1, path_chunks.count - 1);
-            dir_path = sprint("/%", join(..path_chunks_trimmed, separator = "/"));
-        } else {
-            dir_path = join(..path_chunks, separator = "/");
-        }
+        dir_path = join(..path_chunks, separator = "/");
     }
+    while starts_with(dir_path, "//") advance(*dir_path);
     while dir_path != "/" && ends_with(dir_path, #char "/") dir_path.count -= 1;
 
     return dir_path;


### PR DESCRIPTION
- Fix build panel scrollbar color in Gruber Darker.
- Fix issue where typing Opt-Cmd-F resulted in the search bar being opened but prefilled with the ƒ character.
- Remove redundant leading slashes in the path when saving a file in a directory outside of the project directory.