### PR TITLE
Add ability to sort lines

### DIFF
--- a/src/actions.jai
+++ b/src/actions.jai
@@ -174,6 +174,7 @@ ACTIONS_EDITORS :: #run arrays_concat(ACTIONS_COMMON, string.[
     "move_selected_lines_down",
     "join_lines",
     "join_lines_no_spaces_in_between",
+    "sort_lines",
     "indent_or_go_to_next_tabstop",
     "unindent",
     "indent",

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -4201,12 +4201,16 @@ sort_lines :: (editor: *Editor, buffer: *Buffer) {
 
     for * line_range : line_ranges {
         range_str := get_range_as_string(buffer, line_range.range);
-        individual_lines := split(trim_right(range_str, "\n"), #char "\n",, allocator = temp);
+        trimmed_str := trim_right(range_str, "\n");
+        individual_lines := split(trimmed_str, #char "\n",, allocator = temp);
         if individual_lines.count <= 1 continue;
+
+        // Adjust line range to account for trailing newlines
+        line_range.end -= cast(s32) (range_str.count - trimmed_str.count);
 
         quick_sort(individual_lines, compare_strings);
 
-        new_str := join(..individual_lines, "\n", after_last = ends_with(range_str, #char "\n"),, allocator = temp);
+        new_str := join(..individual_lines, "\n",, allocator = temp);
 
         replace_range(buffer, line_range.range, new_str);
     }

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -4199,6 +4199,8 @@ join_lines :: (editor: *Editor, buffer: *Buffer, in_between := " ") {
 sort_lines :: (editor: *Editor, buffer: *Buffer) {
     line_ranges := get_whole_line_ranges_for_cursors(editor, buffer, merge_adjacent = false);
 
+    cursor_positions := remember_cursor_positions(editor.buffer_id, .active_editor);
+
     for * line_range : line_ranges {
         range_str := get_range_as_string(buffer, line_range.range);
         trimmed_str := trim_right(range_str, "\n");
@@ -4214,6 +4216,8 @@ sort_lines :: (editor: *Editor, buffer: *Buffer) {
 
         replace_range(buffer, line_range.range, new_str);
     }
+
+    restore_cursor_positions(editor.buffer_id, cursor_positions);
 }
 
 delete_line :: (editor: *Editor, buffer: *Buffer, go_up := false) {

--- a/src/editors.jai
+++ b/src/editors.jai
@@ -335,6 +335,8 @@ active_editor_handle_event :: (editor: *Editor, buffer: *Buffer, event: Input.Ev
             case .join_lines;                          join_lines                       (editor, buffer);                  keep_selection = true;
             case .join_lines_no_spaces_in_between;     join_lines                       (editor, buffer, in_between = ""); keep_selection = true;
 
+            case .sort_lines;                          sort_lines                       (editor, buffer);                  keep_selection = true;
+
             case .delete_line;                         delete_line                      (editor, buffer);
             case .delete_line_and_go_up;               delete_line                      (editor, buffer, go_up = true);
 
@@ -4192,6 +4194,22 @@ join_lines :: (editor: *Editor, buffer: *Buffer, in_between := " ") {
     }
 
     editor.cursor_moved = true;
+}
+
+sort_lines :: (editor: *Editor, buffer: *Buffer) {
+    line_ranges := get_whole_line_ranges_for_cursors(editor, buffer, merge_adjacent = false);
+
+    for * line_range : line_ranges {
+        range_str := get_range_as_string(buffer, line_range.range);
+        individual_lines := split(trim_right(range_str, "\n"), #char "\n",, allocator = temp);
+        if individual_lines.count <= 1 continue;
+
+        quick_sort(individual_lines, compare_strings);
+
+        new_str := join(..individual_lines, "\n", after_last = ends_with(range_str, #char "\n"),, allocator = temp);
+
+        replace_range(buffer, line_range.range, new_str);
+    }
 }
 
 delete_line :: (editor: *Editor, buffer: *Buffer, go_up := false) {

--- a/src/widgets/commands.jai
+++ b/src/widgets/commands.jai
@@ -176,6 +176,8 @@ base_commands := #run -> [] Command {
         cmd( "Join Lines",                        .join_lines,                       .Single ),
         cmd( "Join Lines (no spaces in between)", .join_lines_no_spaces_in_between,  .Single ),
 
+        cmd( "Sort Lines",                        .sort_lines,                       .Single ),
+
         cmd( "Duplicate Lines",                   .duplicate_lines,                  .Single ),
         cmd( "Delete Line",                       .delete_line,                      .Single ),
         cmd( "Delete Line And Go Up",             .delete_line_and_go_up,            .Single ),


### PR DESCRIPTION
**Disclaimer:** This is the first time I've written anything in Jai and it's also my first time exploring the Focus codebase. Bare with me.

I'm still not sure how we should handle trailing lines at the end of a range (e.g., lines only consisting of ` `, `\t` and `\n`). Right now I strip any `\n` at the end of the range. It kind of works, but is perhaps somewhat dirty?