### PR TITLE
Drag and Drop on Linux Mint: _DUMMY is 0

### DIFF
--- a/modules/Linux_Display/X11.jai
+++ b/modules/Linux_Display/X11.jai
@@ -1287,7 +1287,7 @@ X11_Lib :: struct #type_info_no_size_complaint {
         _NET_WM_NAME                    : Atom;
         _NET_WM_ICON_NAME               : Atom;
 
-        _DUMMY : Atom; @opts(actual_name=JXSelectionWindowProperty)
+        _DUMMY : Atom; @opts(actual_name=JXSelectionWindowProperty,must_exist=false)
     }
 
     Xdnd_Stage :: enum {


### PR DESCRIPTION
I don't know why the X11 _DUMMY atom is named `JXSelectionWindowProperty` but on Linux Mint that does not exist. Dragging a file in Linux Mint 22.2 on focus hangs the app, the dnd message loop is never stopped.
I'm a bit new to Linux, so I don't know if this is really the best way to fix it, but on my machine it works with this fix.

Troubeshooting info if you want it:
<details>

```
Kernel:
  Linux mint 6.14.0-35-generic #35~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Tue Oct 14 13:55:17 UTC 2 x86_64 x86_64 x86_64 GNU/Linux
OS information:
  NAME="Linux Mint"
  VERSION="22.2 (Zara)"
  ID=linuxmint
  ID_LIKE="ubuntu debian"
  PRETTY_NAME="Linux Mint 22.2"
  VERSION_ID="22.2"
  HOME_URL="https://www.linuxmint.com/"
  SUPPORT_URL="https://forums.linuxmint.com/"
  BUG_REPORT_URL="http://linuxmint-troubleshooting-guide.readthedocs.io/en/latest/"
  PRIVACY_POLICY_URL="https://www.linuxmint.com/"
  VERSION_CODENAME=zara
  UBUNTU_CODENAME=noble

Interesting things in the environment:
  FOCUS_LD_BACKEND : <not set>
  FOCUS_LD_GL_BACKEND : <not set>
  FOCUS_LD_FLAGS : <not set>
  DISPLAY : :0
  WAYLAND_DISPLAY : <not set>
  DESKTOP_SESSION : cinnamon
  XDG_SESSION_DESKTOP : cinnamon
  XDG_CURRENT_DESKTOP : X-Cinnamon
  XCURSOR_THEME : <not set>
  XCURSOR_SIZE : <not set>
  LD_LIBRARY_PATH : <not set>
  LD_PRELOAD : <not set>
  PATH : /home/jlami/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin

Loaded libraries:
  /home/jlami/bin/focus
  /usr/lib/x86_64-linux-gnu/libicudata.so.74.2
  /usr/lib/x86_64-linux-gnu/libicuuc.so.74.2
  /usr/lib/x86_64-linux-gnu/libxml2.so.2.9.14
  /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33
  /usr/lib/x86_64-linux-gnu/liblzma.so.5.4.5
  /usr/lib/x86_64-linux-gnu/libtinfo.so.6.4
  /usr/lib/x86_64-linux-gnu/libLLVM.so.20.1
  /usr/lib/x86_64-linux-gnu/libedit.so.2.0.72
  /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
  /usr/lib/x86_64-linux-gnu/libgallium-25.0.7-0ubuntu0.24.04.2.so
  /usr/lib/x86_64-linux-gnu/libpciaccess.so.0.11.1
  /usr/lib/x86_64-linux-gnu/libdrm_intel.so.1.0.0
  /usr/lib/x86_64-linux-gnu/libdrm_amdgpu.so.1.0.0
  /usr/lib/x86_64-linux-gnu/libelf-0.190.so
  /usr/lib/x86_64-linux-gnu/libxshmfence.so.1.0.0
  /usr/lib/x86_64-linux-gnu/libxcb-sync.so.1.0.0
  /usr/lib/x86_64-linux-gnu/libxcb-randr.so.0.1.0
  /usr/lib/x86_64-linux-gnu/libsensors.so.5.0.0
  /usr/lib/x86_64-linux-gnu/libzstd.so.1.5.5
  /usr/lib/x86_64-linux-gnu/libz.so.1.3
  /usr/lib/x86_64-linux-gnu/libxcb-xfixes.so.0.0.0
  /usr/lib/x86_64-linux-gnu/libxcb-present.so.0.0.0
  /usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0.1.0
  /usr/lib/x86_64-linux-gnu/libexpat.so.1.9.1
  /usr/lib/x86_64-linux-gnu/libxcb-shm.so.0.0.0
  /usr/lib/x86_64-linux-gnu/libXext.so.6.4.0
  /usr/lib/x86_64-linux-gnu/libxcb-glx.so.0.0.0
  /usr/lib/x86_64-linux-gnu/libdrm.so.2.4.0
  /usr/lib/x86_64-linux-gnu/libGLX_mesa.so.0.0.0
  /usr/lib/x86_64-linux-gnu/libXrender.so.1.3.0
  /usr/lib/x86_64-linux-gnu/libXcursor.so.1.0.2
  /usr/lib/x86_64-linux-gnu/libXxf86vm.so.1.0.0
  /usr/lib/x86_64-linux-gnu/libXfixes.so.3.1.0
  /usr/lib/x86_64-linux-gnu/libGLdispatch.so.0.0.0
  /usr/lib/x86_64-linux-gnu/libGLX.so.0.0.0
  /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0
  /usr/lib/x86_64-linux-gnu/libxcb-xkb.so.1.0.0
  /usr/lib/x86_64-linux-gnu/libmd.so.0.1.0
  /usr/lib/x86_64-linux-gnu/libbsd.so.0.12.1
  /usr/lib/x86_64-linux-gnu/libXdmcp.so.6.0.0
  /usr/lib/x86_64-linux-gnu/libXau.so.6.0.0
  /usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
  /usr/lib/x86_64-linux-gnu/libwayland-cursor.so.0.22.0
  /usr/lib/x86_64-linux-gnu/libffi.so.8.1.4
  /usr/lib/x86_64-linux-gnu/libxkbcommon.so.0.0.0
  /usr/lib/x86_64-linux-gnu/libm.so.6
  /usr/lib/x86_64-linux-gnu/libc.so.6
  /usr/lib/x86_64-linux-gnu/libX11-xcb.so.1.0.0
  /usr/lib/x86_64-linux-gnu/libwayland-egl.so.1.22.0
  /usr/lib/x86_64-linux-gnu/libwayland-client.so.0.22.0
  /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2

Linux_Display information:
  desired backend    : PREFER_BEST_USER_EXPERIENCE
  active backend     : X11
  desired GL backend : AUTOSELECT
  active GL backend  : GLX

X11_Display.{
    base = {
        type = X11_Display; 
        app_id = "dev.focus-editor.focus"; 
        init_flags = 0; 
        desired_gl_backend = AUTOSELECT; 
        windows = [(union)]; 
        mouse_delta_x = 0; 
        mouse_delta_y = 0; 
        mouse_wheel_delta = {
            vertical = 0; 
            horizontal = 0; 
        }; 
        events_this_frame = []; 
        input_button_states = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, DOWN, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0...]; 
        loop_wakeup_event = 4; 
        gl = {
            type = GLX; 
            data = (union); 
            ops = {
                create_context = procedure 0x85_8820; 
                create_surface = procedure 0x85_8c30; 
                make_current = procedure 0x85_8d60; 
                swap_buffers = procedure 0x85_8e60; 
                get_proc_address = procedure 0x71d6_8dea_5eb0; 
            }; 
        }; 
        xkb_state = {
            kb_context = null; 
            kb_keymap = null; 
            kb_state = null; 
            kb_compose_table = null; 
            kb_compose_state = null; 
            mod_idx_shift = 0; 
            mod_idx_ctrl = 0; 
            mod_idx_alt = 0; 
            mod_idx_caps_lock = 0; 
            mod_idx_super = 0; 
            mod_idx_alt_gr = 0; 
            mods_depressed = 0; 
            mods_latched = 0; 
            mods_locked = 0; 
            grp_depressed = 0; 
            grp_latched = 0; 
            grp_locked = 0; 
        }; 
        create_window = procedure 0x91_29f0; 
        set_fixed_scaling = procedure 0x91_0200; 
        translate_key_code = procedure 0x95_cf60; 
        wait_for_events = procedure 0x90_fc40; 
        update_window_events = procedure 0x90_fa20; 
        clipboard_get_text = procedure 0x91_2370; 
        clipboard_set_text = procedure 0x90_f750; 
        get_mouse_pointer_position = procedure 0x91_1aa0; 
    }; 
    handle = 3635_de60; 
    file_descriptor = 5; 
    im = 3636_ecf0; 
    fixed_scaling = false; 
    dpi_override = 0; 
    global_atoms = {
        XdndEnter = 396; 
        XdndPosition = 398; 
        XdndStatus = 399; 
        XdndTypeList = 577; 
        XdndAware = 501; 
        XdndActionMove = 574; 
        XdndActionLink = 572; 
        XdndActionCopy = 570; 
        XdndDrop = 401; 
        XdndLeave = 397; 
        XdndFinished = 400; 
        XdndSelection = 509; 
        XdndProxy = 502; 
        ATOM = 4; 
        CLIPBOARD = 384; 
        UTF8_STRING = 322; 
        XSEL_DATA = 0; 
        TARGETS = 392; 
        MULTIPLE = 389; 
        TEXT_PLAIN = 0; 
        WM_DELETE_WINDOW = 324; 
        WM_PROTOCOLS = 326; 
        MOTIF_WM_HINTS = 0; 
        NET_WM_NAME = 0; 
        NET_WM_ICON_NAME = 0; 
        NET_WM_STATE = 0; 
        NET_WM_STATE_FULLSCREEN = 0; 
        WM_NAME = 39; 
        WM_ICON_NAME = 37; 
        _NET_WM_STATE = 340; 
        _NET_WM_STATE_DEMANDS_ATTENTION = 486; 
        _NET_WM_STATE_FULLSCREEN = 343; 
        _NET_WM_STATE_MAXIMIZED_HORZ = 347; 
        _NET_WM_STATE_MAXIMIZED_VERT = 346; 
        _NET_WM_ICON = 335; 
        _NET_WM_NAME = 337; 
        _NET_WM_ICON_NAME = 336; 
        _DUMMY = 0; 
    }; 
    clipboard_text = "JXSelectionWindowProperty"; 
    drop_info = {
        data = []; 
        x = 1625; 
        y = 1024; 
        return_type = 601; 
        return_action = 570; 
        user_typelist = [614, 603, 601, 585]; 
        user_actions = []; 
    }; 
    xdnd_context = {
        stage = DROP_IDLE; 
        dragging_version = 0; 
        dragger_typelist = []; 
        dragger_window = 73404826; 
        want_position = false; 
        will_accept = true; 
        rectangle = {
            x = 0; 
            y = 0; 
            width = 0; 
            height = 0; 
        }; 
        dropper_window = 0; 
        dropper_toplevel = 0; 
        root_window = 1001; 
        supported_action = 570; 
        desired_type = 601; 
        x = 1625; 
        y = 1024; 
        time = 0; 
    }; 
    visual_info = 3641_6070; 
    color_map = 71303205; 
    x_cursors = {
        count = 9; 
        allocated = 32; 
        slots_filled = 9; 
        allocator = {
            proc = procedure 0x70_4370; 
            data = null; 
        }; 
        entries = [{
            hash = 0; 
            key = ""; 
            value = 0; 
        }, {
            hash = 0; 
            key = ""; 
            value = 0; 
        }, {
            hash = 0; 
            key = ""; 
            value = 0; 
        }, {
            hash = 4097563523; 
            key = "not-allowed"; 
            value = 71303180; 
        }, {
            hash = 0; 
            key = ""; 
            value = 0; 
        }, {
            hash = 0; 
            key = ""; 
            value = 0; 
        }, {
            hash = 2412903814; 
            key = "row-resize"; 
            value = 71303188; 
        }, {
            hash = 0; 
            key = ""; 
            value = 0; 
        }, {
            hash = 0; 
            key = ""; 
            value = 0; 
        }, {
            hash = 1138208137; 
            key = "nw-resize"; 
            value = 71303196; 
        }, {
            hash = 3066000618; 
            key = "pointer"; 
            value = 71303176; 
        }, {
            hash = 0; 
            key = ""; 
            value = 0; 
        }, {
            hash = 1142960204; 
            key = "col-resize"; 
            value = 71303184; 
        }, {
            hash = 0; 
            key = ""; 
            value = 0; 
        }, {
            hash = 0; 
            key = ""; 
            value = 0; 
        }, {
            hash = 0; 
            key = ""; 
            value = 0; 
        }, {
            hash = 1790169136; 
            key = "se-resize"; 
            value = 71303200; 
        }, {
            hash = 0; 
            key = ""; 
            value = 0; 
        }, {
            hash = 2184325266; 
            key = "all-scroll"; 
            value = 71303192; 
        }, {
            hash = 0; 
            key = ""; 
            value = 0; 
        }, {
            hash = 0; 
            key = ""; 
            value = 0; 
        }, {
            hash = 0; 
            key = ""; 
            value = 0; 
        }, {
            hash = 0; 
            key = ""; 
            value = 0; 
        }, {
            hash = 0; 
            key = ""; 
            value = 0; 
        }, {
            hash = 0; 
            key = ""; 
            value = 0; 
        }, {
            hash = 0; 
            key = ""; 
            value = 0; 
        }, {
            hash = 0; 
            key = ""; 
            value = 0; 
        }, {
            hash = 0; 
            key = ""; 
            value = 0; 
        }, {
            hash = 0; 
            key = ""; 
            value = 0; 
        }, {
            hash = 0; 
            key = ""; 
            value = 0; 
        }, {
            hash = 3597751390; 
            key = "default"; 
            value = 71303172; 
        }, {
            hash = 1534314078; 
            key = "text"; 
            value = 71303204; 
        }]; 
    }; 
}

OpenGL Information:
  vendor       : AMD
  renderer     : AMD Radeon RX 580 Series (radeonsi, polaris10, ACO, DRM 3.61, 6.14.0-35-generic)
  version      : 4.6 (Core Profile) Mesa 25.0.7-0ubuntu0.24.04.2
  GLSL version : 4.60
  extensions (236):
    GL_AMD_conservative_depth, GL_AMD_depth_clamp_separate, GL_AMD_draw_buffers_blend, 
    GL_AMD_gpu_shader_int64, GL_AMD_multi_draw_indirect, GL_AMD_performance_monitor, 
    GL_AMD_query_buffer_object, GL_AMD_seamless_cubemap_per_texture, GL_AMD_shader_stencil_export, 
    GL_AMD_texture_texture4, GL_AMD_vertex_shader_layer, GL_AMD_vertex_shader_viewport_index, 
    GL_ANGLE_texture_compression_dxt5, GL_ARB_ES2_compatibility, GL_ARB_ES3_1_compatibility, 
    GL_ARB_ES3_compatibility, GL_ARB_arrays_of_arrays, GL_ARB_base_instance, GL_ARB_bindless_texture, 
    GL_ARB_buffer_storage, GL_ARB_clear_buffer_object, GL_ARB_clear_texture, GL_ARB_clip_control, 
    GL_ARB_compressed_texture_pixel_storage, GL_ARB_compute_shader, GL_ARB_compute_variable_group_size, 
    GL_ARB_conservative_depth, GL_ARB_copy_buffer, GL_ARB_copy_image, GL_ARB_cull_distance, 
    GL_ARB_depth_buffer_float, GL_ARB_depth_clamp, GL_ARB_derivative_control, 
    GL_ARB_draw_buffers, GL_ARB_draw_buffers_blend, GL_ARB_draw_elements_base_vertex, 
    GL_ARB_draw_instanced, GL_ARB_enhanced_layouts, GL_ARB_explicit_attrib_location, 
    GL_ARB_fragment_coord_conventions, GL_ARB_fragment_layer_viewport, GL_ARB_fragment_shader, 
    GL_ARB_framebuffer_object, GL_ARB_framebuffer_sRGB, GL_ARB_get_program_binary, 
    GL_ARB_gl_spirv, GL_ARB_gpu_shader5, GL_ARB_gpu_shader_fp64, GL_ARB_gpu_shader_int64, 
    GL_ARB_half_float_vertex, GL_ARB_indirect_parameters, GL_ARB_instanced_arrays, 
    GL_ARB_internalformat_query2, GL_ARB_invalidate_subdata, GL_ARB_map_buffer_alignment, 
    GL_ARB_multi_bind, GL_ARB_multi_draw_indirect, GL_ARB_occlusion_query2, 
    GL_ARB_pipeline_statistics_query, GL_ARB_pixel_buffer_object, GL_ARB_point_sprite, 
    GL_ARB_program_interface_query, GL_ARB_provoking_vertex, GL_ARB_query_buffer_object, 
    GL_ARB_robustness, GL_ARB_sample_shading, GL_ARB_sampler_objects, GL_ARB_seamless_cube_map, 
    GL_ARB_separate_shader_objects, GL_ARB_shader_atomic_counter_ops, GL_ARB_shader_atomic_counters, 
    GL_ARB_shader_bit_encoding, GL_ARB_shader_clock, GL_ARB_shader_draw_parameters, 
    GL_ARB_shader_image_load_store, GL_ARB_shader_image_size, GL_ARB_shader_objects, 
    GL_ARB_shader_stencil_export, GL_ARB_shader_storage_buffer_object, GL_ARB_shader_subroutine, 
    GL_ARB_shader_texture_lod, GL_ARB_shader_viewport_layer_array, GL_ARB_shading_language_420pack, 
    GL_ARB_shading_language_packing, GL_ARB_spirv_extensions, GL_ARB_stencil_texturing, GL_ARB_sync, 
    GL_ARB_texture_barrier, GL_ARB_texture_border_clamp, GL_ARB_texture_buffer_object, 
    GL_ARB_texture_buffer_range, GL_ARB_texture_compression_bptc, GL_ARB_texture_compression_rgtc, 
    GL_ARB_texture_filter_anisotropic, GL_ARB_texture_filter_minmax, GL_ARB_texture_float, 
    GL_ARB_texture_mirror_clamp_to_edge, GL_ARB_texture_multisample, GL_ARB_texture_non_power_of_two, 
    GL_ARB_texture_query_lod, GL_ARB_texture_rectangle, GL_ARB_texture_rg, GL_ARB_texture_rgb10_a2ui, 
    GL_ARB_texture_storage, GL_ARB_texture_storage_multisample, GL_ARB_texture_swizzle, 
    GL_ARB_timer_query, GL_ARB_transform_feedback2, GL_ARB_transform_feedback3, 
    GL_ARB_transform_feedback_overflow_query, GL_ARB_uniform_buffer_object, GL_ARB_vertex_array_bgra, 
    GL_ARB_vertex_attrib_64bit, GL_ARB_vertex_attrib_binding, GL_ARB_vertex_buffer_object, 
    GL_ARB_vertex_type_10f_11f_11f_rev, GL_ARB_vertex_type_2_10_10_10_rev, GL_ARB_viewport_array, 
    GL_ATI_meminfo, GL_ATI_texture_float, GL_ATI_texture_mirror_once, GL_EXT_EGL_image_storage, 
    GL_EXT_EGL_sync, GL_EXT_abgr, GL_EXT_blend_equation_separate, GL_EXT_debug_label, 
    GL_EXT_depth_bounds_test, GL_EXT_draw_buffers2, GL_EXT_draw_instanced, GL_EXT_framebuffer_blit, 
    GL_EXT_framebuffer_multisample_blit_scaled, GL_EXT_framebuffer_object, GL_EXT_framebuffer_sRGB, 
    GL_EXT_memory_object_fd, GL_EXT_packed_depth_stencil, GL_EXT_packed_float, 
    GL_EXT_polygon_offset_clamp, GL_EXT_provoking_vertex, GL_EXT_semaphore, GL_EXT_semaphore_fd, 
    GL_EXT_shader_image_load_store, GL_EXT_shader_integer_mix, GL_EXT_shader_samples_identical, 
    GL_EXT_texture_compression_dxt1, GL_EXT_texture_compression_rgtc, GL_EXT_texture_compression_s3tc, 
    GL_EXT_texture_filter_minmax, GL_EXT_texture_integer, GL_EXT_texture_mirror_clamp, 
    GL_EXT_texture_sRGB_R8, GL_EXT_texture_sRGB_decode, GL_EXT_texture_shadow_lod, 
    GL_EXT_texture_snorm, GL_EXT_texture_storage, GL_EXT_texture_swizzle, GL_EXT_timer_query, 
    GL_EXT_vertex_array_bgra, GL_EXT_vertex_attrib_64bit, GL_EXT_window_rectangles, 
    GL_INTEL_blackhole_render, GL_KHR_blend_equation_advanced, GL_KHR_context_flush_control, 
    GL_KHR_no_error, GL_KHR_parallel_shader_compile, GL_KHR_robust_buffer_access_behavior, 
    GL_KHR_shader_subgroup, GL_KHR_texture_compression_astc_ldr, 
    GL_MESA_framebuffer_flip_y, GL_MESA_pack_invert, GL_MESA_shader_integer_functions, 
    GL_MESA_texture_signed_rgba, GL_NVX_gpu_memory_info, GL_NV_alpha_to_coverage_dither_control, 
    GL_NV_conditional_render, GL_NV_copy_image, GL_NV_depth_clamp, GL_NV_packed_depth_stencil, 
    GL_NV_texture_barrier, GL_NV_vdpau_interop, GL_OES_EGL_image, GL_S3_s3tc
```

</details>