### PR TITLE
Windows: Use native Shell API to support third-party file managers for file reveal

### DIFF
--- a/src/platform/windows.jai
+++ b/src/platform/windows.jai
@@ -215,11 +215,24 @@ platform_get_fonts_dir :: () -> string {
 }
 
 platform_open_in_explorer :: (path: string, reveal := false) {
-    path_backslashes := copy_string(path,, allocator = temp);
-    path_overwrite_separators(path_backslashes, #char "\\");
+    ITEMIDLIST :: struct {}
+    ShellExecuteW :: (hwnd: HWND, lpOperation: *u16, lpFile: *u16, lpParameters: *u16, lpDirectory: *u16, nShowCmd: s32) -> HINSTANCE #foreign shell32;
+    ILCreateFromPathW :: (pszPath: *u16) -> *ITEMIDLIST #foreign shell32;
+    ILFree :: (pidl: *ITEMIDLIST) -> void #foreign shell32;
+    SHOpenFolderAndSelectItems :: (pidlFolder: *ITEMIDLIST, cidl: u32, apidl: **ITEMIDLIST, dwFlags: u32) -> HRESULT #foreign shell32;
 
-    if reveal run_command("explorer", "/select,", path_backslashes);
-    else      run_command("explorer", path_backslashes);
+    path_wide := utf8_to_wide(path,, temp);
+
+    if reveal {
+        pidl := ILCreateFromPathW(path_wide);
+        if pidl {
+            SHOpenFolderAndSelectItems(pidl, 0, null, 0);
+            ILFree(pidl);
+        }
+    } else {
+        verb_wide := utf8_to_wide("open",, temp);
+        ShellExecuteW(null, verb_wide, path_wide, null, null, 1);
+    }
 }
 
 platform_path_equals :: inline (path_a: string, path_b: string) -> bool {


### PR DESCRIPTION
The current implementation hardcodes explorer.exe when opening or revealing files. This is a bit of a pain for anyone using custom file managers (like Filepilot or Directory Opus), since it completely bypasses their default OS settings and forces standard Windows Explorer to open.

This PR fixes that by switching to the native Windows Shell APIs:

We now use ShellExecuteW for standard folder opening.
We use SHOpenFolderAndSelectItems when we specifically need to highlight or reveal a file.

(Also, Windows API handles both '/' and '\\' internally for these shell calls so I removed a call to path_overwrite_seperators)