### PR TITLE
Windows: Use native shell APIs in the correct way to support third-party file managers

### DIFF
--- a/src/platform/windows.jai
+++ b/src/platform/windows.jai
@@ -215,11 +215,24 @@ platform_get_fonts_dir :: () -> string {
 }
 
 platform_open_in_explorer :: (path: string, reveal := false) {
-    path_backslashes := copy_string(path,, allocator = temp);
-    path_overwrite_separators(path_backslashes, #char "\\");
+    ITEMIDLIST :: struct {}
+    ShellExecuteW :: (hwnd: HWND, lpOperation: *u16, lpFile: *u16, lpParameters: *u16, lpDirectory: *u16, nShowCmd: s32) -> HINSTANCE #foreign shell32;
+    ILCreateFromPathW :: (pszPath: *u16) -> *ITEMIDLIST #foreign shell32;
+    ILFree :: (pidl: *ITEMIDLIST) -> void #foreign shell32;
+    SHOpenFolderAndSelectItems :: (pidlFolder: *ITEMIDLIST, cidl: u32, apidl: **ITEMIDLIST, dwFlags: u32) -> HRESULT #foreign shell32;
 
-    if reveal run_command("explorer", "/select,", path_backslashes);
-    else      run_command("explorer", path_backslashes);
+    path_wide := utf8_to_wide(path,, temp);
+
+    if reveal {
+        pidl := ILCreateFromPathW(path_wide);
+        if pidl {
+            SHOpenFolderAndSelectItems(pidl, 0, null, 0);
+            ILFree(pidl);
+        }
+    } else {
+        verb_wide := utf8_to_wide("open",, temp);
+        ShellExecuteW(null, verb_wide, path_wide, null, null, 1);
+    }
 }
 
 platform_path_equals :: inline (path_a: string, path_b: string) -> bool {

--- a/src/platform/windows.jai
+++ b/src/platform/windows.jai
@@ -220,19 +220,30 @@ platform_open_in_explorer :: (path: string, reveal := false) {
     ILCreateFromPathW :: (pszPath: *u16) -> *ITEMIDLIST #foreign shell32;
     ILFree :: (pidl: *ITEMIDLIST) -> void #foreign shell32;
     SHOpenFolderAndSelectItems :: (pidlFolder: *ITEMIDLIST, cidl: u32, apidl: **ITEMIDLIST, dwFlags: u32) -> HRESULT #foreign shell32;
+    CoInitialize :: (reserved: *void) -> HRESULT #foreign ole32;
+    CoUninitialize :: () #foreign ole32;
+    
+    CoInitialize(null); // For shell functions
+    defer CoUninitialize();
 
-    path_wide := utf8_to_wide(path,, temp);
+    path_backslashes := copy_string(path,, allocator = temp);
+    path_overwrite_separators(path_backslashes, #char "\\");
+    path_wide := utf8_to_wide(path_backslashes,, temp);
 
     if reveal {
         pidl := ILCreateFromPathW(path_wide);
+        defer ILFree(pidl);
         if pidl {
-            SHOpenFolderAndSelectItems(pidl, 0, null, 0);
-            ILFree(pidl);
+            hr := SHOpenFolderAndSelectItems(pidl, 0, null, 0);
+            if hr == S_OK return;
+        } else {
+            log_error("ILCreateFromPathW returned null for %", path_backslashes);
         }
-    } else {
-        verb_wide := utf8_to_wide("open",, temp);
-        ShellExecuteW(null, verb_wide, path_wide, null, null, 1);
     }
+
+    // Shared fallback
+    verb_wide := utf8_to_wide("open",, temp);
+    ShellExecuteW(null, verb_wide, path_wide, null, null, 1);
 }
 
 platform_path_equals :: inline (path_a: string, path_b: string) -> bool {


### PR DESCRIPTION
My previous PR had a bug, I didn't test it against highlighting files. Sorry about that again. This should work with both Windows Explorer and Filepilot hopefully. 

If you do Ctrl-Shift-P + Open File Directory or navigate to a folder and press Shift-Enter, it calls to ShellExecuteW for that folder (this was the part that worked). If you press Shift-Enter while highlighting a file, it calls to SHOpenFolderAndSelectItems and if that fails, it fallbacks to ShellExecuteW and opens the folder the file is in. (Which seems to be [how Chrome does it](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/chrome/browser/platform_util_win.cc) as well.)

So both paths work correctly for Windows Explorer, but Filepilot falls back to opening the folder the latter case since it fails on SHOpenFolderAndSelectItems. (maybe because it doesn't register the COM stuff it's supposed to, I don't know)