### PR TITLE
Fix tokenization of multiline comments

### DIFF
--- a/src/langs/c.jai
+++ b/src/langs/c.jai
@@ -325,8 +325,8 @@ parse_slash_or_comment :: (using tokenizer: *Tokenizer, token: *Token) {
         case #char "*";
             token.type = .multiline_comment;
             t += 1;
-            while t + 1 < max_t {
-                if t.* == #char "*" && << (t + 1) == #char "/" {
+            while t < max_t {
+                if t.* == #char "*" && (t + 1) < max_t && << (t + 1) == #char "/" {
                   t += 2;
                   break;
                 }

--- a/src/langs/cpp.jai
+++ b/src/langs/cpp.jai
@@ -325,8 +325,8 @@ parse_slash_or_comment :: (using tokenizer: *Tokenizer, token: *Token) {
         case #char "*";
             token.type = .multiline_comment;
             t += 1;
-            while t + 1 < max_t {
-                if t.* == #char "*" && << (t + 1) == #char "/" {
+            while t < max_t {
+                if t.* == #char "*" && (t + 1) < max_t && << (t + 1) == #char "/" {
                   t += 2;
                   break;
                 }

--- a/src/langs/csharp.jai
+++ b/src/langs/csharp.jai
@@ -480,8 +480,8 @@ parse_slash_or_comment :: (using tokenizer: *Tokenizer, token: *Token) {
         case #char "*";
             token.type = .multiline_comment;
             t += 1;
-            while t + 1 < max_t {
-                if t.* == #char "*" && (t + 1).* == #char "/" {
+            while t < max_t {
+                if t.* == #char "*" && (t + 1) < max_t && (t + 1).* == #char "/" {
                   t += 2;
                   break;
                 }

--- a/src/langs/d.jai
+++ b/src/langs/d.jai
@@ -329,8 +329,8 @@ parse_slash_or_comment :: (using tokenizer: *Tokenizer, token: *Token) {
         case #char "*";
             token.type = .multiline_comment;
             t += 1;
-            while t + 1 < max_t {
-                if t.* == #char "*" && << (t + 1) == #char "/" {
+            while t < max_t {
+                if t.* == #char "*" && (t + 1) < max_t && << (t + 1) == #char "/" {
                   t += 2;
                   break;
                 }

--- a/src/langs/dart.jai
+++ b/src/langs/dart.jai
@@ -410,8 +410,8 @@ parse_slash_or_comment :: (using tokenizer: *Dart_Tokenizer, token: *Token) {
         case #char "*";
             token.type = .multiline_comment;
             t += 1;
-            while t + 1 < max_t {
-                if t.* == #char "*" && << (t + 1) == #char "/" {
+            while t < max_t {
+                if t.* == #char "*" && (t + 1) < max_t && << (t + 1) == #char "/" {
                   t += 2;
                   break;
                 }

--- a/src/langs/glsl.jai
+++ b/src/langs/glsl.jai
@@ -302,8 +302,8 @@ parse_slash_or_comment :: (using tokenizer: *Tokenizer, token: *Token) {
         case #char "*";
             token.type = .multiline_comment;
             t += 1;
-            while t + 1 < max_t {
-                if t.* == #char "*" && (t + 1).* == #char "/" {
+            while t < max_t {
+                if t.* == #char "*" && (t + 1) < max_t && (t + 1).* == #char "/" {
                   t += 2;
                   break;
                 }

--- a/src/langs/golang.jai
+++ b/src/langs/golang.jai
@@ -366,8 +366,8 @@ parse_slash_or_comment :: (using tokenizer: *Tokenizer, token: *Token) {
         case #char "*";
             token.type = .multiline_comment;
             t += 1;
-            while t + 1 < max_t {
-                if << t == #char "*" && << (t + 1) == #char "/" {
+            while t < max_t {
+                if << t == #char "*" && (t + 1) < max_t && << (t + 1) == #char "/" {
                   t += 2;
                   break;
                 }

--- a/src/langs/hlsl.jai
+++ b/src/langs/hlsl.jai
@@ -315,8 +315,8 @@ parse_slash_or_comment :: (using tokenizer: *Tokenizer, token: *Token) {
         case #char "*";
             token.type = .multiline_comment;
             t += 1;
-            while t + 1 < max_t {
-                if t.* == #char "*" && (t + 1).* == #char "/" {
+            while t < max_t {
+                if t.* == #char "*" && (t + 1) < max_t && (t + 1).* == #char "/" {
                   t += 2;
                   break;
                 }

--- a/src/langs/jai.jai
+++ b/src/langs/jai.jai
@@ -598,8 +598,8 @@ parse_slash_or_comment :: (using tokenizer: *Jai_Tokenizer, token: *Token) {
             token.type = .multiline_comment;
             t += 1;
             num_open_comments := 0;
-            while t + 1 < max_t {
-                if t.* == #char "*" && (t + 1).* == #char "/" {
+            while t < max_t {
+                if t.* == #char "*" && (t + 1) < max_t && (t + 1).* == #char "/" {
                     if num_open_comments == 0 {
                         t += 2;
                         break;
@@ -607,7 +607,7 @@ parse_slash_or_comment :: (using tokenizer: *Jai_Tokenizer, token: *Token) {
                         num_open_comments -= 1;
                         t += 1;
                     }
-                } else if t.* == #char "/" && (t + 1).* == #char "*" {
+                } else if t.* == #char "/" && (t + 1) < max_t && (t + 1).* == #char "*" {
                     num_open_comments += 1;
                     t += 1;
                 }

--- a/src/langs/java.jai
+++ b/src/langs/java.jai
@@ -335,8 +335,8 @@ parse_slash_or_comment :: (using tokenizer: *Tokenizer, token: *Token) {
         case #char "*";
             token.type = .multiline_comment;
             t += 1;
-            while t + 1 < max_t {
-                if t.* == #char "*" && << (t + 1) == #char "/" {
+            while t < max_t {
+                if t.* == #char "*" && (t + 1) < max_t && << (t + 1) == #char "/" {
                   t += 2;
                   break;
                 }

--- a/src/langs/js.jai
+++ b/src/langs/js.jai
@@ -416,8 +416,8 @@ parse_slash_or_comment :: (using tokenizer: *Js_Tokenizer, token: *Token) {
         case #char "*";
             token.type = .multiline_comment;
             t += 1;
-            while t + 1 < max_t {
-                if << t == #char "*" && << (t + 1) == #char "/" {
+            while t < max_t {
+                if << t == #char "*" && (t + 1) < max_t && << (t + 1) == #char "/" {
                   t += 2;
                   break;
                 }

--- a/src/langs/json.jai
+++ b/src/langs/json.jai
@@ -158,8 +158,8 @@ parse_slash_or_comment :: (using tokenizer: *Tokenizer, token: *Token) {
         case #char "*";
             token.type = .multiline_comment;
             t += 1;
-            while t + 1 < max_t {
-                if << t == #char "*" && << (t + 1) == #char "/" {
+            while t < max_t {
+                if << t == #char "*" && (t + 1) < max_t && << (t + 1) == #char "/" {
                   t += 2;
                   break;
                 }

--- a/src/langs/odin.jai
+++ b/src/langs/odin.jai
@@ -641,15 +641,15 @@ parse_slash_comment_or_filetag :: (using tokenizer: *Odin_Tokenizer, token: *Tok
             token.type = .multiline_comment;
             t += 1;
             num_open_comments := 0;
-            while t + 1 < max_t {
-                if t.* == #char "*" && (t + 1).* == #char "/" {
+            while t < max_t {
+                if t.* == #char "*" && (t + 1) < max_t && (t + 1).* == #char "/" {
                     if num_open_comments == 0 {
                         t += 2;
                         break;
                     } else {
                         num_open_comments -= 1;
                     }
-                } else if t.* == #char "/" && (t + 1).* == #char "*" {
+                } else if t.* == #char "/" && (t + 1) < max_t && (t + 1).* == #char "*" {
                     num_open_comments += 1;
                     t += 1;
                 }

--- a/src/langs/rust.jai
+++ b/src/langs/rust.jai
@@ -528,15 +528,15 @@ parse_slash_or_comment :: (using tokenizer: *Rust_Tokenizer, token: *Token) {
             token.type = .multiline_comment;
             t += 1;
             num_open_comments := 0;
-            while t + 1 < max_t {
-                if t.* == #char "*" && << (t + 1) == #char "/" {
+            while t < max_t {
+                if t.* == #char "*" && (t + 1) < max_t && << (t + 1) == #char "/" {
                     if num_open_comments == 0 {
                         t += 2;
                         break;
                     } else {
                         num_open_comments -= 1;
                     }
-                } else if t.* == #char "/" && << (t + 1) == #char "*" {
+                } else if t.* == #char "/" && (t + 1) < max_t && << (t + 1) == #char "*" {
                     num_open_comments += 1;
                     t += 1;
                 }

--- a/src/langs/swift.jai
+++ b/src/langs/swift.jai
@@ -408,10 +408,8 @@ parse_slash_or_comment :: (using tokenizer: *Swift_Tokenizer, token: *Token) {
         case #char "*";
             token.type = .multiline_comment;
             t += 1;
-            if t >= max_t  return;
-
-            while t + 1 < max_t {
-                if t.* == #char "*" && (t + 1).* == #char "/" {
+            while t < max_t {
+                if t.* == #char "*" && (t + 1) < max_t && (t + 1).* == #char "/" {
                     t += 2;
                     break;
                 }

--- a/src/langs/yang.jai
+++ b/src/langs/yang.jai
@@ -105,8 +105,8 @@ parse_slash_or_comment :: (using tokenizer: *Tokenizer, token: *Token) {
         case #char "*";
             token.type = .comment;
             t += 1;
-            while t + 1 < max_t {
-                if << t == #char "*" && << (t + 1) == #char "/" {
+            while t < max_t {
+                if << t == #char "*" && (t + 1) < max_t && << (t + 1) == #char "/" {
                   t += 2;
                   break;
                 }


### PR DESCRIPTION
Fixes a bug that caused incorrect tokenization if the last content in a file was an un-closed multiline comment.