### PR TITLE
Fix bug in open file dialog

### DIFF
--- a/src/buffer.jai
+++ b/src/buffer.jai
@@ -1840,6 +1840,7 @@ Buffer :: struct {
     binary                 := false;
     error_when_saving      := false;
     crlf                   := false;
+    pending_close          := false;
 
     lang: Lang = .Plain_Text;
 

--- a/src/widgets/open_file_dialog.jai
+++ b/src/widgets/open_file_dialog.jai
@@ -255,10 +255,14 @@ maybe_close_file_under_cursor :: () {
 
     if !entries.filtered return;
 
-    buffer_id  := entries.filtered[entries.selected].buffer_id;
+    buffer_id := entries.filtered[entries.selected].buffer_id;
 
     for editor, editor_id : open_editors {
         if editor.buffer_id != buffer_id continue;
+
+        buffer := *open_buffers[buffer_id];
+        buffer.pending_close = true;
+
         defer_action_close_editor(editor_id);
     }
 
@@ -496,7 +500,7 @@ refresh_entries :: (clear_input := true) {
         case .open_editors;
             for buffer_id : most_recent_buffers {
                 buffer := *open_buffers[buffer_id];
-                maybe_add_a_buffer_entry(buffer, buffer_id);
+                if !buffer.pending_close then maybe_add_a_buffer_entry(buffer, buffer_id);
             }
     }
 


### PR DESCRIPTION
When closing a file in the `Switch Between Open Files` dialog, the file would remain visible in the dialog after closing. I solve this by marking the buffer as "pending close" and then skip adding it as an entry when refreshing the dialog entries.