### PR TITLE
Added `Hash` keyboard symbol for german keyboards

### DIFF
--- a/src/config_parser.jai
+++ b/src/config_parser.jai
@@ -313,6 +313,7 @@ STRING_TO_CODE_MAP :: Str_Code.[
     .{ "Space",             #char " " },
     .{ "Plus",              #char "+" },
     .{ "Minus",             #char "-" },
+    .{ "Hash",              #char "#" },
 
     .{ "F1",                F1  },
     .{ "F2",                F2  },


### PR DESCRIPTION
Apparently German keyboards have `#` on just a normal key.
I don't know if this actually works, I do not have a German keyboard, but it seems like it should