### PR TITLE
Changes for error/warning-less compilation with 0.2.019

### DIFF
--- a/modules/uniform/compile.jai
+++ b/modules/uniform/compile.jai
@@ -710,7 +710,7 @@ add_rune_range :: (using comp: *Compiler, lo: Rune, hi: Rune, foldcase: bool) {
 			}
 		}
 	} else {
-		for #v2 < i: 0 .. n-1 {
+		for < i: 0 .. n-1 {
 			// In forward UTF-8 mode: don't cache the leading byte; cache the last
 			// continuation byte; cache anything else iff it's a byte range (XX-YY).
 			if (i == n-1 || (ulo[i] < uhi[i] && i != 0)) {

--- a/modules/uniform/program.jai
+++ b/modules/uniform/program.jai
@@ -973,7 +973,7 @@ compute_hints :: (using prog: *Prog, flat: *[..] Inst, begin: int, end: int) {
 	colors: [256] int;
 
 	dirty := false;
-	for #v2 < id: begin..end {
+	for < id: begin..end {
 		if (id == end || get_opcode((<<flat)[id]) != .kInstByteRange) {
 			if (dirty) {
 				dirty = false;

--- a/src/buffer.jai
+++ b/src/buffer.jai
@@ -705,7 +705,7 @@ find_matching_bracket :: (using buffer: Buffer, pos: s32) -> index: s32 {
 
     balance := 0;
     if direction < 0 {
-        for #v2 < i : 0 .. pos {
+        for < i : 0 .. pos {
             if tokens[i] != .punctuation continue;
 
             byte := bytes[i];
@@ -1410,7 +1410,7 @@ detect_and_set_indentation :: (using buffer: *Buffer) -> enum { success; error; 
     // E.g. if we have some 2-space indents and some 4-space indents, we might want to count those 4-space indents in favour of 2 because 2 is the common denominator.
     // However, we don't want to do this if there's one 2-space indent and two hundred 4-space indents because it's likely that the 2 space indent is just an exception.
     DIVISOR_RATIO :: 0.1;  // example: if the number of 2-space indents divided by the number of 4 space indents is greater than this ratio, we compress to 2 spaces
-    for #v2 < * smaller_indent, i : non_zero_indents {
+    for < * smaller_indent, i : non_zero_indents {
         if smaller_indent.level <= 1 continue;  // if we allowed 1 here it would compress everything
 
         for j : i+1 .. non_zero_indents.count-1 {

--- a/src/build_system.jai
+++ b/src/build_system.jai
@@ -609,7 +609,7 @@ parse_errors_in_failed_command_output :: (error_regex: string, command: Command_
     // - but if it's missing because it's shifted away by printing too much, fall back to 0
     // NOTE: we used to save output ranges of every command, but that wasn't very robust when the build output limit was reached
     output_range := Offset_Range.{ start = 0, end = buffer.bytes.count };
-    for #v2 < buffer.regions {
+    for < buffer.regions {
         if it.kind == .header {
             output_range.start = it.range.end;
             break;

--- a/src/draw.jai
+++ b/src/draw.jai
@@ -1109,7 +1109,7 @@ draw_editor :: (editor_id: s64, main_area: Rect, ui_id: Ui_Id, pane: *Editor_Pan
                 if mouse_coords.line >= editor_initial_middle_mouse_coords.line {
                     for   editor_initial_middle_mouse_coords.line..mouse_coords.line  maybe_create_cursor_or_move_main_cursor_to_this_line();
                 } else {
-                    for #v2 < mouse_coords.line..editor_initial_middle_mouse_coords.line  maybe_create_cursor_or_move_main_cursor_to_this_line();
+                    for < mouse_coords.line..editor_initial_middle_mouse_coords.line  maybe_create_cursor_or_move_main_cursor_to_this_line();
                 }
             }
 
@@ -2559,7 +2559,7 @@ draw_open_file_dialog :: () {
                 case .navigate;
                     label = ifx !path_chunks then " Navigate to file" else "";
                 case .save;
-                    label = tprint(" Choose where to save '%'", get_buffer_name(*open_buffers[buffer_id_to_save]));
+                    label = tprint(" Choose where to save '%'", get_buffer_name(open_buffers[buffer_id_to_save]));
                 case .move;
                     label = " Move to";
             }

--- a/src/file_watcher.jai
+++ b/src/file_watcher.jai
@@ -12,7 +12,7 @@ init_file_watcher :: () {
     if !init(*watchers.external_watcher, file_changed_callback, watch_recursively = false) {
         add_user_error("Could not initialize the workspace file watcher. Files won't be reloaded. This is likely a bug.");
         watchers.initialized = false;
-        deinit(*watchers.project_watcher);
+        deinit(watchers.project_watcher);
         return;
     }
 

--- a/src/utils/utils.jai
+++ b/src/utils/utils.jai
@@ -587,7 +587,7 @@ trim_both_sides :: (s: string, chars := " \t") -> string, left: s64, right: s64 
         else break;
     }
 
-    for #v2 < left..s.count-1 {
+    for < left..s.count-1 {
         if is_any(s[it], chars) right += 1;
         else break;
     }

--- a/src/widgets/commands.jai
+++ b/src/widgets/commands.jai
@@ -3,7 +3,7 @@ commands_dialog_handle_event :: (event: Input.Event) -> handled: bool {
 }
 
 commands_execute_selected :: (placement: Editor_Placement = .in_place) {
-    hide_dialog(*commands_dialog);
+    hide_dialog(commands_dialog);
 
     using commands_dialog;
     if selected >= filtered.count return;
@@ -50,7 +50,7 @@ commands_open_in_pane :: (number: s64) {
         case;                                                   handled = false;
     }
 
-    hide_dialog(*commands_dialog);
+    hide_dialog(commands_dialog);
 }
 
 commands_refresh_after_config_change :: () {

--- a/src/widgets/language_dialog.jai
+++ b/src/widgets/language_dialog.jai
@@ -16,7 +16,7 @@ Language_Dialog :: struct {
 
 apply_selected_language :: (_: Editor_Placement) {
     using language_dialog;
-    defer hide_dialog(*language_dialog);
+    defer hide_dialog(language_dialog);
 
     if build_panel_is_active() return;  // shouldn't ever be active
 

--- a/src/widgets/switch_to_project.jai
+++ b/src/widgets/switch_to_project.jai
@@ -15,7 +15,7 @@ Switch_To_Project_Dialog :: struct {
 #scope_file
 
 open_selected_project :: (_: Editor_Placement) {
-    hide_dialog(*switch_to_project_dialog);
+    hide_dialog(switch_to_project_dialog);
 
     using switch_to_project_dialog;
     if selected >= filtered.count return;

--- a/src/widgets/theme_dialog.jai
+++ b/src/widgets/theme_dialog.jai
@@ -96,7 +96,7 @@ apply_selected_theme :: (_: Editor_Placement) {
     save_buffer(buffer, buffer_id);
     add_success_message("Theme has been saved to %", config_to_change.path);
 
-    hide_dialog(*theme_dialog);
+    hide_dialog(theme_dialog);
 }
 
 preview_selected_theme :: () {


### PR DESCRIPTION
Required the following:
* Replace `for #v2` with `for` as it is implicitly the case now (not backwards compatible with pre-0.2.019 I suspect).
* Remove automatic dereferencing of pointers passed into non-pointer functions (backwards compatible I expect).